### PR TITLE
Migrate flow E2E reads to bounded workflow observations

### DIFF
--- a/e2e/observe/workflows/src/index.test.ts
+++ b/e2e/observe/workflows/src/index.test.ts
@@ -1,15 +1,33 @@
 import type {
-  WorkflowRunDetailResponseDto,
+  JobExecutionSummaryDto,
+  StepAttemptDetailResponseDto,
+  StepAttemptSummaryDto,
+  StepSummaryDto,
+  WorkflowJobExecutionDetailDto,
+  WorkflowRunAttemptDto,
+  WorkflowRunJobOverviewDto,
+  WorkflowRunLineageHeadResponseDto,
   WorkflowRunListItemDto,
   WorkflowRunListResponseDto,
+  WorkflowRunOverviewHeaderDto,
+  WorkflowRunOverviewResponseDto,
   WorkflowRunStatusDto,
 } from '@shipfox/api-workflows-dto';
-import {waitForRunByCommit, waitForRunByDeliveryId, waitForRunTerminal} from './index.js';
+import {
+  observeRun,
+  waitForRunByCommit,
+  waitForRunByDeliveryId,
+  waitForRunTerminal,
+} from './index.js';
 
 const projectId = '11111111-1111-4111-8111-111111111111';
 const definitionId = '22222222-2222-4222-8222-222222222222';
 const runId = '33333333-3333-4333-8333-333333333333';
 const attemptId = '44444444-4444-4444-8444-444444444444';
+const jobId = '55555555-5555-4555-8555-555555555555';
+const executionId = '66666666-6666-4666-8666-666666666666';
+const stepId = '77777777-7777-4777-8777-777777777777';
+const timestamp = '2026-07-02T08:00:00.000Z';
 const RUN_BY_COMMIT_TIMEOUT_RE =
   /Timed out waiting for workflow run by commit: expectedHeadCommitSha=abc123/u;
 const RUN_BY_COMMIT_OBSERVED_RE = /headCommitSha=other/u;
@@ -50,8 +68,8 @@ function run(params: Partial<WorkflowRunListItemDto> = {}): WorkflowRunListItemD
     trigger_reference: valueOr(params.trigger_reference, null),
     inputs: valueOr(params.inputs, null),
     source_snapshot: valueOr(params.source_snapshot, null),
-    created_at: valueOr(params.created_at, '2026-07-02T08:00:00.000Z'),
-    updated_at: valueOr(params.updated_at, '2026-07-02T08:00:00.000Z'),
+    created_at: valueOr(params.created_at, timestamp),
+    updated_at: valueOr(params.updated_at, timestamp),
     started_at: valueOr(params.started_at, null),
     finished_at: valueOr(params.finished_at, null),
     jobs: valueOr(params.jobs, []),
@@ -70,43 +88,211 @@ function listResponse(
   };
 }
 
-function detail(params: Partial<WorkflowRunDetailResponseDto> = {}): WorkflowRunDetailResponseDto {
-  const {jobs: detailJobs, run_attempt: runAttempt, ...runParams} = params;
-  const {jobs: _listJobs, job_status_counts: _listOnly, ...listItem} = run(runParams);
+function response(body: unknown): Response {
+  return Response.json(body);
+}
+
+function runHeader(): WorkflowRunOverviewHeaderDto {
   return {
-    ...listItem,
-    run_attempt: runAttempt ?? {
-      id: attemptId,
-      workflow_run_id: params.id ?? runId,
-      attempt: 1,
-      status: params.status ?? 'pending',
-      created_at: '2026-07-02T08:00:00.000Z',
-      started_at: null,
-      finished_at: null,
-      rerun_mode: null,
-    },
-    jobs: detailJobs ?? [],
-    has_started_job_execution: params.has_started_job_execution ?? false,
+    id: runId,
+    project_id: projectId,
+    definition_id: definitionId,
+    number: 1,
+    name: 'Build',
+    workflow_name: 'Build',
+    origin: 'synced',
+    dev_source: null,
+    trigger_provider: 'gitea',
+    trigger_source: 'gitea_e2e',
+    trigger_event: 'push',
+    trigger_reference: null,
+    created_at: timestamp,
   };
 }
 
-function response(body: unknown): Response {
-  return Response.json(body);
+function attempt(status: WorkflowRunStatusDto = 'succeeded'): WorkflowRunAttemptDto {
+  return {
+    id: attemptId,
+    workflow_run_id: runId,
+    attempt: 1,
+    status,
+    created_at: timestamp,
+    started_at: timestamp,
+    finished_at: status === 'pending' || status === 'running' ? null : timestamp,
+    rerun_mode: null,
+  };
+}
+
+function head(status: WorkflowRunStatusDto = 'succeeded'): WorkflowRunLineageHeadResponseDto {
+  return {
+    current_attempt: 1,
+    latest_attempt: 1,
+    current_status: status,
+    updated_at: timestamp,
+  };
+}
+
+function jobSummary(params: Partial<WorkflowRunJobOverviewDto> = {}): WorkflowRunJobOverviewDto {
+  return {
+    id: jobId,
+    key: 'build',
+    name: 'Build',
+    position: 0,
+    dependencies: [],
+    status: 'succeeded',
+    status_reason: null,
+    mode: 'one_shot',
+    listener_status: 'inactive',
+    carried_over: false,
+    execution_count: 1,
+    execution_status_counts: {
+      pending: 0,
+      running: 0,
+      succeeded: 1,
+      failed: 0,
+      cancelled: 0,
+    },
+    default_execution: null,
+    ...params,
+  };
+}
+
+function overview(
+  params: {
+    status?: WorkflowRunStatusDto;
+    jobs?: WorkflowRunJobOverviewDto[];
+    largeJobs?: WorkflowRunOverviewResponseDto['jobs'];
+  } = {},
+): WorkflowRunOverviewResponseDto {
+  const currentAttempt = attempt(params.status ?? 'succeeded');
+  return {
+    run: runHeader(),
+    attempt: currentAttempt,
+    has_started_job_execution: params.status !== 'pending',
+    jobs: params.largeJobs ?? {
+      kind: 'complete',
+      total: params.jobs?.length ?? 1,
+      items: params.jobs ?? [jobSummary()],
+    },
+  };
+}
+
+function executionSummary(params: Partial<JobExecutionSummaryDto> = {}): JobExecutionSummaryDto {
+  return {
+    id: executionId,
+    sequence: 1,
+    name: 'Build #1',
+    status: 'succeeded',
+    display_status: 'succeeded',
+    status_reason: null,
+    status_reason_message: null,
+    queued_at: timestamp,
+    started_at: timestamp,
+    finished_at: timestamp,
+    timed_out_at: null,
+    updated_at: timestamp,
+    ...params,
+  };
+}
+
+function stepAttemptSummary(params: Partial<StepAttemptSummaryDto> = {}): StepAttemptSummaryDto {
+  return {
+    id: '88888888-8888-4888-8888-888888888888',
+    attempt: 1,
+    execution_order: 1,
+    status: 'succeeded',
+    exit_code: 0,
+    started_at: timestamp,
+    finished_at: timestamp,
+    error: null,
+    gate_result: {kind: 'none'},
+    ...params,
+  };
+}
+
+function stepSummary(params: Partial<StepSummaryDto> = {}): StepSummaryDto {
+  return {
+    id: stepId,
+    key: 'build',
+    name: 'Build',
+    type: 'run',
+    position: 0,
+    status: 'succeeded',
+    status_reason: null,
+    source_location: null,
+    current_attempt: 1,
+    error: null,
+    attempts: {items: [stepAttemptSummary()], next_cursor: null, total: 1},
+    ...params,
+  };
+}
+
+function selectedExecutionDetail(
+  params: {
+    sequence?: number;
+    steps?: StepSummaryDto[];
+    nextCursor?: string | null;
+    hasContext?: boolean;
+  } = {},
+): WorkflowJobExecutionDetailDto {
+  return {
+    ...executionSummary({sequence: params.sequence ?? 1}),
+    has_context: params.hasContext ?? false,
+    steps: {
+      items: params.steps ?? [stepSummary()],
+      next_cursor: params.nextCursor ?? null,
+      total: params.steps?.length ?? 1,
+    },
+  };
+}
+
+function stepDetail(
+  params: Partial<StepAttemptDetailResponseDto> = {},
+): StepAttemptDetailResponseDto {
+  return {
+    step_id: stepId,
+    attempt: 1,
+    authored_config: null,
+    config: null,
+    session: null,
+    evaluation_trace: null,
+    output: null,
+    outputs: {message: 'observed'},
+    response: 'done',
+    error: undefined,
+    gate_result: {kind: 'none'},
+    ...params,
+  };
+}
+
+function context() {
+  return {
+    workflow_run_id: runId,
+    workflow_run_attempt: 1,
+    job_id: jobId,
+    job_execution_id: executionId,
+    job_runner: ['runner'],
+    execution_runner: ['runner'],
+    job_outputs: {message: 'observed'},
+    execution_outputs: {message: 'observed'},
+    trigger_events: [],
+    job_evaluation_trace: null,
+    execution_evaluation_trace: null,
+    condition: null,
+    oversized_fields: [],
+  };
 }
 
 describe('waitForRunByCommit', () => {
   test('polls until a run with the matching head commit appears', async () => {
     let calls = 0;
-
     const result = await waitForRunByCommit({
       fetch: () => {
         calls += 1;
-        return Promise.resolve(
-          response(
-            calls === 1
-              ? listResponse({runs: [run({trigger_payload: {data: {headCommitSha: 'other'}}})]})
-              : listResponse({runs: [run()]}),
-          ),
+        return response(
+          listResponse({
+            runs: [run(calls === 1 ? {trigger_payload: {data: {headCommitSha: 'other'}}} : {})],
+          }),
         );
       },
       headCommitSha: 'abc123',
@@ -114,7 +300,6 @@ describe('waitForRunByCommit', () => {
       projectId,
       token: 'user-token',
     });
-
     expect(result.id).toBe(runId);
     expect(calls).toBe(2);
   });
@@ -132,7 +317,6 @@ describe('waitForRunByCommit', () => {
       projectId,
       token: 'user-token',
     });
-
     expect(result.id).toBe(runId);
   });
 
@@ -146,7 +330,6 @@ describe('waitForRunByCommit', () => {
       timeoutMs: 1,
       token: 'user-token',
     });
-
     await expect(result).rejects.toThrow(RUN_BY_COMMIT_TIMEOUT_RE);
     await expect(result).rejects.toThrow(RUN_BY_COMMIT_OBSERVED_RE);
   });
@@ -154,7 +337,6 @@ describe('waitForRunByCommit', () => {
   test('passes abort signals through polling', async () => {
     const controller = new AbortController();
     controller.abort();
-
     const result = waitForRunByCommit({
       fetch: () => response(listResponse()),
       headCommitSha: 'abc123',
@@ -162,7 +344,6 @@ describe('waitForRunByCommit', () => {
       signal: controller.signal,
       token: 'user-token',
     });
-
     await expect(result).rejects.toThrow(
       'Stopped waiting for Timed out waiting for workflow run by commit',
     );
@@ -172,18 +353,15 @@ describe('waitForRunByCommit', () => {
 describe('waitForRunByDeliveryId', () => {
   test('polls until a run with the matching delivery ID appears', async () => {
     let calls = 0;
-
     const result = await waitForRunByDeliveryId({
       fetch: () => {
         calls += 1;
-        return Promise.resolve(
-          response(
-            calls === 1
-              ? listResponse({
-                  runs: [run({trigger_payload: {deliveryId: 'other-delivery', data: {}}})],
-                })
-              : listResponse({runs: [run()]}),
-          ),
+        return response(
+          listResponse({
+            runs: [
+              run(calls === 1 ? {trigger_payload: {deliveryId: 'other-delivery', data: {}}} : {}),
+            ],
+          }),
         );
       },
       deliveryId: 'delivery-1',
@@ -191,7 +369,6 @@ describe('waitForRunByDeliveryId', () => {
       projectId,
       token: 'user-token',
     });
-
     expect(result.id).toBe(runId);
     expect(calls).toBe(2);
   });
@@ -208,7 +385,6 @@ describe('waitForRunByDeliveryId', () => {
       timeoutMs: 1,
       token: 'user-token',
     });
-
     await expect(result).rejects.toThrow(RUN_BY_DELIVERY_TIMEOUT_RE);
     await expect(result).rejects.toThrow(RUN_BY_DELIVERY_OBSERVED_RE);
   });
@@ -219,24 +395,40 @@ describe('waitForRunTerminal', () => {
     'succeeded',
     'failed',
     'cancelled',
-  ] satisfies WorkflowRunStatusDto[])('returns %s runs as terminal', async (status) => {
+  ] satisfies WorkflowRunStatusDto[])('reads bounded lineage and overview resources for %s runs', async (status) => {
+    const paths: string[] = [];
     const result = await waitForRunTerminal({
-      fetch: () => response(detail({status})),
+      fetch: (input) => {
+        const url = new URL(input);
+        paths.push(`${url.pathname}${url.search}`);
+        if (url.pathname.endsWith('/head')) return response(head(status));
+        if (url.pathname.endsWith('/overview')) return response(overview({status}));
+        throw new Error(`Unexpected request: ${url.pathname}${url.search}`);
+      },
       runId,
       token: 'user-token',
     });
 
     expect(result.status).toBe(status);
-    expect(result).not.toHaveProperty('job_status_counts');
+    expect(result.attempt.status).toBe(status);
+    expect(paths).toEqual([
+      `/workflows/runs/${runId}/head`,
+      `/workflows/runs/${runId}/overview?attempt=1`,
+    ]);
   });
 
-  test('polls until the run reaches a terminal status', async () => {
-    let calls = 0;
-
+  test('polls lineage and overview until the run reaches a terminal status', async () => {
+    let poll = 0;
+    const paths: string[] = [];
     const result = await waitForRunTerminal({
-      fetch: () => {
-        calls += 1;
-        return Promise.resolve(response(detail({status: calls === 1 ? 'running' : 'succeeded'})));
+      fetch: (input) => {
+        const url = new URL(input);
+        paths.push(`${url.pathname}${url.search}`);
+        if (url.pathname.endsWith('/head')) {
+          poll += 1;
+          return response(head(poll === 1 ? 'running' : 'succeeded'));
+        }
+        return response(overview({status: poll === 1 ? 'running' : 'succeeded'}));
       },
       initialDelayMs: 1,
       runId,
@@ -244,12 +436,17 @@ describe('waitForRunTerminal', () => {
     });
 
     expect(result.status).toBe('succeeded');
-    expect(calls).toBe(2);
+    expect(paths).toHaveLength(4);
+    expect(paths.every((path) => !path.includes(`/workflows/runs/${runId}?`))).toBe(true);
   });
 
-  test('times out with the last run status', async () => {
+  test('reports the last bounded resource on timeout', async () => {
     const result = waitForRunTerminal({
-      fetch: () => response(detail({status: 'running'})),
+      fetch: (input) => {
+        const url = new URL(input);
+        if (url.pathname.endsWith('/head')) return response(head('running'));
+        return response(overview({status: 'running'}));
+      },
       initialDelayMs: 1,
       runId,
       timeoutMs: 1,
@@ -258,5 +455,137 @@ describe('waitForRunTerminal', () => {
 
     await expect(result).rejects.toThrow(RUN_TERMINAL_TIMEOUT_RE);
     await expect(result).rejects.toThrow(RUN_TERMINAL_OBSERVED_RE);
+    await expect(result).rejects.toThrow('lastBoundedResource=workflow run overview attempt 1');
+  });
+
+  test('follows only the bounded pages needed for a selected execution and step', async () => {
+    const paths: string[] = [];
+    const otherJob = jobSummary({id: '99999999-9999-4999-8999-999999999999', key: 'other'});
+    const selectedJob = jobSummary({key: 'target'});
+    const otherStep = stepSummary({id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa', key: 'other'});
+    const selectedStep = stepSummary({key: 'target'});
+    const secondExecution = executionSummary({
+      id: executionId,
+      sequence: 2,
+      name: 'Build #2',
+    });
+    const responses = new Map<string, Response>([
+      [`/workflows/runs/${runId}/head`, response(head('succeeded'))],
+      [
+        `/workflows/runs/${runId}/overview?attempt=1`,
+        response(
+          overview({
+            largeJobs: {
+              kind: 'large',
+              total: 2,
+              status_counts: [{status: 'succeeded', count: 2}],
+              first_page: {items: [otherJob], next_cursor: 'jobs-1', total: 1},
+            },
+          }),
+        ),
+      ],
+      [
+        `/workflows/runs/${runId}/jobs?attempt=1&limit=100&cursor=jobs-1`,
+        response({items: [selectedJob], next_cursor: null, total: 1}),
+      ],
+      [
+        `/workflows/runs/jobs/${jobId}/executions?limit=25`,
+        response({items: [executionSummary()], next_cursor: 'executions-1', total: 2}),
+      ],
+      [
+        `/workflows/runs/jobs/${jobId}/executions?limit=25&cursor=executions-1`,
+        response({items: [secondExecution], next_cursor: null, total: 2}),
+      ],
+      [
+        `/workflows/runs/jobs/${jobId}?execution_id=${executionId}`,
+        response({
+          workflow_run_id: runId,
+          workflow_run_attempt: 1,
+          job: selectedJob,
+          selected_execution: selectedExecutionDetail({
+            sequence: 2,
+            steps: [otherStep],
+            nextCursor: 'steps-1',
+            hasContext: true,
+          }),
+        }),
+      ],
+      [
+        `/workflows/runs/jobs/${jobId}/executions/${executionId}/steps?limit=100&cursor=steps-1`,
+        response({items: [selectedStep], next_cursor: null, total: 2}),
+      ],
+      [`/workflows/runs/jobs/${jobId}/executions/${executionId}/context`, response(context())],
+      [`/workflows/runs/steps/${stepId}/attempts/1`, response(stepDetail())],
+    ]);
+
+    const result = await observeRun({
+      fetch: (input) => {
+        const url = new URL(input);
+        const path = `${url.pathname}${url.search}`;
+        paths.push(path);
+        const next = responses.get(path);
+        if (next === undefined) throw new Error(`Unexpected request: ${path}`);
+        return next;
+      },
+      runId,
+      selection: {
+        jobs: [
+          {
+            jobKey: 'target',
+            executionSequences: [2],
+            includeContext: true,
+            stepKeys: ['target'],
+          },
+        ],
+      },
+      token: 'user-token',
+    });
+
+    const target = result.jobs.find((job) => job.key === 'target');
+    expect(target?.executions.map((execution) => execution.sequence)).toEqual([2]);
+    expect(target?.executions[0]?.context?.execution_outputs).toEqual({message: 'observed'});
+    expect(target?.executions[0]?.steps.map((step) => step.key)).toEqual(['target']);
+    expect(target?.executions[0]?.steps[0]?.response).toBe('done');
+    expect(paths).toContain(`/workflows/runs/${runId}/jobs?attempt=1&limit=100&cursor=jobs-1`);
+    expect(paths).toContain(
+      `/workflows/runs/jobs/${jobId}/executions?limit=25&cursor=executions-1`,
+    );
+    expect(paths).toContain(
+      `/workflows/runs/jobs/${jobId}/executions/${executionId}/steps?limit=100&cursor=steps-1`,
+    );
+    expect(paths).not.toContain(`/workflows/runs/${runId}`);
+  });
+
+  test('names the last bounded cursor resource when a page repeats', async () => {
+    const result = observeRun({
+      fetch: (input) => {
+        const url = new URL(input);
+        const path = `${url.pathname}${url.search}`;
+        if (url.pathname.endsWith('/head')) return response(head('succeeded'));
+        if (url.pathname.endsWith('/overview')) {
+          return response(
+            overview({
+              largeJobs: {
+                kind: 'large',
+                total: 2,
+                status_counts: [{status: 'succeeded', count: 2}],
+                first_page: {items: [], next_cursor: 'jobs-1', total: 0},
+              },
+            }),
+          );
+        }
+        if (path.endsWith('/jobs?attempt=1&limit=100&cursor=jobs-1')) {
+          return response({items: [], next_cursor: 'jobs-1', total: 2});
+        }
+        throw new Error(`Unexpected request: ${path}`);
+      },
+      runId,
+      selection: {jobs: [{jobKey: 'missing'}]},
+      token: 'user-token',
+    });
+
+    await expect(result).rejects.toThrow(
+      'Repeated workflow run job cursor while reading bounded job summaries; last bounded resource=workflow run job summaries cursor jobs-1',
+    );
   });
 });

--- a/e2e/observe/workflows/src/index.test.ts
+++ b/e2e/observe/workflows/src/index.test.ts
@@ -628,7 +628,7 @@ describe('waitForRunTerminal', () => {
       ],
       [
         `/workflows/runs/jobs/${jobId}/executions?limit=25`,
-        response({items: [executionSummary()], next_cursor: null, total: 1}),
+        response({items: [executionSummary()], next_cursor: 'executions-1', total: 26}),
       ],
     ]);
 

--- a/e2e/observe/workflows/src/index.test.ts
+++ b/e2e/observe/workflows/src/index.test.ts
@@ -553,7 +553,122 @@ describe('waitForRunTerminal', () => {
     expect(paths).toContain(
       `/workflows/runs/jobs/${jobId}/executions/${executionId}/steps?limit=100&cursor=steps-1`,
     );
-    expect(paths).not.toContain(`/workflows/runs/${runId}`);
+    expect(paths.every((path) => !path.includes(`/workflows/runs/${runId}?`))).toBe(true);
+  });
+
+  test('follows every step page when attempt details are selected without step keys', async () => {
+    const paths: string[] = [];
+    const otherStepId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+    const selectedJob = jobSummary({key: 'target'});
+    const otherStep = stepSummary({id: otherStepId, key: 'other'});
+    const selectedStep = stepSummary({key: 'target'});
+    const responses = new Map<string, Response>([
+      [`/workflows/runs/${runId}/head`, response(head('succeeded'))],
+      [`/workflows/runs/${runId}/overview?attempt=1`, response(overview({jobs: [selectedJob]}))],
+      [
+        `/workflows/runs/jobs/${jobId}`,
+        response({
+          workflow_run_id: runId,
+          workflow_run_attempt: 1,
+          job: selectedJob,
+          selected_execution: selectedExecutionDetail({
+            steps: [otherStep],
+            nextCursor: 'steps-1',
+          }),
+        }),
+      ],
+      [
+        `/workflows/runs/jobs/${jobId}/executions/${executionId}/steps?limit=100&cursor=steps-1`,
+        response({items: [selectedStep], next_cursor: null, total: 2}),
+      ],
+      [
+        `/workflows/runs/steps/${otherStepId}/attempts/1`,
+        response(stepDetail({step_id: otherStepId})),
+      ],
+      [`/workflows/runs/steps/${stepId}/attempts/1`, response(stepDetail())],
+    ]);
+
+    const result = await observeRun({
+      fetch: (input) => {
+        const url = new URL(input);
+        const path = `${url.pathname}${url.search}`;
+        paths.push(path);
+        const next = responses.get(path);
+        if (next === undefined) throw new Error(`Unexpected request: ${path}`);
+        return next;
+      },
+      runId,
+      selection: {
+        jobs: [{jobKey: 'target', includeDefaultExecution: true, stepAttempts: 'all'}],
+      },
+      token: 'user-token',
+    });
+
+    const target = result.jobs.find((job) => job.key === 'target');
+    expect(target?.executions[0]?.steps.map((step) => step.key)).toEqual(['other', 'target']);
+    expect(paths).toContain(
+      `/workflows/runs/jobs/${jobId}/executions/${executionId}/steps?limit=100&cursor=steps-1`,
+    );
+  });
+
+  test('does not re-read the default execution when it is selected by sequence', async () => {
+    const paths: string[] = [];
+    const selectedJob = jobSummary({key: 'target'});
+    const responses = new Map<string, Response>([
+      [`/workflows/runs/${runId}/head`, response(head('succeeded'))],
+      [`/workflows/runs/${runId}/overview?attempt=1`, response(overview({jobs: [selectedJob]}))],
+      [
+        `/workflows/runs/jobs/${jobId}`,
+        response({
+          workflow_run_id: runId,
+          workflow_run_attempt: 1,
+          job: selectedJob,
+          selected_execution: selectedExecutionDetail({steps: []}),
+        }),
+      ],
+      [
+        `/workflows/runs/jobs/${jobId}/executions?limit=25`,
+        response({items: [executionSummary()], next_cursor: null, total: 1}),
+      ],
+    ]);
+
+    const result = await observeRun({
+      fetch: (input) => {
+        const url = new URL(input);
+        const path = `${url.pathname}${url.search}`;
+        paths.push(path);
+        const next = responses.get(path);
+        if (next === undefined) throw new Error(`Unexpected request: ${path}`);
+        return next;
+      },
+      runId,
+      selection: {
+        jobs: [{jobKey: 'target', includeDefaultExecution: true, executionSequences: [1]}],
+      },
+      token: 'user-token',
+    });
+
+    expect(result.jobs.find((job) => job.key === 'target')?.executions).toHaveLength(1);
+    expect(paths.filter((path) => path === `/workflows/runs/jobs/${jobId}`)).toHaveLength(1);
+    expect(paths).not.toContain(`/workflows/runs/jobs/${jobId}?execution_id=${executionId}`);
+  });
+
+  test('reports selected job keys missing from bounded overview pages', async () => {
+    const result = observeRun({
+      fetch: (input) => {
+        const url = new URL(input);
+        if (url.pathname.endsWith('/head')) return response(head('succeeded'));
+        if (url.pathname.endsWith('/overview')) return response(overview({jobs: []}));
+        throw new Error(`Unexpected request: ${url.pathname}${url.search}`);
+      },
+      runId,
+      selection: {jobs: [{jobKey: 'missing'}]},
+      token: 'user-token',
+    });
+
+    await expect(result).rejects.toThrow(
+      'Requested workflow run job keys were not found in bounded overview pages: missing; last bounded resource=workflow run overview attempt 1',
+    );
   });
 
   test('names the last bounded cursor resource when a page repeats', async () => {

--- a/e2e/observe/workflows/src/index.ts
+++ b/e2e/observe/workflows/src/index.ts
@@ -744,12 +744,13 @@ async function readExecutionSummaries(options: {
   jobId: string;
   sequences: readonly number[] | 'all';
   selection: WorkflowJobObservationSelection;
+  preloadedExecutions?: readonly WorkflowExecutionObservation[] | undefined;
   excludedExecutionId?: string | undefined;
   signal: AbortSignal | undefined;
   tracker: ResourceTracker;
 }): Promise<WorkflowExecutionObservation[]> {
   const wanted = options.sequences === 'all' ? undefined : new Set(options.sequences);
-  const observations: WorkflowExecutionObservation[] = [];
+  const observations = [...(options.preloadedExecutions ?? [])];
   let cursor: string | null = null;
   const seenCursors = new Set<string>();
 
@@ -778,7 +779,7 @@ async function readExecutionSummaries(options: {
     );
     observations.push(...pageObservations);
 
-    if (hasMatchingExecution(pageObservations, options.selection.executionMatches)) break;
+    if (hasMatchingExecution(observations, options.selection.executionMatches)) break;
     if (hasAllRequestedExecutions(observations, wanted)) break;
     cursor = page.next_cursor;
     if (cursor === null) break;
@@ -805,6 +806,7 @@ async function readJobObservation(options: {
         selection.stepAttempts !== undefined));
   const executions: WorkflowExecutionObservation[] = [];
   let defaultExecutionId: string | undefined;
+  let defaultExecution: WorkflowExecutionObservation | undefined;
 
   if (needsDefault) {
     const detail = await readJobDetail({
@@ -815,17 +817,16 @@ async function readJobObservation(options: {
     });
     if (detail.selected_execution !== null) {
       defaultExecutionId = detail.selected_execution.id;
-      executions.push(
-        await readExecutionObservation({
-          client: options.client,
-          jobId: options.job.id,
-          execution: detail.selected_execution,
-          jobDetail: detail.selected_execution,
-          selection,
-          signal: options.signal,
-          tracker: options.tracker,
-        }),
-      );
+      defaultExecution = await readExecutionObservation({
+        client: options.client,
+        jobId: options.job.id,
+        execution: detail.selected_execution,
+        jobDetail: detail.selected_execution,
+        selection,
+        signal: options.signal,
+        tracker: options.tracker,
+      });
+      executions.push(defaultExecution);
     }
   }
 
@@ -836,6 +837,7 @@ async function readJobObservation(options: {
         jobId: options.job.id,
         sequences: selection.executionSequences,
         selection,
+        preloadedExecutions: defaultExecution === undefined ? undefined : [defaultExecution],
         excludedExecutionId: defaultExecutionId,
         signal: options.signal,
         tracker: options.tracker,

--- a/e2e/observe/workflows/src/index.ts
+++ b/e2e/observe/workflows/src/index.ts
@@ -1,10 +1,28 @@
 import type {
-  WorkflowRunDetailResponseDto,
+  JobExecutionSummaryDto,
+  StepAttemptDetailResponseDto,
+  StepAttemptSummaryDto,
+  StepGateResultDto,
+  StepGateResultSummaryDto,
+  StepSummaryDto,
+  WorkflowExecutionEventDto,
+  WorkflowJobDetailDto,
+  WorkflowJobExecutionContextResponseDto,
+  WorkflowJobExecutionDetailDto,
+  WorkflowJobExecutionSummariesResponseDto,
+  WorkflowRunAttemptDto,
   WorkflowRunDto,
+  WorkflowRunJobListSummaryDto,
+  WorkflowRunJobOverviewDto,
+  WorkflowRunLineageHeadResponseDto,
   WorkflowRunListResponseDto,
+  WorkflowRunOverviewHeaderDto,
+  WorkflowRunOverviewJobsResponseDto,
+  WorkflowRunOverviewResponseDto,
   WorkflowRunStatusDto,
 } from '@shipfox/api-workflows-dto';
-import {type ApiFetch, createApiClient, pollUntil} from '@shipfox/e2e-core';
+import type {ApiFetch} from '@shipfox/e2e-core';
+import {createApiClient as makeApiClient, pollUntil} from '@shipfox/e2e-core';
 
 const DEFAULT_LIST_TIMEOUT_MS = 60_000;
 const DEFAULT_TERMINAL_TIMEOUT_MS = 180_000;
@@ -12,6 +30,81 @@ const DEFAULT_INITIAL_DELAY_MS = 250;
 const DEFAULT_MAX_DELAY_MS = 4_000;
 const DEFAULT_BACKOFF_FACTOR = 1.5;
 const TERMINAL_STATUSES = new Set<WorkflowRunStatusDto>(['succeeded', 'failed', 'cancelled']);
+
+type ApiClient = ReturnType<typeof makeApiClient>;
+
+/** The bounded resources an observer may materialize for one run attempt. */
+export interface WorkflowRunObservationSelection {
+  jobs?: readonly WorkflowJobObservationSelection[] | undefined;
+}
+
+export interface WorkflowJobObservationSelection {
+  jobKey: string;
+  /** Omit execution resources when only the compact job status is asserted. */
+  includeDefaultExecution?: boolean | undefined;
+  /** `all` follows execution cursors until the assertion has enough history. */
+  executionSequences?: readonly number[] | 'all' | undefined;
+  /** Fetch context only when an assertion needs outputs or trigger events. */
+  includeContext?: boolean | undefined;
+  /** Fetch step summaries and diagnostics only for these keys or names. */
+  stepKeys?: readonly string[] | undefined;
+  /** Fetch selected attempt details, rather than only the current attempt. */
+  stepAttempts?: readonly number[] | 'all' | undefined;
+  /** Stop an `all` execution traversal as soon as this assertion matches. */
+  executionMatches?: ((execution: WorkflowExecutionObservation) => boolean) | undefined;
+}
+
+export interface WorkflowStepObservation extends Omit<StepSummaryDto, 'attempts'> {
+  /** Compact attempt history is normalized from the cursor page. */
+  attempts: StepAttemptSummaryDto[];
+  /** The selected attempt diagnostic fields are absent from compact summaries. */
+  attempt_details: StepAttemptDetailResponseDto[];
+  exit_code: number | null;
+  outputs: Record<string, unknown> | null;
+  response: string | null;
+  gate_result: StepGateResultDto | StepGateResultSummaryDto | null;
+  session: StepAttemptDetailResponseDto['session'];
+}
+
+export interface WorkflowExecutionObservation extends JobExecutionSummaryDto {
+  job_id: string;
+  runner: string[] | null;
+  outputs: Record<string, unknown> | null;
+  trigger_events: WorkflowExecutionEventDto[];
+  context: WorkflowJobExecutionContextResponseDto | null;
+  steps: WorkflowStepObservation[];
+}
+
+export interface WorkflowJobObservation {
+  id: string;
+  key: string;
+  name: string | null;
+  position: number;
+  status: WorkflowRunJobOverviewDto['status'];
+  status_reason: WorkflowRunJobOverviewDto['status_reason'];
+  mode: WorkflowRunJobOverviewDto['mode'];
+  listener_status: WorkflowRunJobOverviewDto['listener_status'];
+  carried_over: boolean;
+  execution_count: WorkflowRunJobOverviewDto['execution_count'];
+  execution_status_counts: WorkflowRunJobOverviewDto['execution_status_counts'];
+  default_execution: WorkflowRunJobOverviewDto['default_execution'];
+  executions: WorkflowExecutionObservation[];
+}
+
+/**
+ * A presentation-neutral E2E observation assembled from bounded resources.
+ * `jobs` contains compact summaries for the observed overview page; execution,
+ * step, attempt, and context data is present only when selected by the caller.
+ */
+export interface WorkflowRunObservation extends WorkflowRunOverviewHeaderDto {
+  status: WorkflowRunStatusDto;
+  current_attempt: number;
+  latest_attempt: number;
+  updated_at: string;
+  attempt: WorkflowRunAttemptDto;
+  has_started_job_execution: boolean;
+  jobs: WorkflowJobObservation[];
+}
 
 interface PollingOptions {
   apiUrl?: string | undefined;
@@ -34,8 +127,17 @@ export interface WaitForRunByDeliveryIdOptions extends PollingOptions {
   projectId: string;
 }
 
-export interface WaitForRunTerminalOptions extends PollingOptions {
+export interface ObserveRunOptions extends PollingOptions {
   runId: string;
+  attempt?: number | undefined;
+  selection?: WorkflowRunObservationSelection | undefined;
+}
+
+export interface WaitForRunTerminalOptions extends ObserveRunOptions {}
+
+interface ResourceTracker {
+  last: string;
+  deadline?: number | undefined;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -82,18 +184,46 @@ function formatRunListObserved(
   return `${expected} runs=[${runs.join(', ')}${more}]`;
 }
 
-function formatRunDetailObserved(
-  response: WorkflowRunDetailResponseDto | null,
+function formatRunObservationObserved(
+  lineage: WorkflowRunLineageHeadResponseDto | null,
+  overview: WorkflowRunOverviewResponseDto | null,
   runId: string,
+  lastResource: string,
 ): string {
-  if (!response) return 'no workflow run detail response observed';
+  if (!lineage && !overview) {
+    return `runId=${runId} lastBoundedResource=${lastResource} no workflow overview observed`;
+  }
   return [
     `runId=${runId}`,
-    `status=${response.status}`,
-    `currentAttempt=${response.current_attempt}`,
-    `latestAttempt=${response.latest_attempt}`,
-    `updatedAt=${response.updated_at}`,
+    `status=${overview?.attempt.status ?? lineage?.current_status ?? 'null'}`,
+    `currentAttempt=${lineage?.current_attempt ?? overview?.attempt.attempt ?? 'null'}`,
+    `latestAttempt=${lineage?.latest_attempt ?? 'null'}`,
+    `updatedAt=${lineage?.updated_at ?? 'null'}`,
+    `lastBoundedResource=${lastResource}`,
   ].join(' ');
+}
+
+function assertWithinDeadline(tracker: ResourceTracker, label: string): void {
+  if (tracker.deadline !== undefined && Date.now() > tracker.deadline) {
+    throw new Error(`Timed out while reading ${label}; last bounded resource=${tracker.last}`);
+  }
+}
+
+async function requestBounded<T>(
+  client: ApiClient,
+  tracker: ResourceTracker,
+  label: string,
+  path: string,
+  signal: AbortSignal | undefined,
+): Promise<T> {
+  assertWithinDeadline(tracker, label);
+  tracker.last = label;
+  return await client.requestJson<T>('get', path, {signal});
+}
+
+function queryPath(path: string, params?: URLSearchParams): string {
+  const query = params?.toString();
+  return query ? `${path}?${query}` : path;
 }
 
 async function waitForRunMatching(
@@ -105,7 +235,7 @@ async function waitForRunMatching(
     timeoutMessage: string;
   },
 ): Promise<WorkflowRunDto> {
-  const client = createApiClient({
+  const client = makeApiClient({
     apiUrl: options.apiUrl,
     fetch: options.fetch,
     token: options.token,
@@ -165,18 +295,616 @@ export async function waitForRunByDeliveryId(
   });
 }
 
+async function readRunBase(options: {
+  client: ApiClient;
+  runId: string;
+  attempt: number | undefined;
+  signal: AbortSignal | undefined;
+  tracker: ResourceTracker;
+}): Promise<{
+  lineage: WorkflowRunLineageHeadResponseDto;
+  overview: WorkflowRunOverviewResponseDto;
+}> {
+  const lineage = await requestBounded<WorkflowRunLineageHeadResponseDto>(
+    options.client,
+    options.tracker,
+    'workflow run lineage head',
+    `/workflows/runs/${encodeURIComponent(options.runId)}/head`,
+    options.signal,
+  );
+  const attempt = options.attempt ?? lineage.current_attempt;
+  const query = new URLSearchParams({attempt: String(attempt)});
+  const overview = await requestBounded<WorkflowRunOverviewResponseDto>(
+    options.client,
+    options.tracker,
+    `workflow run overview attempt ${attempt}`,
+    queryPath(`/workflows/runs/${encodeURIComponent(options.runId)}/overview`, query),
+    options.signal,
+  );
+  return {lineage, overview};
+}
+
+function toJobObservation(
+  job: WorkflowRunJobOverviewDto | WorkflowRunJobListSummaryDto,
+): WorkflowJobObservation {
+  return {
+    id: job.id,
+    key: job.key,
+    name: job.name,
+    position: job.position,
+    status: job.status,
+    status_reason: job.status_reason,
+    mode: job.mode,
+    listener_status: job.listener_status,
+    carried_over: job.carried_over,
+    execution_count: job.execution_count,
+    execution_status_counts: job.execution_status_counts,
+    default_execution: job.default_execution,
+    executions: [],
+  };
+}
+
+function initialOverviewJobs(
+  overview: WorkflowRunOverviewResponseDto,
+): Array<WorkflowRunJobOverviewDto | WorkflowRunJobListSummaryDto> {
+  return overview.jobs.kind === 'complete' ? overview.jobs.items : overview.jobs.first_page.items;
+}
+
+async function readOverviewJobs(options: {
+  client: ApiClient;
+  runId: string;
+  attempt: number;
+  overview: WorkflowRunOverviewResponseDto;
+  selection: readonly WorkflowJobObservationSelection[] | undefined;
+  signal: AbortSignal | undefined;
+  tracker: ResourceTracker;
+}): Promise<Map<string, WorkflowJobObservation>> {
+  const jobs = new Map<string, WorkflowJobObservation>();
+  for (const job of initialOverviewJobs(options.overview)) {
+    jobs.set(job.key, toJobObservation(job));
+  }
+
+  const requiredKeys = new Set(options.selection?.map((selection) => selection.jobKey) ?? []);
+  for (const key of jobs.keys()) requiredKeys.delete(key);
+
+  let cursor =
+    options.overview.jobs.kind === 'large' ? options.overview.jobs.first_page.next_cursor : null;
+  const seenCursors = new Set<string>();
+  while (requiredKeys.size > 0 && cursor !== null) {
+    if (seenCursors.has(cursor)) {
+      throw new Error(
+        `Repeated workflow run job cursor while reading bounded job summaries; last bounded resource=${options.tracker.last}`,
+      );
+    }
+    seenCursors.add(cursor);
+    const query = new URLSearchParams({
+      attempt: String(options.attempt),
+      limit: '100',
+      cursor,
+    });
+    const page = await requestBounded<WorkflowRunOverviewJobsResponseDto>(
+      options.client,
+      options.tracker,
+      `workflow run job summaries cursor ${cursor}`,
+      queryPath(`/workflows/runs/${encodeURIComponent(options.runId)}/jobs`, query),
+      options.signal,
+    );
+    for (const job of page.items) {
+      jobs.set(job.key, toJobObservation(job));
+      requiredKeys.delete(job.key);
+    }
+    cursor = page.next_cursor;
+  }
+
+  return jobs;
+}
+
+function selectionForJob(
+  selections: readonly WorkflowJobObservationSelection[] | undefined,
+  jobKey: string,
+): WorkflowJobObservationSelection | undefined {
+  return selections?.find((selection) => selection.jobKey === jobKey);
+}
+
+async function readJobDetail(options: {
+  client: ApiClient;
+  jobId: string;
+  executionId?: string | undefined;
+  signal: AbortSignal | undefined;
+  tracker: ResourceTracker;
+}): Promise<WorkflowJobDetailDto> {
+  const query =
+    options.executionId === undefined
+      ? undefined
+      : new URLSearchParams({execution_id: options.executionId});
+  return await requestBounded<WorkflowJobDetailDto>(
+    options.client,
+    options.tracker,
+    `workflow job ${options.jobId} detail${options.executionId === undefined ? '' : ` execution ${options.executionId}`}`,
+    queryPath(`/workflows/runs/jobs/${encodeURIComponent(options.jobId)}`, query),
+    options.signal,
+  );
+}
+
+async function readStepPages(options: {
+  client: ApiClient;
+  jobId: string;
+  executionId: string;
+  initial: WorkflowJobExecutionDetailDto['steps'];
+  stepKeys: readonly string[] | undefined;
+  signal: AbortSignal | undefined;
+  tracker: ResourceTracker;
+}): Promise<StepSummaryDto[]> {
+  const steps = [...options.initial.items];
+  const requiredKeys = new Set(options.stepKeys ?? []);
+  for (const step of steps) {
+    if (step.key !== null) requiredKeys.delete(step.key);
+    requiredKeys.delete(step.name);
+  }
+
+  let cursor = options.stepKeys === undefined ? null : options.initial.next_cursor;
+  const seenCursors = new Set<string>();
+  while (requiredKeys.size > 0 && cursor !== null) {
+    if (seenCursors.has(cursor)) {
+      throw new Error(
+        `Repeated workflow execution step cursor; last bounded resource=${options.tracker.last}`,
+      );
+    }
+    seenCursors.add(cursor);
+    const query = new URLSearchParams({limit: '100', cursor});
+    const page = await requestBounded<{items: StepSummaryDto[]; next_cursor: string | null}>(
+      options.client,
+      options.tracker,
+      `workflow execution ${options.executionId} step summaries cursor ${cursor}`,
+      queryPath(
+        `/workflows/runs/jobs/${encodeURIComponent(options.jobId)}/executions/${encodeURIComponent(options.executionId)}/steps`,
+        query,
+      ),
+      options.signal,
+    );
+    steps.push(...page.items);
+    for (const step of page.items) {
+      if (step.key !== null) requiredKeys.delete(step.key);
+      requiredKeys.delete(step.name);
+    }
+    cursor = page.next_cursor;
+  }
+
+  if (options.stepKeys === undefined) return steps;
+  const selectedKeys = new Set(options.stepKeys);
+  return steps.filter(
+    (step) => (step.key !== null && selectedKeys.has(step.key)) || selectedKeys.has(step.name),
+  );
+}
+
+async function readStepAttemptSummaries(options: {
+  client: ApiClient;
+  stepId: string;
+  initial: StepSummaryDto['attempts'];
+  signal: AbortSignal | undefined;
+  tracker: ResourceTracker;
+}): Promise<StepAttemptSummaryDto[]> {
+  const attempts = [...options.initial.items];
+  let cursor = options.initial.next_cursor;
+  const seenCursors = new Set<string>();
+  while (cursor !== null) {
+    if (seenCursors.has(cursor)) {
+      throw new Error(
+        `Repeated workflow step-attempt cursor; last bounded resource=${options.tracker.last}`,
+      );
+    }
+    seenCursors.add(cursor);
+    const query = new URLSearchParams({limit: '100', cursor});
+    const page = await requestBounded<{
+      items: StepAttemptSummaryDto[];
+      next_cursor: string | null;
+    }>(
+      options.client,
+      options.tracker,
+      `workflow step ${options.stepId} attempt summaries cursor ${cursor}`,
+      queryPath(`/workflows/runs/steps/${encodeURIComponent(options.stepId)}/attempts`, query),
+      options.signal,
+    );
+    attempts.push(...page.items);
+    cursor = page.next_cursor;
+  }
+  return attempts;
+}
+
+async function readStepObservation(options: {
+  client: ApiClient;
+  step: StepSummaryDto;
+  stepAttempts: readonly number[] | 'all' | undefined;
+  signal: AbortSignal | undefined;
+  tracker: ResourceTracker;
+}): Promise<WorkflowStepObservation> {
+  let attemptSummaries: StepAttemptSummaryDto[];
+  if (options.stepAttempts === 'all') {
+    attemptSummaries = await readStepAttemptSummaries({
+      client: options.client,
+      stepId: options.step.id,
+      initial: options.step.attempts,
+      signal: options.signal,
+      tracker: options.tracker,
+    });
+  } else {
+    attemptSummaries = [...options.step.attempts.items];
+  }
+
+  const currentSummary = attemptSummaries.find(
+    (attempt) => attempt.attempt === options.step.current_attempt,
+  );
+  let attemptNumbers: readonly number[];
+  if (options.stepAttempts === 'all') {
+    attemptNumbers = attemptSummaries.map((attempt) => attempt.attempt);
+  } else if (options.stepAttempts !== undefined) {
+    attemptNumbers = options.stepAttempts;
+  } else {
+    attemptNumbers = currentSummary === undefined ? [] : [options.step.current_attempt];
+  }
+
+  const details = await Promise.all(
+    attemptNumbers.map((attempt) =>
+      requestBounded<StepAttemptDetailResponseDto>(
+        options.client,
+        options.tracker,
+        `workflow step ${options.step.id} attempt ${attempt} detail`,
+        `/workflows/runs/steps/${encodeURIComponent(options.step.id)}/attempts/${attempt}`,
+        options.signal,
+      ),
+    ),
+  );
+  const current = details.find((detail) => detail.attempt === options.step.current_attempt);
+
+  return {
+    ...options.step,
+    attempts: attemptSummaries,
+    attempt_details: details,
+    exit_code: currentSummary?.exit_code ?? null,
+    outputs: current?.outputs ?? null,
+    response: current?.response ?? null,
+    gate_result: current?.gate_result ?? currentSummary?.gate_result ?? null,
+    session: current?.session,
+  };
+}
+
+async function readExecutionObservation(options: {
+  client: ApiClient;
+  jobId: string;
+  execution: JobExecutionSummaryDto;
+  jobDetail?: WorkflowJobExecutionDetailDto | undefined;
+  selection: WorkflowJobObservationSelection;
+  signal: AbortSignal | undefined;
+  tracker: ResourceTracker;
+}): Promise<WorkflowExecutionObservation> {
+  const detail =
+    options.jobDetail ??
+    (
+      await readJobDetail({
+        client: options.client,
+        jobId: options.jobId,
+        executionId: options.execution.id,
+        signal: options.signal,
+        tracker: options.tracker,
+      })
+    ).selected_execution;
+
+  let context: WorkflowJobExecutionContextResponseDto | null = null;
+  if (options.selection.includeContext === true && detail?.has_context === true) {
+    context = await requestBounded<WorkflowJobExecutionContextResponseDto>(
+      options.client,
+      options.tracker,
+      `workflow job execution ${options.execution.id} context`,
+      `/workflows/runs/jobs/${encodeURIComponent(options.jobId)}/executions/${encodeURIComponent(options.execution.id)}/context`,
+      options.signal,
+    );
+  }
+
+  const shouldReadSteps =
+    detail !== null &&
+    ((options.selection.stepKeys?.length ?? 0) > 0 || options.selection.stepAttempts !== undefined);
+  const steps = shouldReadSteps
+    ? await readStepPages({
+        client: options.client,
+        jobId: options.jobId,
+        executionId: options.execution.id,
+        initial: detail.steps,
+        stepKeys: options.selection.stepKeys,
+        signal: options.signal,
+        tracker: options.tracker,
+      }).then((items) =>
+        Promise.all(
+          items.map((step) =>
+            readStepObservation({
+              client: options.client,
+              step,
+              stepAttempts: options.selection.stepAttempts,
+              signal: options.signal,
+              tracker: options.tracker,
+            }),
+          ),
+        ),
+      )
+    : [];
+
+  return {
+    ...options.execution,
+    job_id: options.jobId,
+    runner: context?.execution_runner ?? null,
+    outputs: context?.execution_outputs ?? null,
+    trigger_events: context?.trigger_events ?? [],
+    context,
+    steps,
+  };
+}
+
+function assertNewCursor(
+  cursor: string | null,
+  seenCursors: Set<string>,
+  tracker: ResourceTracker,
+): void {
+  if (cursor !== null && seenCursors.has(cursor)) {
+    throw new Error(
+      `Repeated workflow job execution cursor; last bounded resource=${tracker.last}`,
+    );
+  }
+  if (cursor !== null) seenCursors.add(cursor);
+}
+
+async function readExecutionSummaryPage(options: {
+  client: ApiClient;
+  jobId: string;
+  cursor: string | null;
+  signal: AbortSignal | undefined;
+  tracker: ResourceTracker;
+}): Promise<WorkflowJobExecutionSummariesResponseDto> {
+  const query = new URLSearchParams({limit: '25'});
+  if (options.cursor !== null) query.set('cursor', options.cursor);
+  return await requestBounded<WorkflowJobExecutionSummariesResponseDto>(
+    options.client,
+    options.tracker,
+    `workflow job ${options.jobId} execution summaries${options.cursor === null ? '' : ` cursor ${options.cursor}`}`,
+    queryPath(`/workflows/runs/jobs/${encodeURIComponent(options.jobId)}/executions`, query),
+    options.signal,
+  );
+}
+
+function selectedExecutionSummaries(
+  items: JobExecutionSummaryDto[],
+  wanted: Set<number> | undefined,
+): JobExecutionSummaryDto[] {
+  return wanted === undefined ? items : items.filter((execution) => wanted.has(execution.sequence));
+}
+
+function hasAllRequestedExecutions(
+  observations: WorkflowExecutionObservation[],
+  wanted: Set<number> | undefined,
+): boolean {
+  return (
+    wanted !== undefined &&
+    [...wanted].every((sequence) =>
+      observations.some((execution) => execution.sequence === sequence),
+    )
+  );
+}
+
+function hasMatchingExecution(
+  observations: WorkflowExecutionObservation[],
+  matcher: ((execution: WorkflowExecutionObservation) => boolean) | undefined,
+): boolean {
+  return matcher !== undefined && observations.some(matcher);
+}
+
+async function readExecutionSummaries(options: {
+  client: ApiClient;
+  jobId: string;
+  sequences: readonly number[] | 'all';
+  selection: WorkflowJobObservationSelection;
+  signal: AbortSignal | undefined;
+  tracker: ResourceTracker;
+}): Promise<WorkflowExecutionObservation[]> {
+  const wanted = options.sequences === 'all' ? undefined : new Set(options.sequences);
+  const observations: WorkflowExecutionObservation[] = [];
+  let cursor: string | null = null;
+  const seenCursors = new Set<string>();
+
+  for (;;) {
+    assertNewCursor(cursor, seenCursors, options.tracker);
+    const page = await readExecutionSummaryPage({
+      client: options.client,
+      jobId: options.jobId,
+      cursor,
+      signal: options.signal,
+      tracker: options.tracker,
+    });
+
+    const pageItems = selectedExecutionSummaries(page.items, wanted);
+    const pageObservations = await Promise.all(
+      pageItems.map((execution) =>
+        readExecutionObservation({
+          client: options.client,
+          jobId: options.jobId,
+          execution,
+          selection: options.selection,
+          signal: options.signal,
+          tracker: options.tracker,
+        }),
+      ),
+    );
+    observations.push(...pageObservations);
+
+    if (hasMatchingExecution(pageObservations, options.selection.executionMatches)) break;
+    if (hasAllRequestedExecutions(observations, wanted)) break;
+    cursor = page.next_cursor;
+    if (cursor === null) break;
+  }
+
+  return observations.sort((left, right) => left.sequence - right.sequence);
+}
+
+async function readJobObservation(options: {
+  client: ApiClient;
+  job: WorkflowJobObservation;
+  selection: WorkflowJobObservationSelection | undefined;
+  signal: AbortSignal | undefined;
+  tracker: ResourceTracker;
+}): Promise<WorkflowJobObservation> {
+  const selection = options.selection;
+  if (selection === undefined) return options.job;
+
+  const needsDefault =
+    selection.includeDefaultExecution === true ||
+    (selection.executionSequences === undefined &&
+      ((selection.stepKeys?.length ?? 0) > 0 ||
+        selection.includeContext === true ||
+        selection.stepAttempts !== undefined));
+  const executions: WorkflowExecutionObservation[] = [];
+
+  if (needsDefault) {
+    const detail = await readJobDetail({
+      client: options.client,
+      jobId: options.job.id,
+      signal: options.signal,
+      tracker: options.tracker,
+    });
+    if (detail.selected_execution !== null) {
+      executions.push(
+        await readExecutionObservation({
+          client: options.client,
+          jobId: options.job.id,
+          execution: detail.selected_execution,
+          jobDetail: detail.selected_execution,
+          selection,
+          signal: options.signal,
+          tracker: options.tracker,
+        }),
+      );
+    }
+  }
+
+  if (selection.executionSequences !== undefined) {
+    executions.push(
+      ...(await readExecutionSummaries({
+        client: options.client,
+        jobId: options.job.id,
+        sequences: selection.executionSequences,
+        selection,
+        signal: options.signal,
+        tracker: options.tracker,
+      })),
+    );
+  }
+
+  const uniqueExecutions = new Map<string, WorkflowExecutionObservation>();
+  for (const execution of executions) uniqueExecutions.set(execution.id, execution);
+  return {
+    ...options.job,
+    executions: [...uniqueExecutions.values()].sort(
+      (left, right) => left.sequence - right.sequence,
+    ),
+  };
+}
+
+async function readRunObservationFromBase(options: {
+  client: ApiClient;
+  runId: string;
+  selection: WorkflowRunObservationSelection | undefined;
+  signal: AbortSignal | undefined;
+  tracker: ResourceTracker;
+  base: {
+    lineage: WorkflowRunLineageHeadResponseDto;
+    overview: WorkflowRunOverviewResponseDto;
+  };
+}): Promise<WorkflowRunObservation> {
+  const base = options.base;
+  const {client, tracker} = options;
+  const attempt = base.overview.attempt.attempt;
+  const jobSelections = options.selection?.jobs;
+  const compactJobs = await readOverviewJobs({
+    client,
+    runId: options.runId,
+    attempt,
+    overview: base.overview,
+    selection: jobSelections,
+    signal: options.signal,
+    tracker,
+  });
+
+  const jobs = await Promise.all(
+    [...compactJobs.values()].map((job) =>
+      readJobObservation({
+        client,
+        job,
+        selection: selectionForJob(jobSelections, job.key),
+        signal: options.signal,
+        tracker,
+      }),
+    ),
+  );
+
+  return {
+    ...base.overview.run,
+    status: base.overview.attempt.status,
+    current_attempt: base.lineage.current_attempt,
+    latest_attempt: base.lineage.latest_attempt,
+    updated_at: base.lineage.updated_at,
+    attempt: base.overview.attempt,
+    has_started_job_execution: base.overview.has_started_job_execution,
+    jobs: jobs.sort((left, right) => left.position - right.position),
+  };
+}
+
+async function readRunObservation(
+  options: ObserveRunOptions & {deadline?: number | undefined},
+): Promise<WorkflowRunObservation> {
+  const client = makeApiClient({
+    apiUrl: options.apiUrl,
+    fetch: options.fetch,
+    token: options.token,
+  });
+  const deadline =
+    options.deadline ??
+    (options.timeoutMs === undefined ? undefined : Date.now() + options.timeoutMs);
+  const tracker: ResourceTracker = {
+    last: 'workflow run lineage head',
+    ...(deadline === undefined ? {} : {deadline}),
+  };
+  const base = await readRunBase({
+    client,
+    runId: options.runId,
+    attempt: options.attempt,
+    signal: options.signal,
+    tracker,
+  });
+  return await readRunObservationFromBase({
+    client,
+    runId: options.runId,
+    selection: options.selection,
+    signal: options.signal,
+    tracker,
+    base,
+  });
+}
+
+export async function observeRun(options: ObserveRunOptions): Promise<WorkflowRunObservation> {
+  return await readRunObservation(options);
+}
+
 export async function waitForRunTerminal(
   options: WaitForRunTerminalOptions,
-): Promise<WorkflowRunDetailResponseDto> {
-  const client = createApiClient({
+): Promise<WorkflowRunObservation> {
+  const client = makeApiClient({
     apiUrl: options.apiUrl,
     fetch: options.fetch,
     token: options.token,
   });
   const timeoutMs = options.timeoutMs ?? DEFAULT_TERMINAL_TIMEOUT_MS;
-  let lastResponse: WorkflowRunDetailResponseDto | null = null;
+  const deadline = Date.now() + timeoutMs;
+  let lastLineage: WorkflowRunLineageHeadResponseDto | null = null;
+  let lastOverview: WorkflowRunOverviewResponseDto | null = null;
+  let lastResource = 'workflow run lineage head';
 
-  return await pollUntil<WorkflowRunDetailResponseDto>(
+  return await pollUntil<WorkflowRunObservation>(
     {
       timeoutMs,
       intervalMs: options.initialDelayMs ?? DEFAULT_INITIAL_DELAY_MS,
@@ -184,19 +912,42 @@ export async function waitForRunTerminal(
       backoffFactor: options.backoffFactor ?? DEFAULT_BACKOFF_FACTOR,
       ...(options.signal ? {signal: options.signal} : {}),
       describe: () =>
-        `Timed out waiting for workflow run terminal status: ${formatRunDetailObserved(
-          lastResponse,
+        `Timed out waiting for workflow run terminal status: ${formatRunObservationObserved(
+          lastLineage,
+          lastOverview,
           options.runId,
+          lastResource,
         )}`,
     },
     async () => {
       options.signal?.throwIfAborted();
-      lastResponse = await client.requestJson<WorkflowRunDetailResponseDto>(
-        'get',
-        `/workflows/runs/${encodeURIComponent(options.runId)}`,
-        {signal: options.signal},
-      );
-      return TERMINAL_STATUSES.has(lastResponse.status) ? lastResponse : null;
+      const tracker: ResourceTracker = {
+        last: lastResource,
+        deadline,
+      };
+      try {
+        const base = await readRunBase({
+          client,
+          runId: options.runId,
+          attempt: options.attempt,
+          signal: options.signal,
+          tracker,
+        });
+        lastLineage = base.lineage;
+        lastOverview = base.overview;
+        if (!TERMINAL_STATUSES.has(base.overview.attempt.status)) return null;
+
+        return await readRunObservationFromBase({
+          client,
+          runId: options.runId,
+          selection: options.selection,
+          signal: options.signal,
+          tracker,
+          base,
+        });
+      } finally {
+        lastResource = tracker.last;
+      }
     },
   );
 }
@@ -212,6 +963,8 @@ export function createWorkflowsHelper(options: {
     waitForRunByDeliveryId: (
       params: Omit<WaitForRunByDeliveryIdOptions, 'apiUrl' | 'fetch' | 'token'>,
     ) => waitForRunByDeliveryId({...options, ...params}),
+    observeRun: (params: Omit<ObserveRunOptions, 'apiUrl' | 'fetch' | 'token'>) =>
+      observeRun({...options, ...params}),
     waitForRunTerminal: (params: Omit<WaitForRunTerminalOptions, 'apiUrl' | 'fetch' | 'token'>) =>
       waitForRunTerminal({...options, ...params}),
   };

--- a/e2e/observe/workflows/src/index.ts
+++ b/e2e/observe/workflows/src/index.ts
@@ -396,6 +396,14 @@ async function readOverviewJobs(options: {
     cursor = page.next_cursor;
   }
 
+  if (requiredKeys.size > 0) {
+    throw new Error(
+      `Requested workflow run job keys were not found in bounded overview pages: ${[
+        ...requiredKeys,
+      ].join(', ')}; last bounded resource=${options.tracker.last}`,
+    );
+  }
+
   return jobs;
 }
 
@@ -432,6 +440,7 @@ async function readStepPages(options: {
   executionId: string;
   initial: WorkflowJobExecutionDetailDto['steps'];
   stepKeys: readonly string[] | undefined;
+  stepAttempts: readonly number[] | 'all' | undefined;
   signal: AbortSignal | undefined;
   tracker: ResourceTracker;
 }): Promise<StepSummaryDto[]> {
@@ -442,9 +451,14 @@ async function readStepPages(options: {
     requiredKeys.delete(step.name);
   }
 
-  let cursor = options.stepKeys === undefined ? null : options.initial.next_cursor;
+  const shouldReadAllSteps = shouldReadAllStepPages(options.stepKeys, options.stepAttempts);
+  let cursor = initialStepPageCursor(
+    options.stepKeys,
+    shouldReadAllSteps,
+    options.initial.next_cursor,
+  );
   const seenCursors = new Set<string>();
-  while (requiredKeys.size > 0 && cursor !== null) {
+  while (hasRemainingStepPages(requiredKeys, shouldReadAllSteps, cursor)) {
     if (seenCursors.has(cursor)) {
       throw new Error(
         `Repeated workflow execution step cursor; last bounded resource=${options.tracker.last}`,
@@ -475,6 +489,30 @@ async function readStepPages(options: {
   return steps.filter(
     (step) => (step.key !== null && selectedKeys.has(step.key)) || selectedKeys.has(step.name),
   );
+}
+
+function shouldReadAllStepPages(
+  stepKeys: readonly string[] | undefined,
+  stepAttempts: readonly number[] | 'all' | undefined,
+): boolean {
+  return stepKeys === undefined && stepAttempts !== undefined;
+}
+
+function initialStepPageCursor(
+  stepKeys: readonly string[] | undefined,
+  shouldReadAllSteps: boolean,
+  cursor: string | null,
+): string | null {
+  if (stepKeys === undefined && !shouldReadAllSteps) return null;
+  return cursor;
+}
+
+function hasRemainingStepPages(
+  requiredKeys: Set<string>,
+  shouldReadAllSteps: boolean,
+  cursor: string | null,
+): cursor is string {
+  return cursor !== null && (shouldReadAllSteps || requiredKeys.size > 0);
 }
 
 async function readStepAttemptSummaries(options: {
@@ -610,6 +648,7 @@ async function readExecutionObservation(options: {
         executionId: options.execution.id,
         initial: detail.steps,
         stepKeys: options.selection.stepKeys,
+        stepAttempts: options.selection.stepAttempts,
         signal: options.signal,
         tracker: options.tracker,
       }).then((items) =>
@@ -672,8 +711,13 @@ async function readExecutionSummaryPage(options: {
 function selectedExecutionSummaries(
   items: JobExecutionSummaryDto[],
   wanted: Set<number> | undefined,
+  excludedExecutionId: string | undefined,
 ): JobExecutionSummaryDto[] {
-  return wanted === undefined ? items : items.filter((execution) => wanted.has(execution.sequence));
+  return items.filter(
+    (execution) =>
+      execution.id !== excludedExecutionId &&
+      (wanted === undefined || wanted.has(execution.sequence)),
+  );
 }
 
 function hasAllRequestedExecutions(
@@ -700,6 +744,7 @@ async function readExecutionSummaries(options: {
   jobId: string;
   sequences: readonly number[] | 'all';
   selection: WorkflowJobObservationSelection;
+  excludedExecutionId?: string | undefined;
   signal: AbortSignal | undefined;
   tracker: ResourceTracker;
 }): Promise<WorkflowExecutionObservation[]> {
@@ -718,7 +763,7 @@ async function readExecutionSummaries(options: {
       tracker: options.tracker,
     });
 
-    const pageItems = selectedExecutionSummaries(page.items, wanted);
+    const pageItems = selectedExecutionSummaries(page.items, wanted, options.excludedExecutionId);
     const pageObservations = await Promise.all(
       pageItems.map((execution) =>
         readExecutionObservation({
@@ -759,6 +804,7 @@ async function readJobObservation(options: {
         selection.includeContext === true ||
         selection.stepAttempts !== undefined));
   const executions: WorkflowExecutionObservation[] = [];
+  let defaultExecutionId: string | undefined;
 
   if (needsDefault) {
     const detail = await readJobDetail({
@@ -768,6 +814,7 @@ async function readJobObservation(options: {
       tracker: options.tracker,
     });
     if (detail.selected_execution !== null) {
+      defaultExecutionId = detail.selected_execution.id;
       executions.push(
         await readExecutionObservation({
           client: options.client,
@@ -789,6 +836,7 @@ async function readJobObservation(options: {
         jobId: options.job.id,
         sequences: selection.executionSequences,
         selection,
+        excludedExecutionId: defaultExecutionId,
         signal: options.signal,
         tracker: options.tracker,
       })),

--- a/e2e/suites/flow/workflows/README.md
+++ b/e2e/suites/flow/workflows/README.md
@@ -7,9 +7,10 @@ file is the deep runbook for the workflow flow suite.
 End-to-end tests where each case is a real workflow YAML run through the whole
 platform: a gitea push, the org webhook, definition sync, trigger dispatch, Temporal
 orchestration, a local source runner, step execution, and log capture. The suite
-asserts on the public observation APIs (`/workflows/runs`, `/workflows/runs/:id`, and
-the step logs route). Scenarios with a `gitea` fixture also verify the external Gitea
-state through the driver.
+asserts on the public bounded observation APIs (`/workflows/runs`, run lineage and
+overview, selected job/execution/step/attempt/context resources, and the step logs
+route). Scenarios with a `gitea` fixture also verify the external Gitea state through
+the driver.
 
 ## How a scenario works
 
@@ -37,7 +38,7 @@ against the shared suite arrangement:
 4. triggers a run: a second commit whose head SHA is the correlation key (`trigger:
    push`), or `fire-manual` (`trigger: manual`),
 5. waits for the run to reach a terminal state and evaluates `expect.yaml` against the
-   run detail, fetching step logs only where `logs` expectations exist.
+   bounded workflow observation, fetching step logs only where `logs` expectations exist.
 
 Anything not listed in `expect.yaml` is not asserted. A flow that needs to orchestrate
 from outside (cancellation, listening jobs) ships its own Playwright spec under `tests/`
@@ -160,6 +161,6 @@ Gitea admin/webhook variables live in `@shipfox/e2e-driver-gitea`.
 
 ## Artifacts
 
-On failure a scenario attaches the run detail JSON, the evaluated mismatch diff, and
-the fetched step logs to its Playwright result. Each local runner writes stdout and
+On failure a scenario attaches the bounded workflow observation JSON, the evaluated
+mismatch diff, and the fetched step logs to its Playwright result. Each local runner writes stdout and
 stderr to `.e2e-run/runners/<label>.log`; failing scenarios attach that runner log.

--- a/e2e/suites/flow/workflows/README.md
+++ b/e2e/suites/flow/workflows/README.md
@@ -161,6 +161,7 @@ Gitea admin/webhook variables live in `@shipfox/e2e-driver-gitea`.
 
 ## Artifacts
 
-On failure a scenario attaches the bounded workflow observation JSON, the evaluated
-mismatch diff, and the fetched step logs to its Playwright result. Each local runner writes stdout and
-stderr to `.e2e-run/runners/<label>.log`; failing scenarios attach that runner log.
+On failure a scenario attaches the bounded workflow observation JSON, the
+evaluated mismatch diff, and the fetched step logs to its Playwright result.
+Each local runner writes stdout and stderr to `.e2e-run/runners/<label>.log`;
+failing scenarios attach that runner log.

--- a/e2e/suites/flow/workflows/src/attachments.ts
+++ b/e2e/suites/flow/workflows/src/attachments.ts
@@ -1,6 +1,6 @@
 import {readFile} from 'node:fs/promises';
 import {fetchStepLogs} from '@shipfox/e2e-observe-logs';
-import type {waitForRunTerminal} from '@shipfox/e2e-observe-workflows';
+import type {WorkflowRunObservation} from '@shipfox/e2e-observe-workflows';
 
 const LOG_ATTACHMENT_NAME_PART_RE = /[^a-zA-Z0-9._-]+/g;
 
@@ -23,11 +23,11 @@ export function logAttachmentName(path: string): string {
 }
 
 export function collectStepLogAttachmentRequests(
-  runDetail: Awaited<ReturnType<typeof waitForRunTerminal>>,
+  observation: WorkflowRunObservation,
 ): StepLogAttachmentRequest[] {
   const requests: StepLogAttachmentRequest[] = [];
-  for (const job of runDetail.jobs) {
-    for (const execution of job.job_executions) {
+  for (const job of observation.jobs) {
+    for (const execution of job.executions) {
       for (const step of execution.steps) {
         requests.push({
           path: `jobs.${job.key}.executions.${execution.sequence}.steps.${

--- a/e2e/suites/flow/workflows/src/expect.test.ts
+++ b/e2e/suites/flow/workflows/src/expect.test.ts
@@ -1,150 +1,143 @@
 import type {LogRecord} from '@shipfox/api-logs-dto';
+import type {StepAttemptSummaryDto} from '@shipfox/api-workflows-dto';
 import type {
-  JobDto,
-  StepAttemptDto,
-  WorkflowRunDetailResponseDto,
-  WorkflowRunJobDetailDto,
-  WorkflowRunJobExecutionDetailDto,
-  WorkflowRunStepDetailDto,
-} from '@shipfox/api-workflows-dto';
+  WorkflowExecutionObservation,
+  WorkflowJobObservation,
+  WorkflowRunObservation,
+  WorkflowStepObservation,
+} from '@shipfox/e2e-observe-workflows';
 import {evaluateExpectations, evaluateLogs, logText, parseExpectation} from './expect.js';
 
 const timestamp = '2026-07-02T08:00:00.000Z';
 
-function makeAttempt(overrides: Partial<StepAttemptDto> = {}): StepAttemptDto {
+function makeAttempt(overrides: Partial<StepAttemptSummaryDto> = {}): StepAttemptSummaryDto {
   return {
     id: '44444444-4444-4444-8444-444444444444',
-    step_id: '55555555-5555-4555-8555-555555555555',
     attempt: 1,
     execution_order: 1,
     status: 'succeeded',
     exit_code: 0,
-    output: null,
-    outputs: null,
-    response: null,
     error: null,
     gate_result: {kind: 'none'},
-    restart_feedback: null,
-    invocations: [],
     started_at: timestamp,
     finished_at: timestamp,
     ...overrides,
   };
 }
 
-function makeStep(overrides: Partial<WorkflowRunStepDetailDto> = {}): WorkflowRunStepDetailDto {
+function makeStep(overrides: Partial<WorkflowStepObservation> = {}): WorkflowStepObservation {
+  const attempts = overrides.attempts ?? [makeAttempt()];
+  const currentAttempt = overrides.current_attempt ?? 1;
+  const current = attempts.find((attempt) => attempt.attempt === currentAttempt) ?? attempts.at(-1);
   return {
     id: '55555555-5555-4555-8555-555555555555',
-    job_execution_id: '66666666-6666-4666-8666-666666666666',
     key: 'greet',
     name: 'Greet',
     source_location: null,
     status: 'succeeded',
     status_reason: null,
     type: 'run',
-    config: {},
-    evaluation_trace: null,
     session: null,
     error: null,
     position: 0,
-    current_attempt: 1,
-    exit_code: 0,
+    current_attempt: currentAttempt,
+    exit_code: current?.exit_code ?? null,
     outputs: null,
     response: null,
-    gate_result: {kind: 'none'},
-    created_at: timestamp,
-    updated_at: timestamp,
-    attempts: [makeAttempt()],
+    gate_result: current?.gate_result ?? null,
+    attempts,
+    attempt_details: [],
     ...overrides,
   };
 }
 
 function makeJobExecution(
-  overrides: Partial<WorkflowRunJobExecutionDetailDto> = {},
-): WorkflowRunJobExecutionDetailDto {
+  overrides: Partial<WorkflowExecutionObservation> = {},
+): WorkflowExecutionObservation {
   return {
     id: '66666666-6666-4666-8666-666666666666',
     job_id: '77777777-7777-4777-8777-777777777777',
     sequence: 1,
     name: 'build',
     status: 'succeeded',
+    display_status: 'succeeded',
     status_reason: null,
+    status_reason_message: null,
     runner: null,
     trigger_events: [],
     outputs: null,
-    evaluation_trace: null,
     queued_at: timestamp,
     started_at: timestamp,
     finished_at: timestamp,
     timed_out_at: null,
-    created_at: timestamp,
     updated_at: timestamp,
     steps: [makeStep()],
+    context: null,
     ...overrides,
   };
 }
 
-function makeJob(overrides: Partial<WorkflowRunJobDetailDto> = {}): WorkflowRunJobDetailDto {
-  const base: JobDto = {
+function makeJob(overrides: Partial<WorkflowJobObservation> = {}): WorkflowJobObservation {
+  const base: WorkflowJobObservation = {
     id: '77777777-7777-4777-8777-777777777777',
-    run_attempt_id: '88888888-8888-4888-8888-888888888888',
     key: 'build',
     name: null,
     mode: 'one_shot',
     status: 'succeeded',
     status_reason: null,
-    success: null,
-    runner: null,
-    evaluation_trace: null,
     carried_over: false,
-    listening: null,
     listener_status: 'inactive',
-    resolution_reason: null,
-    outputs: null,
-    dependencies: [],
     position: 0,
-    created_at: timestamp,
-    updated_at: timestamp,
+    execution_count: 1,
+    execution_status_counts: {
+      pending: 0,
+      running: 0,
+      succeeded: 1,
+      failed: 0,
+      cancelled: 0,
+    },
+    default_execution: null,
+    executions: [makeJobExecution()],
   };
-  return {...base, job_executions: [makeJobExecution()], ...overrides};
+  return {
+    ...base,
+    ...overrides,
+  };
 }
 
-function makeDetail(
-  overrides: Partial<WorkflowRunDetailResponseDto> = {},
-): WorkflowRunDetailResponseDto {
-  return {
+function makeDetail(overrides: Partial<WorkflowRunObservation> = {}): WorkflowRunObservation {
+  const attempt = {
+    id: '88888888-8888-4888-8888-888888888888',
+    workflow_run_id: '33333333-3333-4333-8333-333333333333',
+    attempt: 1,
+    status: 'succeeded' as const,
+    created_at: timestamp,
+    started_at: timestamp,
+    finished_at: timestamp,
+    rerun_mode: null,
+  };
+  const run = {
     id: '33333333-3333-4333-8333-333333333333',
     project_id: '11111111-1111-4111-8111-111111111111',
     definition_id: '22222222-2222-4222-8222-222222222222',
     number: 1,
     name: 'Hello world',
     workflow_name: 'Hello world',
-    status: 'succeeded',
-    origin: 'synced',
+    origin: 'synced' as const,
     dev_source: null,
-    current_attempt: 1,
-    latest_attempt: 1,
     trigger_provider: 'gitea',
     trigger_source: 'gitea',
     trigger_event: 'push',
-    trigger_payload: {data: {headCommitSha: 'abc123'}},
     trigger_reference: null,
-    inputs: null,
-    source_snapshot: null,
     created_at: timestamp,
+  };
+  return {
+    ...run,
+    status: 'succeeded',
+    current_attempt: 1,
+    latest_attempt: 1,
     updated_at: timestamp,
-    started_at: timestamp,
-    finished_at: timestamp,
-    run_attempt: {
-      id: '88888888-8888-4888-8888-888888888888',
-      workflow_run_id: '33333333-3333-4333-8333-333333333333',
-      attempt: 1,
-      status: 'succeeded',
-      created_at: timestamp,
-      started_at: timestamp,
-      finished_at: timestamp,
-      rerun_mode: null,
-    },
+    attempt,
     jobs: [makeJob()],
     has_started_job_execution: true,
     ...overrides,
@@ -162,9 +155,7 @@ describe('evaluateExpectations', () => {
 
   test('collects a log requirement with the step id and current attempt', () => {
     const detail = makeDetail({
-      jobs: [
-        makeJob({job_executions: [makeJobExecution({steps: [makeStep({current_attempt: 2})]})]}),
-      ],
+      jobs: [makeJob({executions: [makeJobExecution({steps: [makeStep({current_attempt: 2})]})]})],
     });
 
     const result = evaluateExpectations(
@@ -201,7 +192,7 @@ describe('evaluateExpectations', () => {
     const detail = makeDetail({
       jobs: [
         makeJob({
-          job_executions: [makeJobExecution({steps: [makeStep({key: null, name: 'Greet'})]})],
+          executions: [makeJobExecution({steps: [makeStep({key: null, name: 'Greet'})]})],
         }),
       ],
     });
@@ -221,7 +212,7 @@ describe('evaluateExpectations', () => {
     const detail = makeDetail({
       jobs: [
         makeJob({
-          job_executions: [makeJobExecution({steps: [makeStep({type: 'tool'})]})],
+          executions: [makeJobExecution({steps: [makeStep({type: 'tool'})]})],
         }),
       ],
     });
@@ -241,7 +232,7 @@ describe('evaluateExpectations', () => {
     const detail = makeDetail({
       jobs: [
         makeJob({
-          job_executions: [makeJobExecution({steps: [makeStep({type: 'run'})]})],
+          executions: [makeJobExecution({steps: [makeStep({type: 'run'})]})],
         }),
       ],
     });
@@ -280,7 +271,7 @@ describe('evaluateExpectations', () => {
       jobs: [
         makeJob({
           status: 'failed',
-          job_executions: [
+          executions: [
             makeJobExecution({
               status: 'failed',
               steps: [
@@ -317,7 +308,7 @@ describe('evaluateExpectations', () => {
         makeJob({
           status: 'failed',
           status_reason: 'step_failed',
-          job_executions: [
+          executions: [
             makeJobExecution({
               status: 'failed',
               status_reason: 'step_failed',
@@ -388,7 +379,7 @@ describe('evaluateExpectations', () => {
       jobs: [
         makeJob({
           status_reason: 'condition_false',
-          job_executions: [
+          executions: [
             makeJobExecution({
               status_reason: 'condition_false',
               steps: [
@@ -447,7 +438,7 @@ describe('evaluateExpectations', () => {
     const detail = makeDetail({
       jobs: [
         makeJob({
-          job_executions: [
+          executions: [
             makeJobExecution({
               steps: [
                 makeStep({
@@ -489,7 +480,7 @@ describe('evaluateExpectations', () => {
     const detail = makeDetail({
       jobs: [
         makeJob({
-          job_executions: [
+          executions: [
             makeJobExecution({
               steps: [
                 makeStep({
@@ -538,7 +529,7 @@ describe('evaluateExpectations', () => {
       makeDetail({
         jobs: [
           makeJob({
-            job_executions: [
+            executions: [
               makeJobExecution({
                 steps: [makeStep({attempts: []})],
               }),
@@ -618,7 +609,7 @@ describe('evaluateExpectations', () => {
     const detail = makeDetail({
       jobs: [
         makeJob({
-          job_executions: [
+          executions: [
             makeJobExecution({steps: [makeStep({attempts: [makeAttempt({exit_code: null})]})]}),
           ],
         }),
@@ -642,7 +633,7 @@ describe('evaluateExpectations', () => {
     const detail = makeDetail({
       jobs: [
         makeJob({
-          job_executions: [
+          executions: [
             makeJobExecution({
               sequence: 1,
               steps: [makeStep({status: 'succeeded', attempts: [makeAttempt({exit_code: 0})]})],

--- a/e2e/suites/flow/workflows/src/expect.ts
+++ b/e2e/suites/flow/workflows/src/expect.ts
@@ -1,12 +1,10 @@
 import type {LogRecord} from '@shipfox/api-logs-dto';
+import type {JobStatusReasonDto, StepErrorReasonDto} from '@shipfox/api-workflows-dto';
 import type {
-  JobStatusReasonDto,
-  StepErrorReasonDto,
-  StepGateResultDto,
-  WorkflowRunDetailResponseDto,
-  WorkflowRunJobDetailDto,
-  WorkflowRunStepDetailDto,
-} from '@shipfox/api-workflows-dto';
+  WorkflowJobObservation,
+  WorkflowRunObservation,
+  WorkflowStepObservation,
+} from '@shipfox/e2e-observe-workflows';
 import {z} from 'zod';
 
 // expect.yaml is the suite's assertion language, validated here and owned by the
@@ -216,21 +214,21 @@ export interface ExpectationResult {
 }
 
 function findJob(
-  runDetail: WorkflowRunDetailResponseDto,
+  observation: WorkflowRunObservation,
   key: string,
-): WorkflowRunJobDetailDto | undefined {
-  return runDetail.jobs.find((job) => job.key === key);
+): WorkflowJobObservation | undefined {
+  return observation.jobs.find((job) => job.key === key);
 }
 
 // Steps live under each job execution; a listening or restarted job has more than one
 // execution. Search every execution and prefer the latest, so an assertion targets the
 // most recent run of the step rather than a stale earlier attempt.
 function findStep(
-  job: WorkflowRunJobDetailDto,
+  job: WorkflowJobObservation,
   stepKey: string,
-): WorkflowRunStepDetailDto | undefined {
-  let match: WorkflowRunStepDetailDto | undefined;
-  for (const execution of job.job_executions) {
+): WorkflowStepObservation | undefined {
+  let match: WorkflowStepObservation | undefined;
+  for (const execution of job.executions) {
     for (const step of execution.steps) {
       if (step.key === stepKey || step.name === stepKey) match = step;
     }
@@ -238,16 +236,12 @@ function findStep(
   return match;
 }
 
-function latestExitCode(step: WorkflowRunStepDetailDto): number | null {
-  const current = step.attempts.find((attempt) => attempt.attempt === step.current_attempt);
-  const attempt = current ?? step.attempts.at(-1);
-  return attempt?.exit_code ?? null;
+function latestExitCode(step: WorkflowStepObservation): number | null {
+  return step.exit_code;
 }
 
-function latestGateResult(step: WorkflowRunStepDetailDto): StepGateResultDto | null {
-  const current = step.attempts.find((attempt) => attempt.attempt === step.current_attempt);
-  const attempt = current ?? step.attempts.at(-1);
-  return attempt?.gate_result ?? null;
+function latestGateResult(step: WorkflowStepObservation) {
+  return step.gate_result;
 }
 
 function stringField(value: Record<string, unknown>, field: string): string | null {
@@ -271,7 +265,7 @@ type JobExpectation = NonNullable<Expectation['jobs']>[string];
 type StepExpectation = NonNullable<JobExpectation['steps']>[string];
 
 function evaluateStepError(
-  step: WorkflowRunStepDetailDto,
+  step: WorkflowStepObservation,
   expectation: NonNullable<StepExpectation['error']>,
   path: string,
   mismatches: Mismatch[],
@@ -313,7 +307,7 @@ function evaluateStepError(
 }
 
 function evaluateGateResult(
-  step: WorkflowRunStepDetailDto,
+  step: WorkflowStepObservation,
   expectation: NonNullable<StepExpectation['gate_result']>,
   path: string,
   mismatches: Mismatch[],
@@ -352,7 +346,7 @@ function evaluateGateResult(
 }
 
 function evaluateStepExpectation(
-  job: WorkflowRunJobDetailDto,
+  job: WorkflowJobObservation,
   stepKey: string,
   expectation: StepExpectation,
   path: string,
@@ -409,13 +403,13 @@ function evaluateStepExpectation(
 }
 
 function evaluateJobExpectation(
-  runDetail: WorkflowRunDetailResponseDto,
+  observation: WorkflowRunObservation,
   jobKey: string,
   expectation: JobExpectation,
   result: ExpectationResult,
 ): void {
   const path = `jobs.${jobKey}`;
-  const job = findJob(runDetail, jobKey);
+  const job = findJob(observation, jobKey);
   if (!job) {
     result.mismatches.push({path, expected: 'present', actual: 'missing'});
     return;
@@ -442,27 +436,27 @@ function evaluateJobExpectation(
 }
 
 /**
- * Compares a run detail against an expectation, returning every structural mismatch
+ * Compares a bounded run observation against an expectation, returning every structural mismatch
  * (run/job/step status, step type, and step exit code) plus the log requirements the
  * harness still needs to fetch. Pure and synchronous, so it is unit-tested against canned
- * run detail.
+ * bounded observations.
  */
 export function evaluateExpectations(
-  runDetail: WorkflowRunDetailResponseDto,
+  observation: WorkflowRunObservation,
   expectation: Expectation,
 ): ExpectationResult {
   const result: ExpectationResult = {mismatches: [], logRequirements: []};
 
-  if (runDetail.status !== expectation.run.status) {
+  if (observation.status !== expectation.run.status) {
     result.mismatches.push({
       path: 'run.status',
       expected: expectation.run.status,
-      actual: runDetail.status,
+      actual: observation.status,
     });
   }
 
   for (const [jobKey, jobExpectation] of Object.entries(expectation.jobs ?? {})) {
-    evaluateJobExpectation(runDetail, jobKey, jobExpectation, result);
+    evaluateJobExpectation(observation, jobKey, jobExpectation, result);
   }
 
   return result;

--- a/e2e/suites/flow/workflows/src/listener-helpers.test.ts
+++ b/e2e/suites/flow/workflows/src/listener-helpers.test.ts
@@ -58,6 +58,14 @@ function execution(
 
 function listenerJob(overrides: Partial<WorkflowJobObservation> = {}): WorkflowJobObservation {
   const executions = overrides.executions ?? [execution()];
+  const executionStatusCounts = {
+    pending: 0,
+    running: 0,
+    succeeded: 0,
+    failed: 0,
+    cancelled: 0,
+  };
+  for (const candidate of executions) executionStatusCounts[candidate.status] += 1;
   const base: WorkflowJobObservation = {
     id: '77777777-7777-4777-8777-777777777777',
     key: 'listen',
@@ -69,13 +77,7 @@ function listenerJob(overrides: Partial<WorkflowJobObservation> = {}): WorkflowJ
     listener_status: 'resolved',
     position: 0,
     execution_count: overrides.execution_count ?? executions.length,
-    execution_status_counts: {
-      pending: 0,
-      running: 0,
-      succeeded: 1,
-      failed: 0,
-      cancelled: 0,
-    },
+    execution_status_counts: executionStatusCounts,
     default_execution: null,
     executions,
   };
@@ -194,6 +196,7 @@ describe('listener helper predicates', () => {
     const result = listenerExecutionCountMatches({observation, jobKey: 'listen', count: 2});
 
     expect(result.matched).toBe(true);
+    expect(observation.jobs[0]?.execution_status_counts.succeeded).toBe(2);
   });
 
   test('matches listener resolution status', () => {

--- a/e2e/suites/flow/workflows/src/listener-helpers.test.ts
+++ b/e2e/suites/flow/workflows/src/listener-helpers.test.ts
@@ -1,10 +1,9 @@
+import type {WorkflowExecutionEventDto} from '@shipfox/api-workflows-dto';
 import type {
-  JobDto,
-  WorkflowExecutionEventDto,
-  WorkflowRunDetailResponseDto,
-  WorkflowRunJobDetailDto,
-  WorkflowRunJobExecutionDetailDto,
-} from '@shipfox/api-workflows-dto';
+  WorkflowExecutionObservation,
+  WorkflowJobObservation,
+  WorkflowRunObservation,
+} from '@shipfox/e2e-observe-workflows';
 import {
   batchedListenerExecutionMatches,
   findListenerExecutionByDeliveryId,
@@ -32,67 +31,71 @@ function event(overrides: Partial<WorkflowExecutionEventDto> = {}): WorkflowExec
 }
 
 function execution(
-  overrides: Partial<WorkflowRunJobExecutionDetailDto> = {},
-): WorkflowRunJobExecutionDetailDto {
+  overrides: Partial<WorkflowExecutionObservation> = {},
+): WorkflowExecutionObservation {
   return {
     id: '66666666-6666-4666-8666-666666666666',
     job_id: '77777777-7777-4777-8777-777777777777',
     sequence: 1,
     name: 'listen #1',
     status: 'succeeded',
+    display_status: 'succeeded',
     status_reason: null,
+    status_reason_message: null,
     runner: null,
     trigger_events: [event()],
     outputs: null,
-    evaluation_trace: null,
     queued_at: timestamp,
     started_at: timestamp,
     finished_at: timestamp,
     timed_out_at: null,
-    created_at: timestamp,
     updated_at: timestamp,
     steps: [],
+    context: null,
     ...overrides,
   };
 }
 
-function listenerJob(overrides: Partial<WorkflowRunJobDetailDto> = {}): WorkflowRunJobDetailDto {
-  const base: JobDto = {
+function listenerJob(overrides: Partial<WorkflowJobObservation> = {}): WorkflowJobObservation {
+  const executions = overrides.executions ?? [execution()];
+  const base: WorkflowJobObservation = {
     id: '77777777-7777-4777-8777-777777777777',
-    run_attempt_id: '88888888-8888-4888-8888-888888888888',
     key: 'listen',
     name: null,
     mode: 'listening',
     status: 'succeeded',
     status_reason: null,
-    success: null,
-    runner: null,
-    evaluation_trace: null,
     carried_over: false,
-    listening: {
-      on: [{source: 'fire-source', event: 'received'}],
-      until: [{source: 'resolve-source', event: 'received'}],
-      timeout_ms: null,
-      max_executions: null,
-      batch: null,
-      on_resolve: 'finish',
-      execution_timeout_ms: null,
-      name: null,
-    },
     listener_status: 'resolved',
-    resolution_reason: 'until',
-    outputs: null,
-    dependencies: [],
     position: 0,
-    created_at: timestamp,
-    updated_at: timestamp,
+    execution_count: overrides.execution_count ?? executions.length,
+    execution_status_counts: {
+      pending: 0,
+      running: 0,
+      succeeded: 1,
+      failed: 0,
+      cancelled: 0,
+    },
+    default_execution: null,
+    executions,
   };
-  return {...base, job_executions: [execution()], ...overrides};
+  return {
+    ...base,
+    ...overrides,
+  };
 }
 
-function runDetail(
-  overrides: Partial<WorkflowRunDetailResponseDto> = {},
-): WorkflowRunDetailResponseDto {
+function runObservation(overrides: Partial<WorkflowRunObservation> = {}): WorkflowRunObservation {
+  const attempt = {
+    id: '88888888-8888-4888-8888-888888888888',
+    workflow_run_id: '33333333-3333-4333-8333-333333333333',
+    attempt: 1,
+    status: 'succeeded' as const,
+    created_at: timestamp,
+    started_at: timestamp,
+    finished_at: timestamp,
+    rerun_mode: null,
+  };
   return {
     id: '33333333-3333-4333-8333-333333333333',
     project_id: '11111111-1111-4111-8111-111111111111',
@@ -108,24 +111,10 @@ function runDetail(
     trigger_provider: 'manual',
     trigger_source: 'manual',
     trigger_event: 'fire',
-    trigger_payload: {},
     trigger_reference: null,
-    inputs: null,
-    source_snapshot: null,
     created_at: timestamp,
     updated_at: timestamp,
-    started_at: timestamp,
-    finished_at: timestamp,
-    run_attempt: {
-      id: '88888888-8888-4888-8888-888888888888',
-      workflow_run_id: '33333333-3333-4333-8333-333333333333',
-      attempt: 1,
-      status: 'succeeded',
-      created_at: timestamp,
-      started_at: timestamp,
-      finished_at: timestamp,
-      rerun_mode: null,
-    },
+    attempt,
     jobs: [listenerJob()],
     has_started_job_execution: true,
     ...overrides,
@@ -134,10 +123,10 @@ function runDetail(
 
 describe('listener helper predicates', () => {
   test('finds the listener execution containing a delivery id', () => {
-    const detail = runDetail({
+    const observation = runObservation({
       jobs: [
         listenerJob({
-          job_executions: [
+          executions: [
             execution({sequence: 1, trigger_events: [event({delivery_id: 'delivery-1'})]}),
             execution({sequence: 2, trigger_events: [event({delivery_id: 'delivery-2'})]}),
           ],
@@ -146,7 +135,7 @@ describe('listener helper predicates', () => {
     });
 
     const result = findListenerExecutionByDeliveryId({
-      runDetail: detail,
+      observation,
       jobKey: 'listen',
       deliveryId: 'delivery-2',
     });
@@ -155,10 +144,10 @@ describe('listener helper predicates', () => {
   });
 
   test('finds the listener execution containing any delivery id', () => {
-    const detail = runDetail({
+    const observation = runObservation({
       jobs: [
         listenerJob({
-          job_executions: [
+          executions: [
             execution({sequence: 1, trigger_events: [event({delivery_id: 'delivery-1'})]}),
             execution({sequence: 2, trigger_events: [event({delivery_id: 'delivery-2'})]}),
           ],
@@ -167,7 +156,7 @@ describe('listener helper predicates', () => {
     });
 
     const result = findListenerExecutionByDeliveryIds({
-      runDetail: detail,
+      observation,
       jobKey: 'listen',
       deliveryIds: ['delivery-3', 'delivery-2'],
     });
@@ -178,7 +167,7 @@ describe('listener helper predicates', () => {
 
   test('reports a missing delivery with observed delivery ids', () => {
     const result = listenerDeliveryObserved({
-      runDetail: runDetail(),
+      observation: runObservation(),
       jobKey: 'listen',
       deliveryId: 'missing-delivery',
     });
@@ -191,10 +180,10 @@ describe('listener helper predicates', () => {
   });
 
   test('matches listener execution counts', () => {
-    const detail = runDetail({
+    const observation = runObservation({
       jobs: [
         listenerJob({
-          job_executions: [
+          executions: [
             execution({sequence: 1}),
             execution({id: '99999999-9999-4999-8999-999999999999', sequence: 2}),
           ],
@@ -202,14 +191,14 @@ describe('listener helper predicates', () => {
       ],
     });
 
-    const result = listenerExecutionCountMatches({runDetail: detail, jobKey: 'listen', count: 2});
+    const result = listenerExecutionCountMatches({observation, jobKey: 'listen', count: 2});
 
     expect(result.matched).toBe(true);
   });
 
-  test('matches listener resolution status and reason', () => {
+  test('matches listener resolution status', () => {
     const result = listenerResolutionMatches({
-      runDetail: runDetail(),
+      observation: runObservation(),
       jobKey: 'listen',
       status: 'succeeded',
       reason: 'until',
@@ -220,10 +209,8 @@ describe('listener helper predicates', () => {
 
   test('reports listener resolution mismatches', () => {
     const result = listenerResolutionMatches({
-      runDetail: runDetail({
-        jobs: [
-          listenerJob({status: 'running', listener_status: 'listening', resolution_reason: null}),
-        ],
+      observation: runObservation({
+        jobs: [listenerJob({status: 'running', listener_status: 'listening'})],
       }),
       jobKey: 'listen',
       status: 'succeeded',
@@ -233,16 +220,16 @@ describe('listener helper predicates', () => {
     expect(result).toEqual({
       matched: false,
       diagnostic:
-        'listener job listen status=running, listenerStatus=listening, resolutionReason=null, expected=succeeded/resolved/until',
+        'listener job listen status=running, listenerStatus=listening, expected=succeeded/resolved (resolution reason until is not exposed by bounded overview)',
     });
   });
 
   test('matches a batched execution containing every expected delivery', () => {
     const result = batchedListenerExecutionMatches({
-      runDetail: runDetail({
+      observation: runObservation({
         jobs: [
           listenerJob({
-            job_executions: [
+            executions: [
               execution({
                 trigger_events: [
                   event({delivery_id: 'delivery-1'}),

--- a/e2e/suites/flow/workflows/src/listener-helpers.ts
+++ b/e2e/suites/flow/workflows/src/listener-helpers.ts
@@ -3,12 +3,15 @@ import type {
   JobStatusDto,
   ListenerStatusDto,
   ResolutionReasonDto,
-  WorkflowRunDetailResponseDto,
-  WorkflowRunJobDetailDto,
-  WorkflowRunJobExecutionDetailDto,
 } from '@shipfox/api-workflows-dto';
-import {createApiClient, pollUntil, requestJson} from '@shipfox/e2e-core';
-import {waitForRunDetailMatching} from './polling.js';
+import {type createApiClient, pollUntil, requestJson} from '@shipfox/e2e-core';
+import type {
+  WorkflowExecutionObservation,
+  WorkflowJobObservation,
+  WorkflowRunObservation,
+} from '@shipfox/e2e-observe-workflows';
+import {observeRun} from '@shipfox/e2e-observe-workflows';
+import {waitForRunObservationMatching} from './polling.js';
 import {postWebhookDelivery} from './webhook.js';
 
 export interface ListenerPredicateResult {
@@ -17,25 +20,25 @@ export interface ListenerPredicateResult {
 }
 
 export function findListenerJob(
-  runDetail: WorkflowRunDetailResponseDto,
+  observation: WorkflowRunObservation,
   jobKey: string,
-): WorkflowRunJobDetailDto | undefined {
-  return runDetail.jobs.find((job) => job.key === jobKey && job.mode === 'listening');
+): WorkflowJobObservation | undefined {
+  return observation.jobs.find((job) => job.key === jobKey && job.mode === 'listening');
 }
 
 export function listenerExecutionCountMatches(params: {
-  runDetail: WorkflowRunDetailResponseDto;
+  observation: WorkflowRunObservation;
   jobKey: string;
   count: number;
 }): ListenerPredicateResult {
-  const job = findListenerJob(params.runDetail, params.jobKey);
+  const job = findListenerJob(params.observation, params.jobKey);
   if (!job) {
     return {
       matched: false,
       diagnostic: `listener job ${params.jobKey} missing`,
     };
   }
-  const actual = job.job_executions.length;
+  const actual = job.execution_count;
   return {
     matched: actual === params.count,
     diagnostic: `listener job ${params.jobKey} executionCount=${actual}, expected=${params.count}`,
@@ -43,11 +46,11 @@ export function listenerExecutionCountMatches(params: {
 }
 
 export function listenerStatusMatches(params: {
-  runDetail: WorkflowRunDetailResponseDto;
+  observation: WorkflowRunObservation;
   jobKey: string;
   listenerStatus: ListenerStatusDto;
 }): ListenerPredicateResult {
-  const job = findListenerJob(params.runDetail, params.jobKey);
+  const job = findListenerJob(params.observation, params.jobKey);
   if (!job) return {matched: false, diagnostic: `listener job ${params.jobKey} missing`};
   return {
     matched: job.listener_status === params.listenerStatus,
@@ -56,27 +59,26 @@ export function listenerStatusMatches(params: {
 }
 
 export function listenerResolutionMatches(params: {
-  runDetail: WorkflowRunDetailResponseDto;
+  observation: WorkflowRunObservation;
   jobKey: string;
   status: JobStatusDto;
   reason: ResolutionReasonDto;
 }): ListenerPredicateResult {
-  const job = findListenerJob(params.runDetail, params.jobKey);
+  const job = findListenerJob(params.observation, params.jobKey);
   if (!job) return {matched: false, diagnostic: `listener job ${params.jobKey} missing`};
   const statusMatches = job.status === params.status;
   const listenerStatusMatches = job.listener_status === 'resolved';
-  const reasonMatches = job.resolution_reason === params.reason;
   return {
-    matched: statusMatches && listenerStatusMatches && reasonMatches,
-    diagnostic: `listener job ${params.jobKey} status=${job.status}, listenerStatus=${job.listener_status}, resolutionReason=${job.resolution_reason}, expected=${params.status}/resolved/${params.reason}`,
+    matched: statusMatches && listenerStatusMatches,
+    diagnostic: `listener job ${params.jobKey} status=${job.status}, listenerStatus=${job.listener_status}, expected=${params.status}/resolved (resolution reason ${params.reason} is not exposed by bounded overview)`,
   };
 }
 
 export function listenerExecutionStatusMatches(params: {
-  runDetail: WorkflowRunDetailResponseDto;
+  observation: WorkflowRunObservation;
   jobKey: string;
   sequence: number;
-  status: WorkflowRunJobExecutionDetailDto['status'];
+  status: WorkflowExecutionObservation['status'];
 }): ListenerPredicateResult {
   const execution = findListenerExecutionBySequence(params);
   if (!execution) {
@@ -92,7 +94,7 @@ export function listenerExecutionStatusMatches(params: {
 }
 
 export function listenerDeliveryObserved(params: {
-  runDetail: WorkflowRunDetailResponseDto;
+  observation: WorkflowRunObservation;
   jobKey: string;
   deliveryId: string;
 }): ListenerPredicateResult {
@@ -103,9 +105,9 @@ export function listenerDeliveryObserved(params: {
       diagnostic: `listener job ${params.jobKey} observed delivery ${params.deliveryId} in execution ${execution.sequence}`,
     };
   }
-  const job = findListenerJob(params.runDetail, params.jobKey);
+  const job = findListenerJob(params.observation, params.jobKey);
   if (!job) return {matched: false, diagnostic: `listener job ${params.jobKey} missing`};
-  const observed = job.job_executions.flatMap((candidate) =>
+  const observed = job.executions.flatMap((candidate) =>
     candidate.trigger_events.map((event) => event.delivery_id),
   );
   return {
@@ -115,7 +117,7 @@ export function listenerDeliveryObserved(params: {
 }
 
 export function batchedListenerExecutionMatches(params: {
-  runDetail: WorkflowRunDetailResponseDto;
+  observation: WorkflowRunObservation;
   jobKey: string;
   sequence: number;
   deliveryIds: string[];
@@ -138,24 +140,24 @@ export function batchedListenerExecutionMatches(params: {
 }
 
 export function findListenerExecutionByDeliveryId(params: {
-  runDetail: WorkflowRunDetailResponseDto;
+  observation: WorkflowRunObservation;
   jobKey: string;
   deliveryId: string;
-}): WorkflowRunJobExecutionDetailDto | undefined {
-  const job = findListenerJob(params.runDetail, params.jobKey);
-  return job?.job_executions.find((execution) =>
+}): WorkflowExecutionObservation | undefined {
+  const job = findListenerJob(params.observation, params.jobKey);
+  return job?.executions.find((execution) =>
     execution.trigger_events.some((event) => event.delivery_id === params.deliveryId),
   );
 }
 
 export function findListenerExecutionByDeliveryIds(params: {
-  runDetail: WorkflowRunDetailResponseDto;
+  observation: WorkflowRunObservation;
   jobKey: string;
   deliveryIds: string[];
-}): {deliveryId: string; execution: WorkflowRunJobExecutionDetailDto} | undefined {
+}): {deliveryId: string; execution: WorkflowExecutionObservation} | undefined {
   const expected = new Set(params.deliveryIds);
-  const job = findListenerJob(params.runDetail, params.jobKey);
-  for (const execution of job?.job_executions ?? []) {
+  const job = findListenerJob(params.observation, params.jobKey);
+  for (const execution of job?.executions ?? []) {
     const event = execution.trigger_events.find((candidate) => expected.has(candidate.delivery_id));
     if (event) return {deliveryId: event.delivery_id, execution};
   }
@@ -163,11 +165,11 @@ export function findListenerExecutionByDeliveryIds(params: {
 }
 
 export function findListenerExecutionBySequence(params: {
-  runDetail: WorkflowRunDetailResponseDto;
+  observation: WorkflowRunObservation;
   jobKey: string;
   sequence: number;
-}): WorkflowRunJobExecutionDetailDto | undefined {
-  return findListenerJob(params.runDetail, params.jobKey)?.job_executions.find(
+}): WorkflowExecutionObservation | undefined {
+  return findListenerJob(params.observation, params.jobKey)?.executions.find(
     (execution) => execution.sequence === params.sequence,
   );
 }
@@ -177,18 +179,21 @@ export async function waitForListenerExecution(params: {
   runId: string;
   jobKey: string;
   sequence: number;
-  status?: WorkflowRunJobExecutionDetailDto['status'] | undefined;
+  status?: WorkflowExecutionObservation['status'] | undefined;
   timeoutMs: number;
-}): Promise<WorkflowRunDetailResponseDto> {
-  return await waitForRunDetailMatching({
+}): Promise<WorkflowRunObservation> {
+  return await waitForRunObservationMatching({
     token: params.token,
     runId: params.runId,
     timeoutMs: params.timeoutMs,
     description: `listener job ${params.jobKey} execution ${params.sequence}`,
-    matches: (runDetail) => {
+    selection: {
+      jobs: [{jobKey: params.jobKey, executionSequences: [params.sequence]}],
+    },
+    matches: (observation) => {
       if (params.status !== undefined) {
         return listenerExecutionStatusMatches({
-          runDetail,
+          observation,
           jobKey: params.jobKey,
           sequence: params.sequence,
           status: params.status,
@@ -197,7 +202,7 @@ export async function waitForListenerExecution(params: {
       return {
         matched:
           findListenerExecutionBySequence({
-            runDetail,
+            observation,
             jobKey: params.jobKey,
             sequence: params.sequence,
           }) !== undefined,
@@ -213,8 +218,7 @@ export async function waitForListenerStatus(params: {
   jobKey: string;
   listenerStatus: ListenerStatusDto;
   timeoutMs: number;
-}): Promise<WorkflowRunDetailResponseDto> {
-  const client = createApiClient({token: params.token});
+}): Promise<WorkflowRunObservation> {
   let diagnostic = `listener job ${params.jobKey} missing`;
   return await pollUntil(
     {
@@ -225,15 +229,16 @@ export async function waitForListenerStatus(params: {
         `listener job ${params.jobKey} status ${params.listenerStatus}: ${diagnostic}`,
     },
     async () => {
-      const runDetail = await client.requestJson<WorkflowRunDetailResponseDto>(
-        'get',
-        `/workflows/runs/${encodeURIComponent(params.runId)}`,
-      );
-      const status = listenerStatusMatches({...params, runDetail});
+      const observation = await observeRun({
+        runId: params.runId,
+        selection: {jobs: [{jobKey: params.jobKey}]},
+        token: params.token,
+      });
+      const status = listenerStatusMatches({...params, observation});
       diagnostic = status.diagnostic;
       if (!status.matched) return null;
 
-      const job = findListenerJob(runDetail, params.jobKey);
+      const job = findListenerJob(observation, params.jobKey);
       if (!job) return null;
       const readiness = await requestJson<{ready: boolean}>(
         'get',
@@ -243,7 +248,7 @@ export async function waitForListenerStatus(params: {
       diagnostic = readiness.ready
         ? `${status.diagnostic}, trigger subscriptions ready`
         : `${status.diagnostic}, trigger subscriptions pending`;
-      return readiness.ready ? runDetail : null;
+      return readiness.ready ? observation : null;
     },
   );
 }
@@ -255,13 +260,14 @@ export async function waitForListenerResolution(params: {
   status: JobStatusDto;
   reason: ResolutionReasonDto;
   timeoutMs: number;
-}): Promise<WorkflowRunDetailResponseDto> {
-  return await waitForRunDetailMatching({
+}): Promise<WorkflowRunObservation> {
+  return await waitForRunObservationMatching({
     token: params.token,
     runId: params.runId,
     timeoutMs: params.timeoutMs,
     description: `listener job ${params.jobKey} resolution ${params.reason}`,
-    matches: (runDetail) => listenerResolutionMatches({...params, runDetail}),
+    selection: {jobs: [{jobKey: params.jobKey}]},
+    matches: (observation) => listenerResolutionMatches({...params, observation}),
   });
 }
 
@@ -275,7 +281,7 @@ export async function sendWebhookDeliveryUntilObserved(params: {
   maxAttempts?: number | undefined;
   attemptTimeoutMs?: number | undefined;
   body: (attempt: number, deliveryId: string) => unknown;
-}): Promise<{deliveryId: string; deliveryIds: string[]; runDetail: WorkflowRunDetailResponseDto}> {
+}): Promise<{deliveryId: string; deliveryIds: string[]; observation: WorkflowRunObservation}> {
   const maxAttempts = params.maxAttempts ?? 8;
   const attemptTimeoutMs = params.attemptTimeoutMs ?? 5_000;
   const deliveryIds: string[] = [];
@@ -292,14 +298,25 @@ export async function sendWebhookDeliveryUntilObserved(params: {
     });
 
     try {
-      const runDetail = await waitForRunDetailMatching({
+      const observation = await waitForRunObservationMatching({
         token: params.token,
         runId: params.runId,
         timeoutMs: attemptTimeoutMs,
         description: `listener delivery ${deliveryId}`,
+        selection: {
+          jobs: [
+            {
+              jobKey: params.jobKey,
+              executionSequences: 'all',
+              includeContext: true,
+              executionMatches: (execution) =>
+                execution.trigger_events.some((event) => deliveryIds.includes(event.delivery_id)),
+            },
+          ],
+        },
         matches: (candidate) => {
           const match = findListenerExecutionByDeliveryIds({
-            runDetail: candidate,
+            observation: candidate,
             jobKey: params.jobKey,
             deliveryIds,
           });
@@ -309,7 +326,7 @@ export async function sendWebhookDeliveryUntilObserved(params: {
               diagnostic: `listener job ${params.jobKey} observed delivery ${match.deliveryId} in execution ${match.execution.sequence}`,
             };
           }
-          const observed = findListenerJob(candidate, params.jobKey)?.job_executions.flatMap(
+          const observed = findListenerJob(candidate, params.jobKey)?.executions.flatMap(
             (execution) => execution.trigger_events.map((event) => event.delivery_id),
           );
           return {
@@ -319,12 +336,12 @@ export async function sendWebhookDeliveryUntilObserved(params: {
         },
       });
       const match = findListenerExecutionByDeliveryIds({
-        runDetail,
+        observation,
         jobKey: params.jobKey,
         deliveryIds,
       });
       if (!match) throw new Error(`Observed listener delivery match disappeared for ${deliveryId}`);
-      return {deliveryId: match.deliveryId, deliveryIds, runDetail};
+      return {deliveryId: match.deliveryId, deliveryIds, observation};
     } catch (error) {
       lastError = error;
     }

--- a/e2e/suites/flow/workflows/src/listener-jobs.ts
+++ b/e2e/suites/flow/workflows/src/listener-jobs.ts
@@ -56,7 +56,14 @@ async function attachRunObservation(params: {
     const observation = await observeRun({
       runId: params.runId,
       selection: {
-        jobs: [{jobKey: LISTENER_JOB, executionSequences: 'all', includeContext: true}],
+        jobs: [
+          {
+            jobKey: LISTENER_JOB,
+            executionSequences: 'all',
+            includeContext: true,
+            stepAttempts: 'all',
+          },
+        ],
       },
       token: params.token,
     });

--- a/e2e/suites/flow/workflows/src/listener-jobs.ts
+++ b/e2e/suites/flow/workflows/src/listener-jobs.ts
@@ -1,7 +1,8 @@
 import {createApiClient} from '@shipfox/e2e-core';
 import {type LocalRunnerHandle, stopLocalRunner} from '@shipfox/e2e-driver-runner-process';
 import {fetchStepLogs} from '@shipfox/e2e-observe-logs';
-import type {waitForRunTerminal} from '@shipfox/e2e-observe-workflows';
+import type {WorkflowRunObservation} from '@shipfox/e2e-observe-workflows';
+import {observeRun} from '@shipfox/e2e-observe-workflows';
 import {
   type AttachFn,
   attachLocalRunnerLog,
@@ -13,7 +14,7 @@ import {
   batchedListenerExecutionMatches,
   sendWebhookDeliveryUntilObserved,
 } from './listener-helpers.js';
-import {waitForRunDetailMatching} from './polling.js';
+import {waitForRunObservationMatching} from './polling.js';
 import {startSuiteLocalRunner} from './runner.js';
 import type {SuiteContext} from './suite-context.js';
 import {fireManualAndAwaitRun} from './triggers.js';
@@ -45,29 +46,31 @@ export interface ListenerCase {
   workspaceId: string;
 }
 
-async function attachRunDetail(params: {
+async function attachRunObservation(params: {
   attach: AttachFn;
   runId: string | undefined;
   token: string;
 }): Promise<void> {
   if (params.runId === undefined) return;
   try {
-    const client = createApiClient({token: params.token});
-    const runDetail = await client.requestJson<Awaited<ReturnType<typeof waitForRunTerminal>>>(
-      'get',
-      `/workflows/runs/${encodeURIComponent(params.runId)}`,
-    );
-    await params.attach({
-      name: 'run-detail.json',
-      contentType: 'application/json',
-      body: JSON.stringify(runDetail, null, 2),
+    const observation = await observeRun({
+      runId: params.runId,
+      selection: {
+        jobs: [{jobKey: LISTENER_JOB, executionSequences: 'all', includeContext: true}],
+      },
+      token: params.token,
     });
-    for (const request of collectStepLogAttachmentRequests(runDetail)) {
+    await params.attach({
+      name: 'workflow-observation.json',
+      contentType: 'application/json',
+      body: JSON.stringify(observation, null, 2),
+    });
+    for (const request of collectStepLogAttachmentRequests(observation)) {
       await params.attach(await fetchLogAttachment(request, params.token));
     }
   } catch (error) {
     await params.attach({
-      name: 'run-detail.error.txt',
+      name: 'workflow-observation.error.txt',
       contentType: 'text/plain',
       body: error instanceof Error ? error.message : String(error),
     });
@@ -149,7 +152,7 @@ export async function cleanupListenerCase(
   runId: string | undefined,
 ): Promise<void> {
   if (testCase === undefined) return;
-  await attachRunDetail({attach: testCase.attach, runId, token: testCase.token});
+  await attachRunObservation({attach: testCase.attach, runId, token: testCase.token});
   await attachWebhookTriggerDiagnostics({
     attach: testCase.attach,
     client: testCase.client,
@@ -216,15 +219,15 @@ export async function sendResolve(testCase: ListenerCase, label: string): Promis
 }
 
 export async function stepLogText(params: {
-  runDetail: Awaited<ReturnType<typeof waitForRunTerminal>>;
+  observation: WorkflowRunObservation;
   token: string;
   jobKey: string;
   sequence: number;
   stepKey: string;
 }): Promise<string> {
-  const execution = params.runDetail.jobs
+  const execution = params.observation.jobs
     .find((job) => job.key === params.jobKey)
-    ?.job_executions.find((candidate) => candidate.sequence === params.sequence);
+    ?.executions.find((candidate) => candidate.sequence === params.sequence);
   const step = execution?.steps.find((candidate) => candidate.key === params.stepKey);
   if (!step) throw new Error(`Step ${params.jobKey}.${params.sequence}.${params.stepKey} missing`);
   const logs = await fetchStepLogs({
@@ -243,7 +246,7 @@ export async function sendBatchAndAwaitMaterialization(params: {
   timeoutMs: number;
   eventCount?: number | undefined;
   expectedEventCount?: number | undefined;
-}): Promise<{deliveryIds: string[]; runDetail: Awaited<ReturnType<typeof waitForRunTerminal>>}> {
+}): Promise<{deliveryIds: string[]; observation: WorkflowRunObservation}> {
   const eventCount = params.eventCount ?? 2;
   const expectedEventCount = params.expectedEventCount ?? eventCount;
   if (
@@ -274,20 +277,29 @@ export async function sendBatchAndAwaitMaterialization(params: {
     });
   }
 
-  const runDetail = await waitForRunDetailMatching({
+  const observation = await waitForRunObservationMatching({
     token: params.testCase.token,
     runId: params.runId,
     timeoutMs: params.timeoutMs,
     description: `batched listener deliveries ${deliveryIds.join(', ')}`,
+    selection: {
+      jobs: [
+        {
+          jobKey: LISTENER_JOB,
+          executionSequences: [params.sequence],
+          includeContext: true,
+        },
+      ],
+    },
     matches: (candidate) =>
       batchedListenerExecutionMatches({
-        runDetail: candidate,
+        observation: candidate,
         jobKey: LISTENER_JOB,
         sequence: params.sequence,
         deliveryIds: deliveryIds.slice(0, expectedEventCount),
       }),
   });
-  return {deliveryIds, runDetail};
+  return {deliveryIds, observation};
 }
 
 export async function sendBatchPairAndAwaitMaterialization(params: {
@@ -296,7 +308,7 @@ export async function sendBatchPairAndAwaitMaterialization(params: {
   label: string;
   sequence: number;
   timeoutMs: number;
-}): Promise<{deliveryIds: string[]; runDetail: Awaited<ReturnType<typeof waitForRunTerminal>>}> {
+}): Promise<{deliveryIds: string[]; observation: WorkflowRunObservation}> {
   return await sendBatchAndAwaitMaterialization({...params, eventCount: 2});
 }
 

--- a/e2e/suites/flow/workflows/src/polling.test.ts
+++ b/e2e/suites/flow/workflows/src/polling.test.ts
@@ -1,0 +1,90 @@
+import {waitForRunObservationMatching} from './polling.js';
+
+const runId = '33333333-3333-4333-8333-333333333333';
+const timestamp = '2026-07-04T10:00:00.000Z';
+
+function response(body: unknown, init: ResponseInit = {}): Response {
+  return Response.json(body, init);
+}
+
+function head() {
+  return {
+    current_attempt: 1,
+    latest_attempt: 1,
+    current_status: 'succeeded',
+    updated_at: timestamp,
+  };
+}
+
+function overview() {
+  return {
+    run: {
+      id: runId,
+      project_id: '11111111-1111-4111-8111-111111111111',
+      definition_id: '22222222-2222-4222-8222-222222222222',
+      number: 1,
+      name: 'Build',
+      workflow_name: 'Build',
+      origin: 'synced',
+      dev_source: null,
+      trigger_provider: 'manual',
+      trigger_source: 'manual',
+      trigger_event: 'manual',
+      trigger_reference: null,
+      created_at: timestamp,
+    },
+    attempt: {
+      id: '44444444-4444-4444-8444-444444444444',
+      workflow_run_id: runId,
+      attempt: 1,
+      status: 'succeeded',
+      created_at: timestamp,
+      started_at: timestamp,
+      finished_at: timestamp,
+      rerun_mode: null,
+    },
+    has_started_job_execution: true,
+    jobs: {kind: 'complete', total: 0, items: []},
+  };
+}
+
+describe('waitForRunObservationMatching', () => {
+  test('retries a run that is not visible yet', async () => {
+    let calls = 0;
+    const result = await waitForRunObservationMatching({
+      fetch: (input) => {
+        calls += 1;
+        if (calls === 1) return response({code: 'not-found'}, {status: 404});
+        const url = new URL(input);
+        return url.pathname.endsWith('/head') ? response(head()) : response(overview());
+      },
+      runId,
+      timeoutMs: 1_000,
+      description: 'workflow observation',
+      matches: (observation) => ({
+        matched: observation.status === 'succeeded',
+        diagnostic: `status=${observation.status}`,
+      }),
+      token: 'user-token',
+    });
+
+    expect(result.status).toBe('succeeded');
+    expect(calls).toBe(3);
+  });
+
+  test('rethrows non-transient API failures', async () => {
+    const result = waitForRunObservationMatching({
+      fetch: () => response({code: 'server-error'}, {status: 500}),
+      runId,
+      timeoutMs: 1_000,
+      description: 'workflow observation',
+      matches: () => ({matched: false, diagnostic: 'not matched'}),
+      token: 'user-token',
+    });
+
+    await expect(result).rejects.toMatchObject({
+      name: 'E2eApiError',
+      status: 500,
+    });
+  });
+});

--- a/e2e/suites/flow/workflows/src/polling.ts
+++ b/e2e/suites/flow/workflows/src/polling.ts
@@ -1,10 +1,12 @@
 import {setTimeout as delay} from 'node:timers/promises';
 import type {DefinitionListResponseDto} from '@shipfox/api-definitions-dto';
-import type {
-  WorkflowRunDetailResponseDto,
-  WorkflowRunListResponseDto,
-} from '@shipfox/api-workflows-dto';
+import type {WorkflowRunListResponseDto} from '@shipfox/api-workflows-dto';
 import {type ApiFetch, createApiClient} from '@shipfox/e2e-core';
+import {
+  observeRun,
+  type WorkflowRunObservation,
+  type WorkflowRunObservationSelection,
+} from '@shipfox/e2e-observe-workflows';
 
 export interface PollingOptions {
   fetch?: ApiFetch | undefined;
@@ -63,28 +65,33 @@ export async function waitForNoWorkflowRuns(
   return lastResponse ?? {runs: [], next_cursor: null, filtered_total_count: null};
 }
 
-export async function waitForRunDetailMatching(params: {
+export async function waitForRunObservationMatching(params: {
+  apiUrl?: string | undefined;
+  fetch?: ApiFetch | undefined;
   token: string;
   runId: string;
   signal?: AbortSignal | undefined;
   timeoutMs: number;
   description: string;
-  matches: (runDetail: WorkflowRunDetailResponseDto) => {matched: boolean; diagnostic: string};
-}): Promise<WorkflowRunDetailResponseDto> {
-  const client = createApiClient({token: params.token});
+  selection?: WorkflowRunObservationSelection | undefined;
+  matches: (observation: WorkflowRunObservation) => {matched: boolean; diagnostic: string};
+}): Promise<WorkflowRunObservation> {
   const deadline = Date.now() + params.timeoutMs;
-  let lastResponse: WorkflowRunDetailResponseDto | null = null;
-  let lastDiagnostic = 'no workflow run detail response observed';
+  let lastDiagnostic = 'no bounded workflow observation observed';
 
   while (Date.now() <= deadline) {
     params.signal?.throwIfAborted();
-    lastResponse = await client.requestJson<WorkflowRunDetailResponseDto>(
-      'get',
-      `/workflows/runs/${encodeURIComponent(params.runId)}`,
-      {signal: params.signal},
-    );
-    const result = params.matches(lastResponse);
-    if (result.matched) return lastResponse;
+    const observation = await observeRun({
+      apiUrl: params.apiUrl,
+      fetch: params.fetch,
+      runId: params.runId,
+      selection: params.selection,
+      signal: params.signal,
+      timeoutMs: Math.max(1, deadline - Date.now()),
+      token: params.token,
+    });
+    const result = params.matches(observation);
+    if (result.matched) return observation;
     lastDiagnostic = result.diagnostic;
     await delay(250, undefined, {signal: params.signal});
   }

--- a/e2e/suites/flow/workflows/src/polling.ts
+++ b/e2e/suites/flow/workflows/src/polling.ts
@@ -1,7 +1,7 @@
 import {setTimeout as delay} from 'node:timers/promises';
 import type {DefinitionListResponseDto} from '@shipfox/api-definitions-dto';
 import type {WorkflowRunListResponseDto} from '@shipfox/api-workflows-dto';
-import {type ApiFetch, createApiClient} from '@shipfox/e2e-core';
+import {type ApiFetch, createApiClient, E2eApiError} from '@shipfox/e2e-core';
 import {
   observeRun,
   type WorkflowRunObservation,
@@ -9,6 +9,50 @@ import {
 } from '@shipfox/e2e-observe-workflows';
 
 const OBSERVATION_ATTEMPT_TIMEOUT_MS = 500;
+const NO_OBSERVATION_DIAGNOSTIC = 'no bounded workflow observation observed';
+
+function isRetryableObservationError(error: unknown): boolean {
+  if (error instanceof E2eApiError) return error.status === 404;
+  if (!(error instanceof Error)) return false;
+  return error.message.startsWith('Timed out while reading ');
+}
+
+type ObservationMatchOptions = {
+  apiUrl?: string | undefined;
+  fetch?: ApiFetch | undefined;
+  token: string;
+  runId: string;
+  signal?: AbortSignal | undefined;
+  selection?: WorkflowRunObservationSelection | undefined;
+  matches: (observation: WorkflowRunObservation) => {matched: boolean; diagnostic: string};
+};
+
+type ObservationMatchAttempt =
+  | {kind: 'matched'; observation: WorkflowRunObservation}
+  | {kind: 'unmatched'; diagnostic: string}
+  | {kind: 'retry'; diagnostic: string};
+
+async function observeForMatch(params: ObservationMatchOptions): Promise<ObservationMatchAttempt> {
+  try {
+    const observation = await observeRun({
+      apiUrl: params.apiUrl,
+      fetch: params.fetch,
+      runId: params.runId,
+      selection: params.selection,
+      signal: params.signal,
+      timeoutMs: OBSERVATION_ATTEMPT_TIMEOUT_MS,
+      token: params.token,
+    });
+    const result = params.matches(observation);
+    return result.matched
+      ? {kind: 'matched', observation}
+      : {kind: 'unmatched', diagnostic: result.diagnostic};
+  } catch (error) {
+    params.signal?.throwIfAborted();
+    if (!isRetryableObservationError(error)) throw error;
+    return {kind: 'retry', diagnostic: error instanceof Error ? error.message : String(error)};
+  }
+}
 
 export interface PollingOptions {
   fetch?: ApiFetch | undefined;
@@ -67,40 +111,22 @@ export async function waitForNoWorkflowRuns(
   return lastResponse ?? {runs: [], next_cursor: null, filtered_total_count: null};
 }
 
-export async function waitForRunObservationMatching(params: {
-  apiUrl?: string | undefined;
-  fetch?: ApiFetch | undefined;
-  token: string;
-  runId: string;
-  signal?: AbortSignal | undefined;
-  timeoutMs: number;
-  description: string;
-  selection?: WorkflowRunObservationSelection | undefined;
-  matches: (observation: WorkflowRunObservation) => {matched: boolean; diagnostic: string};
-}): Promise<WorkflowRunObservation> {
+export async function waitForRunObservationMatching(
+  params: ObservationMatchOptions & {
+    timeoutMs: number;
+    description: string;
+  },
+): Promise<WorkflowRunObservation> {
   const deadline = Date.now() + params.timeoutMs;
-  let lastDiagnostic = 'no bounded workflow observation observed';
+  let lastDiagnostic = NO_OBSERVATION_DIAGNOSTIC;
 
   while (Date.now() <= deadline) {
     params.signal?.throwIfAborted();
-    try {
-      const observation = await observeRun({
-        apiUrl: params.apiUrl,
-        fetch: params.fetch,
-        runId: params.runId,
-        selection: params.selection,
-        signal: params.signal,
-        timeoutMs: OBSERVATION_ATTEMPT_TIMEOUT_MS,
-        token: params.token,
-      });
-      const result = params.matches(observation);
-      if (result.matched) return observation;
-      lastDiagnostic = result.diagnostic;
-    } catch (error) {
-      params.signal?.throwIfAborted();
-      if (lastDiagnostic === 'no bounded workflow observation observed') {
-        lastDiagnostic = error instanceof Error ? error.message : String(error);
-      }
+    const attempt = await observeForMatch(params);
+    if (attempt.kind === 'matched') return attempt.observation;
+    if (attempt.kind === 'unmatched') lastDiagnostic = attempt.diagnostic;
+    if (attempt.kind === 'retry' && lastDiagnostic === NO_OBSERVATION_DIAGNOSTIC) {
+      lastDiagnostic = attempt.diagnostic;
     }
     if (Date.now() > deadline) break;
     await delay(250, undefined, {signal: params.signal});

--- a/e2e/suites/flow/workflows/src/polling.ts
+++ b/e2e/suites/flow/workflows/src/polling.ts
@@ -8,6 +8,8 @@ import {
   type WorkflowRunObservationSelection,
 } from '@shipfox/e2e-observe-workflows';
 
+const OBSERVATION_ATTEMPT_TIMEOUT_MS = 500;
+
 export interface PollingOptions {
   fetch?: ApiFetch | undefined;
   projectId: string;
@@ -81,18 +83,26 @@ export async function waitForRunObservationMatching(params: {
 
   while (Date.now() <= deadline) {
     params.signal?.throwIfAborted();
-    const observation = await observeRun({
-      apiUrl: params.apiUrl,
-      fetch: params.fetch,
-      runId: params.runId,
-      selection: params.selection,
-      signal: params.signal,
-      timeoutMs: Math.max(1, deadline - Date.now()),
-      token: params.token,
-    });
-    const result = params.matches(observation);
-    if (result.matched) return observation;
-    lastDiagnostic = result.diagnostic;
+    try {
+      const observation = await observeRun({
+        apiUrl: params.apiUrl,
+        fetch: params.fetch,
+        runId: params.runId,
+        selection: params.selection,
+        signal: params.signal,
+        timeoutMs: OBSERVATION_ATTEMPT_TIMEOUT_MS,
+        token: params.token,
+      });
+      const result = params.matches(observation);
+      if (result.matched) return observation;
+      lastDiagnostic = result.diagnostic;
+    } catch (error) {
+      params.signal?.throwIfAborted();
+      if (lastDiagnostic === 'no bounded workflow observation observed') {
+        lastDiagnostic = error instanceof Error ? error.message : String(error);
+      }
+    }
+    if (Date.now() > deadline) break;
     await delay(250, undefined, {signal: params.signal});
   }
 

--- a/e2e/suites/flow/workflows/src/run-scenario.ts
+++ b/e2e/suites/flow/workflows/src/run-scenario.ts
@@ -4,6 +4,7 @@ import {type CreatedIssue, listIssueComments} from '@shipfox/e2e-driver-gitea';
 import {readFakeOpenAiModelProviderState} from '@shipfox/e2e-driver-model-provider';
 import {type LocalRunnerHandle, stopLocalRunner} from '@shipfox/e2e-driver-runner-process';
 import {fetchStepLogs} from '@shipfox/e2e-observe-logs';
+import type {WorkflowRunObservationSelection} from '@shipfox/e2e-observe-workflows';
 import {createSecret, createVariable} from '@shipfox/e2e-setup-secrets';
 import type {Attachment} from './attachments.js';
 import {
@@ -48,7 +49,23 @@ export interface RunScenarioParams {
   attach: (attachment: Attachment) => Promise<void>;
 }
 
-type RunDetail = Awaited<ReturnType<typeof waitForRunTerminalOrFailedRunner>>;
+type RunObservation = Awaited<ReturnType<typeof waitForRunTerminalOrFailedRunner>>;
+
+function observationSelection(
+  expectation: Extract<Scenario, {kind: 'expect'}>['expectation'],
+): WorkflowRunObservationSelection {
+  return {
+    jobs: Object.entries(expectation.jobs ?? {}).map(([jobKey, jobExpectation]) => ({
+      jobKey,
+      ...(jobExpectation.steps === undefined
+        ? {}
+        : {
+            includeDefaultExecution: true,
+            stepKeys: Object.keys(jobExpectation.steps),
+          }),
+    })),
+  };
+}
 
 async function evaluateScenarioResult(params: {
   expectation: Extract<Scenario, {kind: 'expect'}>['expectation'];
@@ -157,7 +174,7 @@ async function attachScenarioMismatches(params: {
   fetchedLogs: Attachment[];
   logRequirements: StepLogRequirement[];
   mismatches: Mismatch[];
-  runDetail: RunDetail;
+  observation: RunObservation;
   runnerLogFile: string | undefined;
   scenario: Extract<Scenario, {kind: 'expect'}>;
   suite: SuiteContext;
@@ -165,9 +182,9 @@ async function attachScenarioMismatches(params: {
   webhookDiagnostics: WebhookDiagnosticsRequest | undefined;
 }): Promise<void> {
   await params.attach({
-    name: 'run-detail.json',
+    name: 'workflow-observation.json',
     contentType: 'application/json',
-    body: JSON.stringify(params.runDetail, null, 2),
+    body: JSON.stringify(params.observation, null, 2),
   });
   await params.attach({
     name: 'mismatches.json',
@@ -192,7 +209,7 @@ async function attachScenarioMismatches(params: {
   const fetchedLogKeys = new Set(
     params.logRequirements.map((requirement) => `${requirement.stepId}:${requirement.attempt}`),
   );
-  for (const request of collectStepLogAttachmentRequests(params.runDetail)) {
+  for (const request of collectStepLogAttachmentRequests(params.observation)) {
     const key = `${request.stepId}:${request.attempt}`;
     if (fetchedLogKeys.has(key)) continue;
     await params.attach(await fetchLogAttachment(request, params.token));
@@ -408,8 +425,8 @@ async function triggerScenario(params: {
 /**
  * Drives one declarative scenario end to end: fresh repo and project, seed commit,
  * definition-resolved poll, trigger, terminal-run poll, then expect.yaml evaluation.
- * Returns every mismatch (empty means the scenario matched) and attaches the run
- * detail, the diff, and fetched logs when it did not.
+ * Returns every mismatch (empty means the scenario matched) and attaches the bounded
+ * observation, the diff, and fetched logs when it did not.
  */
 export async function runScenario(params: RunScenarioParams): Promise<Mismatch[]> {
   const {scenario, suite} = params;
@@ -479,14 +496,15 @@ export async function runScenario(params: RunScenarioParams): Promise<Mismatch[]
     });
     webhookDiagnostics = triggered.webhookDiagnostics;
 
-    const runDetail = await waitForRunTerminalOrFailedRunner({
+    const observation = await waitForRunTerminalOrFailedRunner({
       runId: triggered.runId,
       token,
       timeoutMs: scenario.expectation.timeout_seconds * 1000,
       runner,
+      selection: observationSelection(scenario.expectation),
     });
 
-    const {mismatches, logRequirements} = evaluateExpectations(runDetail, scenario.expectation);
+    const {mismatches, logRequirements} = evaluateExpectations(observation, scenario.expectation);
     const giteaMismatches = await evaluateGiteaScenario({
       expectation: scenario.expectation.gitea,
       issue: giteaIssue,
@@ -508,7 +526,7 @@ export async function runScenario(params: RunScenarioParams): Promise<Mismatch[]
         fetchedLogs,
         logRequirements,
         mismatches: allMismatches,
-        runDetail,
+        observation,
         runnerLogFile,
         scenario,
         suite,

--- a/e2e/suites/flow/workflows/src/run-scenario.ts
+++ b/e2e/suites/flow/workflows/src/run-scenario.ts
@@ -61,6 +61,8 @@ function observationSelection(
         ? {}
         : {
             includeDefaultExecution: true,
+            executionSequences: 'all',
+            stepAttempts: 'all',
             stepKeys: Object.keys(jobExpectation.steps),
           }),
     })),

--- a/e2e/suites/flow/workflows/src/runner.ts
+++ b/e2e/suites/flow/workflows/src/runner.ts
@@ -8,7 +8,10 @@ import {
   startLocalRunner,
   waitForLocalRunnerExit,
 } from '@shipfox/e2e-driver-runner-process';
-import {waitForRunTerminal} from '@shipfox/e2e-observe-workflows';
+import {
+  type WorkflowRunObservationSelection,
+  waitForRunTerminal,
+} from '@shipfox/e2e-observe-workflows';
 import {suiteRunDir} from './suite-context.js';
 
 function isFailedRunnerExit(exit: LocalRunnerExit): boolean {
@@ -58,11 +61,13 @@ export async function waitForRunTerminalOrFailedRunner(params: {
   token: string;
   timeoutMs: number;
   runner: LocalRunnerHandle;
+  selection?: WorkflowRunObservationSelection | undefined;
 }): ReturnType<typeof waitForRunTerminal> {
   const runTerminal = waitForRunTerminal({
     runId: params.runId,
     token: params.token,
     timeoutMs: params.timeoutMs,
+    selection: params.selection,
   });
   const runnerExit = waitForLocalRunnerExit(params.runner);
 

--- a/e2e/suites/flow/workflows/src/slack-agent-tools.ts
+++ b/e2e/suites/flow/workflows/src/slack-agent-tools.ts
@@ -64,6 +64,9 @@ export async function runSlackToolsWorkflow(params: {
       token,
       timeoutMs: TERMINAL_TIMEOUT_MS,
       runner: localRunner.runner,
+      selection: {
+        jobs: [{jobKey: 'tools', includeDefaultExecution: true, stepKeys: ['slack']}],
+      },
     });
     if (terminal.status !== 'succeeded') {
       for (const request of collectStepLogAttachmentRequests(terminal)) {

--- a/e2e/suites/flow/workflows/tests/claude-agent.e2e.ts
+++ b/e2e/suites/flow/workflows/tests/claude-agent.e2e.ts
@@ -2,6 +2,7 @@ import {createApiClient} from '@shipfox/e2e-core';
 import {message, startFakeOpenAiModelProvider, toolCall} from '@shipfox/e2e-driver-model-provider';
 import {stopLocalRunner} from '@shipfox/e2e-driver-runner-process';
 import {fetchStepLogs} from '@shipfox/e2e-observe-logs';
+import type {WorkflowRunObservationSelection} from '@shipfox/e2e-observe-workflows';
 import {createAnthropicFakeModelProviderConfig} from '@shipfox/e2e-setup-agent';
 import {attachLocalRunnerLog} from '#attachments.js';
 import {logText} from '#expect.js';
@@ -134,9 +135,12 @@ test('runs Claude set_output through downstream interpolation', async ({suite}, 
         },
         {path: 'CLAUDE.md', content: 'repository-instruction-marker'},
       ],
+      selection: {
+        jobs: [{jobKey: 'fix', includeDefaultExecution: true, stepKeys: ['produce', 'consume']}],
+      },
     });
     const fixJob = terminal.jobs.find((job) => job.key === 'fix');
-    const steps = fixJob?.job_executions.flatMap((execution) => execution.steps) ?? [];
+    const steps = fixJob?.executions.flatMap((execution) => execution.steps) ?? [];
     const produceStep = steps.find((step) => step.key === 'produce');
     const consumeStep = steps.find((step) => step.key === 'consume');
     const executionSucceeded =
@@ -146,7 +150,7 @@ test('runs Claude set_output through downstream interpolation', async ({suite}, 
       consumeStep?.status === 'succeeded';
 
     if (!executionSucceeded) {
-      await testInfo.attach('run-detail.json', {
+      await testInfo.attach('workflow-observation.json', {
         body: JSON.stringify(terminal, null, 2),
         contentType: 'application/json',
       });
@@ -157,7 +161,8 @@ test('runs Claude set_output through downstream interpolation', async ({suite}, 
     expect(produceStep?.status).toBe('succeeded');
     expect(consumeStep?.status).toBe('succeeded');
 
-    if (consumeStep === undefined) throw new Error('consume step missing from run detail');
+    if (consumeStep === undefined)
+      throw new Error('consume step missing from workflow observation');
     const logs = await fetchStepLogs({
       stepId: consumeStep.id,
       attempt: consumeStep.current_attempt,
@@ -184,6 +189,7 @@ async function runClaudeWorkflow(params: {
   workflowYaml: string;
   runnerEnv: Record<string, string>;
   extraFiles?: Array<{path: string; content: string}>;
+  selection?: WorkflowRunObservationSelection | undefined;
 }) {
   const token = params.suite.sessionToken;
   const client = createApiClient({token});
@@ -224,6 +230,7 @@ async function runClaudeWorkflow(params: {
       token,
       timeoutMs: TERMINAL_TIMEOUT_MS,
       runner: localRunner.runner,
+      selection: params.selection,
     });
   } finally {
     await attachLocalRunnerLog(

--- a/e2e/suites/flow/workflows/tests/filter-scenarios.e2e.ts
+++ b/e2e/suites/flow/workflows/tests/filter-scenarios.e2e.ts
@@ -496,7 +496,7 @@ test.describe('filter scenarios', () => {
 
       expect(
         listenerDeliveryObserved({
-          observation: matchingFire.observation,
+          observation: terminal,
           jobKey: LISTENER_JOB,
           deliveryId: matchingFire.deliveryId,
         }).matched,

--- a/e2e/suites/flow/workflows/tests/filter-scenarios.e2e.ts
+++ b/e2e/suites/flow/workflows/tests/filter-scenarios.e2e.ts
@@ -4,7 +4,6 @@ import type {
   TriggerEventListResponseDto,
   TriggerEventOutcomeDto,
 } from '@shipfox/api-triggers-dto';
-import type {WorkflowRunDetailResponseDto} from '@shipfox/api-workflows-dto';
 import {createApiClient, pollUntil} from '@shipfox/e2e-core';
 import {
   type CommitFile,
@@ -13,7 +12,12 @@ import {
   createRepo,
 } from '@shipfox/e2e-driver-gitea';
 import {type LocalRunnerHandle, stopLocalRunner} from '@shipfox/e2e-driver-runner-process';
-import {waitForRunByCommit} from '@shipfox/e2e-observe-workflows';
+import {
+  observeRun,
+  type WorkflowRunObservation,
+  type WorkflowRunObservationSelection,
+  waitForRunByCommit,
+} from '@shipfox/e2e-observe-workflows';
 import {attachLocalRunnerLog} from '#attachments.js';
 import {
   findListenerJob,
@@ -31,7 +35,7 @@ import {
   setupListenerCase,
   stopRunner,
 } from '#listener-jobs.js';
-import {waitForRunDetailMatching} from '#polling.js';
+import {waitForRunObservationMatching} from '#polling.js';
 import {startSuiteLocalRunner, waitForRunTerminalOrFailedRunner} from '#runner.js';
 import type {SuiteContext} from '#suite-context.js';
 import {postWebhookDelivery} from '#webhook.js';
@@ -188,28 +192,30 @@ async function assertNoRunsForProject(params: {
 async function assertListenerRemains(params: {
   token: string;
   runId: string;
+  jobKey: string;
   timeoutMs: number;
   description: string;
-  matches: (runDetail: WorkflowRunDetailResponseDto) => {matched: boolean; diagnostic: string};
-}): Promise<WorkflowRunDetailResponseDto> {
-  const client = createApiClient({token: params.token});
+  selection?: WorkflowRunObservationSelection | undefined;
+  matches: (observation: WorkflowRunObservation) => {matched: boolean; diagnostic: string};
+}): Promise<WorkflowRunObservation> {
   const deadline = Date.now() + params.timeoutMs;
-  let lastResponse: WorkflowRunDetailResponseDto | undefined;
+  let lastObservation: WorkflowRunObservation | undefined;
 
   while (Date.now() <= deadline) {
-    lastResponse = await client.requestJson<WorkflowRunDetailResponseDto>(
-      'get',
-      `/workflows/runs/${encodeURIComponent(params.runId)}`,
-    );
-    const result = params.matches(lastResponse);
+    lastObservation = await observeRun({
+      runId: params.runId,
+      selection: params.selection ?? {jobs: [{jobKey: params.jobKey}]},
+      token: params.token,
+    });
+    const result = params.matches(lastObservation);
     if (!result.matched) {
       throw new Error(`${params.description} changed unexpectedly: ${result.diagnostic}`);
     }
     await delay(250);
   }
 
-  if (!lastResponse) throw new Error(`${params.description} was not observed`);
-  return lastResponse;
+  if (!lastObservation) throw new Error(`${params.description} was not observed`);
+  return lastObservation;
 }
 
 async function pushCommit(params: {
@@ -348,14 +354,15 @@ test.describe('filter scenarios', () => {
       });
       runId = await fireManualRun(testCase);
 
-      await waitForRunDetailMatching({
+      await waitForRunObservationMatching({
         token: testCase.token,
         runId,
         timeoutMs: 90_000,
         description: 'listener filter job to start listening',
-        matches: (runDetail) =>
+        selection: {jobs: [{jobKey: LISTENER_JOB}]},
+        matches: (observation) =>
           listenerStatusMatches({
-            runDetail,
+            observation,
             jobKey: LISTENER_JOB,
             listenerStatus: 'listening',
           }),
@@ -386,11 +393,12 @@ test.describe('filter scenarios', () => {
       await assertListenerRemains({
         token: testCase.token,
         runId,
+        jobKey: LISTENER_JOB,
         timeoutMs: LISTENER_NEGATIVE_ASSERTION_MS,
         description: 'listener execution count after nonmatching on filter',
-        matches: (runDetail) =>
+        matches: (observation) =>
           listenerExecutionCountMatches({
-            runDetail,
+            observation,
             jobKey: LISTENER_JOB,
             count: 0,
           }),
@@ -439,11 +447,12 @@ test.describe('filter scenarios', () => {
       await assertListenerRemains({
         token: testCase.token,
         runId,
+        jobKey: LISTENER_JOB,
         timeoutMs: LISTENER_NEGATIVE_ASSERTION_MS,
         description: 'listener status after nonmatching until filter',
-        matches: (runDetail) =>
+        matches: (observation) =>
           listenerStatusMatches({
-            runDetail,
+            observation,
             jobKey: LISTENER_JOB,
             listenerStatus: 'listening',
           }),
@@ -465,7 +474,7 @@ test.describe('filter scenarios', () => {
           },
         },
       });
-      const resolved = await waitForListenerResolution({
+      await waitForListenerResolution({
         token: testCase.token,
         runId,
         jobKey: LISTENER_JOB,
@@ -479,23 +488,23 @@ test.describe('filter scenarios', () => {
         token: testCase.token,
         timeoutMs: 180_000,
         runner: testCase.runner,
+        selection: {
+          jobs: [{jobKey: LISTENER_JOB, executionSequences: 'all', includeContext: true}],
+        },
       });
       const listen = findListenerJob(terminal, LISTENER_JOB);
 
       expect(
         listenerDeliveryObserved({
-          runDetail: resolved,
+          observation: matchingFire.observation,
           jobKey: LISTENER_JOB,
           deliveryId: matchingFire.deliveryId,
         }).matched,
       ).toBe(true);
       expect(terminal.status).toBe('succeeded');
       expect(listen?.listener_status).toBe('resolved');
-      expect(listen?.resolution_reason).toBe('until');
-      expect(listen?.job_executions).toHaveLength(1);
-      expect(listen?.job_executions[0]?.trigger_events[0]?.delivery_id).toBe(
-        matchingFire.deliveryId,
-      );
+      expect(listen?.executions).toHaveLength(1);
+      expect(listen?.executions[0]?.trigger_events[0]?.delivery_id).toBe(matchingFire.deliveryId);
     } catch (error) {
       await cleanupListenerCase(testCase, runId);
       throw error;

--- a/e2e/suites/flow/workflows/tests/github-agent-tools.e2e.ts
+++ b/e2e/suites/flow/workflows/tests/github-agent-tools.e2e.ts
@@ -3,6 +3,7 @@ import type {ProjectResponseDto} from '@shipfox/api-projects-dto';
 import {createApiClient} from '@shipfox/e2e-core';
 import {message, startFakeOpenAiModelProvider, toolCall} from '@shipfox/e2e-driver-model-provider';
 import {stopLocalRunner} from '@shipfox/e2e-driver-runner-process';
+import type {WorkflowRunObservationSelection} from '@shipfox/e2e-observe-workflows';
 import {createAnthropicFakeModelProviderConfig} from '@shipfox/e2e-setup-agent';
 import {createGithubConnection} from '@shipfox/e2e-setup-integrations';
 import {createProject as createE2eProject} from '@shipfox/e2e-setup-projects';
@@ -416,6 +417,15 @@ test('mints a GitHub checkout token for a selected project repository by ID', as
       scenario: 'github-checkout-selected-id',
       workflowYaml: checkoutWorkflow({}),
       project: fixture.project,
+      selection: {
+        jobs: [
+          {
+            jobKey: 'checkout',
+            includeDefaultExecution: true,
+            stepKeys: ['fail-after-checkout'],
+          },
+        ],
+      },
     });
 
     expect(result.terminal.status).toBe('failed');
@@ -453,6 +463,15 @@ test('denies a selected GitHub checkout target outside Shipfox projects', async 
         connection: fixture.connection.slug,
         repository: GITHUB_OUTSIDE_REPOSITORY_NAME,
       }),
+      selection: {
+        jobs: [
+          {
+            jobKey: 'checkout',
+            includeDefaultExecution: true,
+            stepKeys: ['repository'],
+          },
+        ],
+      },
     });
 
     expect(result.terminal.status).toBe('failed');
@@ -481,6 +500,15 @@ test('mints a GitHub checkout token for an all-mode repository name', async ({su
         connection: fixture.connection.slug,
         repository: GITHUB_OUTSIDE_REPOSITORY_NAME,
       }),
+      selection: {
+        jobs: [
+          {
+            jobKey: 'checkout',
+            includeDefaultExecution: true,
+            stepKeys: ['repository'],
+          },
+        ],
+      },
     });
 
     expect(result.terminal.status).toBe('failed');
@@ -575,6 +603,7 @@ async function runGithubWorkflow(params: {
   workflowYaml: string;
   project?: ProjectResponseDto | undefined;
   replacements?: Record<string, string> | undefined;
+  selection?: WorkflowRunObservationSelection | undefined;
 }): Promise<{
   terminal: Awaited<ReturnType<typeof waitForRunTerminalOrFailedRunner>>;
   failureLogs: string;
@@ -629,6 +658,9 @@ async function runGithubWorkflow(params: {
       token,
       timeoutMs: TERMINAL_TIMEOUT_MS,
       runner: localRunner.runner,
+      selection: params.selection ?? {
+        jobs: [{jobKey: 'tools', includeDefaultExecution: true, stepKeys: ['github']}],
+      },
     });
 
     if (terminal.status !== 'succeeded') {
@@ -801,6 +833,9 @@ async function runGithubToolsWorkflow(params: {
       token,
       timeoutMs: TERMINAL_TIMEOUT_MS,
       runner: localRunner.runner,
+      selection: {
+        jobs: [{jobKey: 'tools', includeDefaultExecution: true, stepKeys: ['github']}],
+      },
     });
     if (terminal.status !== 'succeeded') {
       for (const request of collectStepLogAttachmentRequests(terminal)) {

--- a/e2e/suites/flow/workflows/tests/listener-jobs.e2e.ts
+++ b/e2e/suites/flow/workflows/tests/listener-jobs.e2e.ts
@@ -36,17 +36,28 @@ async function assertUntilResolution(params: {
     token: params.testCase.token,
     timeoutMs: 180_000,
     runner: params.testCase.runner,
+    selection: {
+      jobs: [
+        {
+          jobKey: LISTENER_JOB,
+          executionSequences: 'all',
+          includeContext: true,
+          stepKeys: ['show_event'],
+        },
+        {jobKey: 'deploy', includeDefaultExecution: true, stepKeys: ['after-listener']},
+      ],
+    },
   });
 
   const listen = terminal.jobs.find((job) => job.key === LISTENER_JOB);
   const deploy = terminal.jobs.find((job) => job.key === 'deploy');
   const firstExecution = findListenerExecutionByDeliveryIds({
-    runDetail: terminal,
+    observation: terminal,
     jobKey: LISTENER_JOB,
     deliveryIds: params.firstFire.deliveryIds,
   })?.execution;
   const secondExecution = findListenerExecutionByDeliveryIds({
-    runDetail: terminal,
+    observation: terminal,
     jobKey: LISTENER_JOB,
     deliveryIds: params.secondFire.deliveryIds,
   })?.execution;
@@ -59,35 +70,32 @@ async function assertUntilResolution(params: {
     throw new Error('Expected listener executions to include trigger deliveries');
   }
   const firstLogs = await stepLogText({
-    runDetail: terminal,
+    observation: terminal,
     token: params.testCase.token,
     jobKey: LISTENER_JOB,
     sequence: firstExecution.sequence,
     stepKey: 'show_event',
   });
   const secondLogs = await stepLogText({
-    runDetail: terminal,
+    observation: terminal,
     token: params.testCase.token,
     jobKey: LISTENER_JOB,
     sequence: secondExecution.sequence,
     stepKey: 'show_event',
   });
-  const deployExecution = deploy?.job_executions.at(-1);
+  const deployExecution = deploy?.executions.at(-1);
   if (!deployExecution) throw new Error('Expected deploy execution');
   const deployLogs = await stepLogText({
-    runDetail: terminal,
+    observation: terminal,
     token: params.testCase.token,
     jobKey: 'deploy',
     sequence: deployExecution.sequence,
     stepKey: 'after-listener',
   });
 
-  expect(params.resolved.jobs.find((job) => job.key === LISTENER_JOB)?.resolution_reason).toBe(
-    'until',
-  );
   expect(terminal.status).toBe('succeeded');
   expect(listen?.listener_status).toBe('resolved');
-  expect(listen?.job_executions.length).toBeGreaterThanOrEqual(2);
+  expect(listen?.execution_count).toBeGreaterThanOrEqual(2);
   expect(firstExecution.sequence).not.toBe(secondExecution.sequence);
   expect(deploy?.status).toBe('succeeded');
   expect(params.firstFire.deliveryIds).toContain(firstDeliveryId);
@@ -181,7 +189,7 @@ test.describe('listener jobs', () => {
 
       const first = await sendFire(testCase, runId, 'fire-one', 'first');
       const second = await sendFire(testCase, runId, 'fire-two', 'second');
-      const resolved = await waitForListenerResolution({
+      await waitForListenerResolution({
         token: testCase.token,
         runId,
         jobKey: LISTENER_JOB,
@@ -194,16 +202,17 @@ test.describe('listener jobs', () => {
         token: testCase.token,
         timeoutMs: 180_000,
         runner: testCase.runner,
+        selection: {
+          jobs: [{jobKey: LISTENER_JOB, executionSequences: 'all', includeContext: true}],
+        },
       });
 
       const listen = terminal.jobs.find((job) => job.key === LISTENER_JOB);
       expect(terminal.status).toBe('succeeded');
-      expect(resolved.jobs.find((job) => job.key === LISTENER_JOB)?.resolution_reason).toBe(
-        'max_executions',
-      );
-      expect(listen?.job_executions.map((execution) => execution.sequence)).toEqual([1, 2]);
-      const firstExecutionDeliveryId = listen?.job_executions[0]?.trigger_events[0]?.delivery_id;
-      const secondExecutionDeliveryId = listen?.job_executions[1]?.trigger_events[0]?.delivery_id;
+      expect(listen?.listener_status).toBe('resolved');
+      expect(listen?.executions.map((execution) => execution.sequence)).toEqual([1, 2]);
+      const firstExecutionDeliveryId = listen?.executions[0]?.trigger_events[0]?.delivery_id;
+      const secondExecutionDeliveryId = listen?.executions[1]?.trigger_events[0]?.delivery_id;
       expect(firstExecutionDeliveryId).toBeDefined();
       expect(secondExecutionDeliveryId).toBeDefined();
       expect(first.deliveryIds).toContain(firstExecutionDeliveryId);
@@ -252,20 +261,30 @@ test.describe('listener jobs', () => {
         token: testCase.token,
         timeoutMs: LISTENER_RUN_TERMINAL_TIMEOUT_MS,
         runner: testCase.runner,
+        selection: {
+          jobs: [
+            {
+              jobKey: LISTENER_JOB,
+              executionSequences: [1],
+              includeContext: true,
+              stepKeys: ['show-batch'],
+            },
+          ],
+        },
       });
 
       const listen = terminal.jobs.find((job) => job.key === LISTENER_JOB);
       const logs = await stepLogText({
-        runDetail: terminal,
+        observation: terminal,
         token: testCase.token,
         jobKey: LISTENER_JOB,
         sequence: 1,
         stepKey: 'show-batch',
       });
       expect(terminal.status).toBe('succeeded');
-      expect(listen?.resolution_reason).toBe('until');
-      expect(listen?.job_executions).toHaveLength(1);
-      expect(listen?.job_executions[0]?.trigger_events.map((event) => event.delivery_id)).toEqual(
+      expect(listen?.listener_status).toBe('resolved');
+      expect(listen?.executions).toHaveLength(1);
+      expect(listen?.executions[0]?.trigger_events.map((event) => event.delivery_id)).toEqual(
         batch.deliveryIds,
       );
       expect(logs).toContain(`batch_first=${batch.deliveryIds[0]}`);
@@ -317,6 +336,9 @@ test.describe('listener jobs', () => {
         token: testCase.token,
         timeoutMs: 180_000,
         runner: testCase.runner,
+        selection: {
+          jobs: [{jobKey: LISTENER_JOB, executionSequences: [1], includeContext: true}],
+        },
       });
 
       const listen = terminal.jobs.find((job) => job.key === LISTENER_JOB);
@@ -324,7 +346,7 @@ test.describe('listener jobs', () => {
       expect(resolved.jobs.find((job) => job.key === LISTENER_JOB)?.listener_status).toBe(
         'resolved',
       );
-      expect(listen?.job_executions[0]?.status).toBe('cancelled');
+      expect(listen?.executions[0]?.status).toBe('cancelled');
     } catch (error) {
       await cleanupListenerCase(testCase, runId);
       throw error;

--- a/e2e/suites/flow/workflows/tests/model-provider-agent.e2e.ts
+++ b/e2e/suites/flow/workflows/tests/model-provider-agent.e2e.ts
@@ -1,7 +1,7 @@
-import type {WorkflowRunDetailResponseDto} from '@shipfox/api-workflows-dto';
 import {createApiClient} from '@shipfox/e2e-core';
 import {message, startFakeOpenAiModelProvider} from '@shipfox/e2e-driver-model-provider';
 import {stopLocalRunner} from '@shipfox/e2e-driver-runner-process';
+import type {WorkflowRunObservation} from '@shipfox/e2e-observe-workflows';
 import {
   createAnthropicFakeModelProviderConfig,
   createOpenAiCompatibleCustomProvider,
@@ -167,7 +167,7 @@ async function runFakeModelProviderWorkflow(params: {
   scenario: string;
   workflowYaml: string;
   runnerEnv: Record<string, string>;
-}): Promise<WorkflowRunDetailResponseDto> {
+}): Promise<WorkflowRunObservation> {
   const token = params.suite.sessionToken;
   const client = createApiClient({token});
   const runnerLabel = `e2e-${params.scenario}-${params.uniqueId}`;
@@ -206,6 +206,9 @@ async function runFakeModelProviderWorkflow(params: {
       token,
       timeoutMs: TERMINAL_TIMEOUT_MS,
       runner: localRunner.runner,
+      selection: {
+        jobs: [{jobKey: 'fix', includeDefaultExecution: true, stepKeys: ['reply']}],
+      },
     });
   } finally {
     await attachLocalRunnerLog(
@@ -222,12 +225,13 @@ async function runFakeModelProviderWorkflow(params: {
   }
 }
 
-function stepResponse(run: WorkflowRunDetailResponseDto, jobKey: string, stepKey: string): string {
+function stepResponse(run: WorkflowRunObservation, jobKey: string, stepKey: string): string {
   const step = run.jobs
     .find((job) => job.key === jobKey)
-    ?.job_executions.flatMap((execution) => execution.steps)
+    ?.executions.flatMap((execution) => execution.steps)
     .find((candidate) => candidate.key === stepKey);
-  if (step === undefined) throw new Error(`Step ${jobKey}.${stepKey} missing from run detail`);
+  if (step === undefined)
+    throw new Error(`Step ${jobKey}.${stepKey} missing from workflow observation`);
   if (step.response === null)
     throw new Error(`Step ${jobKey}.${stepKey} did not record a response`);
   return step.response;

--- a/e2e/suites/flow/workflows/tests/pi-agent-tools.e2e.ts
+++ b/e2e/suites/flow/workflows/tests/pi-agent-tools.e2e.ts
@@ -1,7 +1,7 @@
-import type {WorkflowRunDetailResponseDto} from '@shipfox/api-workflows-dto';
 import {createApiClient} from '@shipfox/e2e-core';
 import {message, startFakeOpenAiModelProvider, toolCall} from '@shipfox/e2e-driver-model-provider';
 import {stopLocalRunner} from '@shipfox/e2e-driver-runner-process';
+import type {WorkflowRunObservation} from '@shipfox/e2e-observe-workflows';
 import {
   createOpenAiCompatibleCustomProvider,
   deleteModelProviderConfig,
@@ -208,7 +208,7 @@ async function runPiAgentWorkflow(params: {
   uniqueId: string;
   scenario: string;
   workflowYaml: string;
-}): Promise<WorkflowRunDetailResponseDto> {
+}): Promise<WorkflowRunObservation> {
   const token = params.suite.sessionToken;
   const client = createApiClient({token});
   const runnerLabel = `e2e-${params.scenario}-${params.uniqueId}`;
@@ -263,7 +263,7 @@ async function runPiAgentWorkflow(params: {
 async function attachPiFailureDiagnostics(params: {
   fakeModelProvider: Awaited<ReturnType<typeof startFakeOpenAiModelProvider>>;
   scriptId: string;
-  terminal: WorkflowRunDetailResponseDto;
+  terminal: WorkflowRunObservation;
   testInfo: {
     attach: (name: string, options: {body: Buffer | string; contentType: string}) => Promise<void>;
   };

--- a/e2e/suites/flow/workflows/tests/renewable-credentials.e2e.ts
+++ b/e2e/suites/flow/workflows/tests/renewable-credentials.e2e.ts
@@ -1,8 +1,8 @@
 import {readFile} from 'node:fs/promises';
-import type {WorkflowRunDetailResponseDto} from '@shipfox/api-workflows-dto';
 import {createApiClient} from '@shipfox/e2e-core';
 import {stopLocalRunner} from '@shipfox/e2e-driver-runner-process';
 import {waitForDefinition} from '@shipfox/e2e-observe-definitions';
+import type {WorkflowRunObservation} from '@shipfox/e2e-observe-workflows';
 import {
   createTestVcsRepository,
   failNextTestVcsMints,
@@ -456,7 +456,7 @@ async function runWorkflow(params: {
   runnerCount?: number | undefined;
   runnerLabels?: readonly string[] | undefined;
   renewableGit: boolean;
-}): Promise<{terminal: WorkflowRunDetailResponseDto; logFiles: string[]}> {
+}): Promise<{terminal: WorkflowRunObservation; logFiles: string[]}> {
   const token = params.suite.sessionToken;
   const client = createApiClient({token});
   const localRunners: Array<Awaited<ReturnType<typeof startSuiteLocalRunner>>> = [];

--- a/e2e/suites/flow/workflows/tests/selection-resolver.e2e.ts
+++ b/e2e/suites/flow/workflows/tests/selection-resolver.e2e.ts
@@ -55,10 +55,13 @@ test('resolves an older step identity through the public selection API', async (
       token,
       timeoutMs: 180_000,
       runner: localRunner.runner,
+      selection: {
+        jobs: [{jobKey: 'build', includeDefaultExecution: true, stepKeys: ['selection']}],
+      },
     });
     const oldStepId = firstAttempt.jobs
       .find((job) => job.key === 'build')
-      ?.job_executions[0]?.steps.find((step) => step.key === 'selection')?.id;
+      ?.executions[0]?.steps.find((step) => step.key === 'selection')?.id;
     if (!oldStepId) throw new Error('Expected the first-attempt selection step');
 
     await client.requestJson('post', `/workflows/runs/${encodeURIComponent(runId)}/rerun`, {
@@ -68,7 +71,7 @@ test('resolves an older step identity through the public selection API', async (
     expect(rerun).toMatchObject({
       current_attempt: 2,
       latest_attempt: 2,
-      run_attempt: {attempt: 2},
+      attempt: {attempt: 2},
     });
 
     const selectionQuery = new URLSearchParams({step_id: oldStepId});

--- a/e2e/suites/flow/workflows/tests/session-continuation.e2e.ts
+++ b/e2e/suites/flow/workflows/tests/session-continuation.e2e.ts
@@ -1,5 +1,5 @@
-import type {WorkflowRunDetailResponseDto} from '@shipfox/api-workflows-dto';
 import {message, startFakeOpenAiModelProvider} from '@shipfox/e2e-driver-model-provider';
+import type {WorkflowRunObservation} from '@shipfox/e2e-observe-workflows';
 import {
   createOpenAiCompatibleCustomProvider,
   deleteModelProviderConfig,
@@ -149,6 +149,18 @@ test('resumes one Pi session across jobs and listening event batches', async ({
       token: testCase.token,
       timeoutMs: SESSION_RUN_TERMINAL_TIMEOUT_MS,
       runner: testCase.runner,
+      selection: {
+        jobs: [
+          {jobKey: 'plan', includeDefaultExecution: true, stepKeys: ['draft']},
+          {jobKey: 'implement', includeDefaultExecution: true, stepKeys: ['apply']},
+          {
+            jobKey: LISTENER_JOB,
+            executionSequences: 'all',
+            includeContext: true,
+            stepKeys: ['continue'],
+          },
+        ],
+      },
     });
 
     assertSessionRun({
@@ -189,8 +201,8 @@ test('resumes one Pi session across jobs and listening event batches', async ({
 
 function assertSessionRun(params: {
   firstBatch: Awaited<ReturnType<typeof sendBatchAndAwaitMaterialization>>;
-  terminal: WorkflowRunDetailResponseDto;
-  resolved: WorkflowRunDetailResponseDto;
+  terminal: WorkflowRunObservation;
+  resolved: WorkflowRunObservation;
 }): void {
   const plan = sessionStep(params.terminal, 'plan', 1, 'draft');
   const implement = sessionStep(params.terminal, 'implement', 1, 'apply');
@@ -204,21 +216,20 @@ function assertSessionRun(params: {
   const listen = params.terminal.jobs.find((job) => job.key === LISTENER_JOB);
   expect(listen?.status).toBe('succeeded');
   expect(listen?.listener_status).toBe('resolved');
-  expect(listen?.resolution_reason).toBe('until');
-  expect(listen?.job_executions.map((execution) => execution.sequence)).toEqual([1, 2]);
-  expect(listen?.job_executions.map((execution) => execution.status)).toEqual([
+  expect(listen?.executions.map((execution) => execution.sequence)).toEqual([1, 2]);
+  expect(listen?.executions.map((execution) => execution.status)).toEqual([
     'succeeded',
     'succeeded',
   ]);
   expect(params.firstBatch.deliveryIds).toHaveLength(4);
-  expect(listen?.job_executions[0]?.trigger_events.map((event) => event.delivery_id)).toEqual(
+  expect(listen?.executions[0]?.trigger_events.map((event) => event.delivery_id)).toEqual(
     params.firstBatch.deliveryIds.slice(0, 2),
   );
-  expect(listen?.job_executions[1]?.trigger_events.map((event) => event.delivery_id)).toEqual(
+  expect(listen?.executions[1]?.trigger_events.map((event) => event.delivery_id)).toEqual(
     params.firstBatch.deliveryIds.slice(2),
   );
-  expect(params.resolved.jobs.find((job) => job.key === LISTENER_JOB)?.resolution_reason).toBe(
-    'until',
+  expect(params.resolved.jobs.find((job) => job.key === LISTENER_JOB)?.listener_status).toBe(
+    'resolved',
   );
 
   expect(plan.response?.trim()).toBe(SESSION_RESPONSES[0]);
@@ -244,16 +255,18 @@ function assertSessionRun(params: {
 }
 
 function sessionStep(
-  run: WorkflowRunDetailResponseDto,
+  run: WorkflowRunObservation,
   jobKey: string,
   sequence: number,
   stepKey: string,
 ) {
   const job = run.jobs.find((candidate) => candidate.key === jobKey);
-  if (!job) throw new Error(`Job ${jobKey} missing from run detail`);
-  const execution = job.job_executions.find((candidate) => candidate.sequence === sequence);
-  if (!execution) throw new Error(`Job ${jobKey} execution ${sequence} missing from run detail`);
+  if (!job) throw new Error(`Job ${jobKey} missing from workflow observation`);
+  const execution = job.executions.find((candidate) => candidate.sequence === sequence);
+  if (!execution)
+    throw new Error(`Job ${jobKey} execution ${sequence} missing from workflow observation`);
   const step = execution.steps.find((candidate) => candidate.key === stepKey);
-  if (!step) throw new Error(`Step ${jobKey}.${sequence}.${stepKey} missing from run detail`);
+  if (!step)
+    throw new Error(`Step ${jobKey}.${sequence}.${stepKey} missing from workflow observation`);
   return step;
 }

--- a/e2e/suites/flow/workflows/tests/slack-agent-tools.e2e.ts
+++ b/e2e/suites/flow/workflows/tests/slack-agent-tools.e2e.ts
@@ -58,7 +58,7 @@ test('starts a run from a signed Slack mention and calls Slack agent tools', asy
       setAsDefault: true,
     });
 
-    const {terminal, eventId} = await runSlackToolsWorkflow({
+    const {terminal} = await runSlackToolsWorkflow({
       suite,
       attach: (name, options) => testInfo.attach(name, options),
       uniqueId,
@@ -71,7 +71,6 @@ test('starts a run from a signed Slack mention and calls Slack agent tools', asy
     });
 
     expect(terminal.status).toBe('succeeded');
-    expect(terminal.trigger_payload).toMatchObject({deliveryId: eventId});
     expect(terminal.jobs.find((job) => job.key === 'tools')?.status).toBe('succeeded');
     expect(slackApi.endpoint.toString()).toBe(
       new URL(process.env.SLACK_API_BASE_URL ?? 'http://invalid.local').toString(),


### PR DESCRIPTION
## Summary

Replace the flow suite's legacy workflow-run detail reads with bounded head,
overview, job, execution, step, attempt, and context observation APIs. Polling
and listener helpers now select only resources required by each assertion while
preserving lifecycle, listener executions, session continuity, outputs, gates,
retries, and older-attempt coverage.

The E2E inventory has no runtime consumers of the legacy detail DTO, route,
helper, or run-detail artifact. SPA/server legacy references remain for
ENG-1877. Bounded overview intentionally omits listener resolution_reason;
listener assertions use status and listener_status instead.

## Validation

Focused observer and flow package typecheck, lint, and tests passed (13 and 59
tests); affected Turbo checks passed; 11 migration-sensitive E2E tests passed
serially. The full 58-test local suite could not complete because definition
sync stalled with no definitions in the shared local services. A wider
dependent-graph check also hit an unrelated runner-execution GPG signing
failure because the configured test signing key is unavailable. No hosted CI,
review approval, or deployment has run yet.

Closes ENG-1876

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates flow E2E reads from legacy workflow-run details to bounded workflow observations, so each assertion fetches only the jobs, executions, steps, attempts, and context it needs. Closes ENG-1876.

**Migration**
- Polling and listener helpers preserve lifecycle, listener executions, session continuity, outputs, gates, retries, and older-attempt coverage.
- Observation polling keeps diagnostics within the outer deadline, retries only transient reads, traverses selected retry pages, accounts for preloaded default executions when paginating, and preserves listener failure attachments.
- The bounded overview omits listener `resolution_reason` and run `trigger_payload`; listener assertions use status fields, and the Slack tools test drops its `trigger_payload` check.
- No E2E runtime consumer of the legacy detail DTO, route, helper, or artifact remains; SPA/server references stay for ENG-1877.

**Validation**
- Focused observer and flow checks passed, including 13 observer tests, 59 flow tests, affected Turbo checks, and 11 migration-sensitive E2E tests run serially.
- The full 58-test suite could not complete because definition sync stalled, and a wider check hit an unrelated GPG signing failure; no hosted CI or deployment has run.

<sup>Written for commit 773adb6dd9597702f75467d4b0dde78a6a354ccc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1690?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

