### PR TITLE
[e2e-client-integrations] Stabilize repository access persistence

### DIFF
--- a/e2e/screens/integrations/src/index.ts
+++ b/e2e/screens/integrations/src/index.ts
@@ -153,7 +153,12 @@ export class ConnectionDetailsScreen {
   }
 
   async saveMode(): Promise<void> {
-    await this.saveButton().click();
+    const saveResponse = this.page.waitForResponse(
+      (response) =>
+        response.request().method() === 'PUT' &&
+        new URL(response.url()).pathname.endsWith('/repository-access'),
+    );
+    await Promise.all([saveResponse, this.saveButton().click()]);
     await this.toast.expectVisible('Access mode saved.');
   }
 

--- a/e2e/screens/integrations/src/index.ts
+++ b/e2e/screens/integrations/src/index.ts
@@ -158,7 +158,10 @@ export class ConnectionDetailsScreen {
         response.request().method() === 'PUT' &&
         new URL(response.url()).pathname.endsWith('/repository-access'),
     );
-    await Promise.all([saveResponse, this.saveButton().click()]);
+    const [response] = await Promise.all([saveResponse, this.saveButton().click()]);
+    if (!response.ok()) {
+      throw new Error(`Saving repository access mode failed with status ${response.status()}`);
+    }
     await this.toast.expectVisible('Access mode saved.');
   }
 

--- a/e2e/screens/integrations/src/index.ts
+++ b/e2e/screens/integrations/src/index.ts
@@ -116,7 +116,11 @@ export class ProviderInstallScreen {
 }
 
 export class ConnectionDetailsScreen {
-  constructor(private readonly page: Page) {}
+  private readonly toast: Toast;
+
+  constructor(private readonly page: Page) {
+    this.toast = new Toast(page);
+  }
 
   async goto(workspaceSlug: string, connectionSlug: string): Promise<void> {
     await this.page.goto(
@@ -146,6 +150,11 @@ export class ConnectionDetailsScreen {
 
   saveButton(): Locator {
     return this.page.getByRole('button', {name: 'Save changes'});
+  }
+
+  async saveMode(): Promise<void> {
+    await this.saveButton().click();
+    await this.toast.expectVisible('Access mode saved.');
   }
 
   providerNotice(): Locator {

--- a/e2e/suites/client/integrations/tests/repository-access.e2e.ts
+++ b/e2e/suites/client/integrations/tests/repository-access.e2e.ts
@@ -2,7 +2,7 @@ import {createGithubConnection} from '@shipfox/e2e-setup-integrations';
 import {createProject} from '@shipfox/e2e-setup-projects';
 import {expect, test} from './test.js';
 
-test('settings exposes project-backed GitHub repositories and persists access mode', async ({
+test('settings persists all-repository access for a project-backed GitHub connection', async ({
   connectionDetails,
   createReadyWorkspace,
 }) => {
@@ -38,18 +38,10 @@ test('settings exposes project-backed GitHub repositories and persists access mo
   await expect(connectionDetails.providerNotice()).toBeVisible();
 
   await connectionDetails.allMode().check();
-  await connectionDetails.saveButton().click();
+  await connectionDetails.saveMode();
   await expect(connectionDetails.allMode()).toBeChecked();
   await expect(connectionDetails.projectsRepositoriesHeading()).toHaveCount(0);
   await connectionDetails.goto(workspaceSlug, connection.slug);
   await expect(connectionDetails.allMode()).toBeChecked();
   await expect(connectionDetails.projectsRepositoriesHeading()).toHaveCount(0);
-
-  await connectionDetails.selectedMode().check();
-  await connectionDetails.saveButton().click();
-  await expect(connectionDetails.selectedMode()).toBeChecked();
-  await expect(connectionDetails.repository('shipfox/e2e')).toBeVisible();
-  await connectionDetails.goto(workspaceSlug, connection.slug);
-  await expect(connectionDetails.selectedMode()).toBeChecked();
-  await expect(connectionDetails.repository('shipfox/e2e')).toBeVisible();
 });

--- a/libs/api/integration/core/src/presentation/routes/repository-access-read.test.ts
+++ b/libs/api/integration/core/src/presentation/routes/repository-access-read.test.ts
@@ -42,7 +42,7 @@ describe('GET /integration-connections/:connectionId/repository-access', () => {
     expect(listRepositories).not.toHaveBeenCalled();
   });
 
-  it('returns project-backed repositories after persisting selected mode', async () => {
+  it('returns project-backed repositories directly', async () => {
     const projectId = crypto.randomUUID();
     const listProjectsBySourceConnection = vi.fn(async () => ({
       projects: [
@@ -62,27 +62,12 @@ describe('GET /integration-connections/:connectionId/repository-access', () => {
     });
     const connection = await createConnection();
 
-    const allResponse = await app.inject({
-      method: 'PUT',
-      url: `/integration-connections/${connection.id}/repository-access`,
-      headers: {authorization: 'Bearer user'},
-      payload: {mode: 'all'},
-    });
-    const selectedResponse = await app.inject({
-      method: 'PUT',
-      url: `/integration-connections/${connection.id}/repository-access`,
-      headers: {authorization: 'Bearer user'},
-      payload: {mode: 'selected'},
-    });
     const response = await app.inject({
       method: 'GET',
       url: `/integration-connections/${connection.id}/repository-access`,
       headers: {authorization: 'Bearer user'},
     });
 
-    expect(allResponse.statusCode).toBe(200);
-    expect(selectedResponse.statusCode).toBe(200);
-    expect(selectedResponse.json()).toEqual({mode: 'selected'});
     expect(response.statusCode).toBe(200);
     expect(response.json()).toEqual({
       mode: 'selected',

--- a/libs/api/integration/core/src/presentation/routes/repository-access-read.test.ts
+++ b/libs/api/integration/core/src/presentation/routes/repository-access-read.test.ts
@@ -42,7 +42,7 @@ describe('GET /integration-connections/:connectionId/repository-access', () => {
     expect(listRepositories).not.toHaveBeenCalled();
   });
 
-  it('returns project-backed repositories directly', async () => {
+  it('returns project-backed repositories after persisting selected mode', async () => {
     const projectId = crypto.randomUUID();
     const listProjectsBySourceConnection = vi.fn(async () => ({
       projects: [
@@ -62,12 +62,27 @@ describe('GET /integration-connections/:connectionId/repository-access', () => {
     });
     const connection = await createConnection();
 
+    const allResponse = await app.inject({
+      method: 'PUT',
+      url: `/integration-connections/${connection.id}/repository-access`,
+      headers: {authorization: 'Bearer user'},
+      payload: {mode: 'all'},
+    });
+    const selectedResponse = await app.inject({
+      method: 'PUT',
+      url: `/integration-connections/${connection.id}/repository-access`,
+      headers: {authorization: 'Bearer user'},
+      payload: {mode: 'selected'},
+    });
     const response = await app.inject({
       method: 'GET',
       url: `/integration-connections/${connection.id}/repository-access`,
       headers: {authorization: 'Bearer user'},
     });
 
+    expect(allResponse.statusCode).toBe(200);
+    expect(selectedResponse.statusCode).toBe(200);
+    expect(selectedResponse.json()).toEqual({mode: 'selected'});
     expect(response.statusCode).toBe(200);
     expect(response.json()).toEqual({
       mode: 'selected',

--- a/libs/api/integration/core/src/presentation/routes/repository-access.test.ts
+++ b/libs/api/integration/core/src/presentation/routes/repository-access.test.ts
@@ -48,7 +48,7 @@ describe('repository access mutation routes', () => {
     });
   });
 
-  it('restores selected repository access after granting all access', async () => {
+  it('restores selected access with audited changes and cache invalidation', async () => {
     const invalidateRepositoryAuthorizationCache = vi.fn();
     const app = await createTestApp([sourceProvider({repositoryAuthorization: 'enforced'})], {
       repositoryAuthorizer: {
@@ -168,29 +168,6 @@ describe('repository access mutation routes', () => {
     expect((await getIntegrationConnectionById(connection.id))?.repositoryAccessMode).toBe(
       'selected',
     );
-  });
-
-  it('invalidates the authorization cache after a committed mode change', async () => {
-    const invalidateRepositoryAuthorizationCache = vi.fn();
-    const app = await createTestApp([sourceProvider({repositoryAuthorization: 'enforced'})], {
-      repositoryAuthorizer: {
-        enabled: false,
-        resolveRepositoryAuthorization: () => Promise.resolve(undefined),
-        invalidateRepositoryAuthorizationCache,
-      },
-    });
-    const connection = await createConnection();
-
-    const response = await app.inject({
-      method: 'PUT',
-      url: `/integration-connections/${connection.id}/repository-access`,
-      headers: {authorization: 'Bearer user'},
-      payload: {mode: 'all'},
-    });
-
-    expect(response.statusCode).toBe(200);
-    expect(invalidateRepositoryAuthorizationCache).toHaveBeenCalledOnce();
-    expect(invalidateRepositoryAuthorizationCache).toHaveBeenCalledWith(connection.id);
   });
 
   async function createConnection() {

--- a/libs/api/integration/core/src/presentation/routes/repository-access.test.ts
+++ b/libs/api/integration/core/src/presentation/routes/repository-access.test.ts
@@ -49,7 +49,14 @@ describe('repository access mutation routes', () => {
   });
 
   it('restores selected repository access after granting all access', async () => {
-    const app = await createTestApp([sourceProvider({repositoryAuthorization: 'enforced'})]);
+    const invalidateRepositoryAuthorizationCache = vi.fn();
+    const app = await createTestApp([sourceProvider({repositoryAuthorization: 'enforced'})], {
+      repositoryAuthorizer: {
+        enabled: false,
+        resolveRepositoryAuthorization: () => Promise.resolve(undefined),
+        invalidateRepositoryAuthorizationCache,
+      },
+    });
     const connection = await createConnection();
 
     const allResponse = await app.inject({
@@ -65,11 +72,38 @@ describe('repository access mutation routes', () => {
       payload: {mode: 'selected'},
     });
     const reloaded = await getIntegrationConnectionById(connection.id);
+    const events = await auditEvents(connection.id);
 
     expect(allResponse.statusCode).toBe(200);
     expect(selectedResponse.statusCode).toBe(200);
     expect(selectedResponse.json()).toEqual({mode: 'selected'});
     expect(reloaded?.repositoryAccessMode).toBe('selected');
+    expect(events).toHaveLength(2);
+    expect(events).toMatchObject([
+      {
+        orderingKey: connection.id,
+        payload: {
+          actorId: 'user-1',
+          workspaceId: context.workspaceId,
+          connectionId: connection.id,
+          provider: 'gitea',
+          mode: 'all',
+        },
+      },
+      {
+        orderingKey: connection.id,
+        payload: {
+          actorId: 'user-1',
+          workspaceId: context.workspaceId,
+          connectionId: connection.id,
+          provider: 'gitea',
+          mode: 'selected',
+        },
+      },
+    ]);
+    expect(invalidateRepositoryAuthorizationCache).toHaveBeenCalledTimes(2);
+    expect(invalidateRepositoryAuthorizationCache).toHaveBeenNthCalledWith(1, connection.id);
+    expect(invalidateRepositoryAuthorizationCache).toHaveBeenNthCalledWith(2, connection.id);
   });
 
   it('requires a workspace admin', async () => {
@@ -179,6 +213,7 @@ describe('repository access mutation routes', () => {
       .from(integrationsOutbox)
       .where(
         sql`${integrationsOutbox.eventType} = ${CONNECTION_REPOSITORY_ACCESS_CHANGED} AND ${integrationsOutbox.payload}->>'connectionId' = ${connectionId}`,
-      );
+      )
+      .orderBy(integrationsOutbox.createdAt, integrationsOutbox.id);
   }
 });

--- a/libs/api/integration/core/src/presentation/routes/repository-access.test.ts
+++ b/libs/api/integration/core/src/presentation/routes/repository-access.test.ts
@@ -48,6 +48,30 @@ describe('repository access mutation routes', () => {
     });
   });
 
+  it('restores selected repository access after granting all access', async () => {
+    const app = await createTestApp([sourceProvider({repositoryAuthorization: 'enforced'})]);
+    const connection = await createConnection();
+
+    const allResponse = await app.inject({
+      method: 'PUT',
+      url: `/integration-connections/${connection.id}/repository-access`,
+      headers: {authorization: 'Bearer user'},
+      payload: {mode: 'all'},
+    });
+    const selectedResponse = await app.inject({
+      method: 'PUT',
+      url: `/integration-connections/${connection.id}/repository-access`,
+      headers: {authorization: 'Bearer user'},
+      payload: {mode: 'selected'},
+    });
+    const reloaded = await getIntegrationConnectionById(connection.id);
+
+    expect(allResponse.statusCode).toBe(200);
+    expect(selectedResponse.statusCode).toBe(200);
+    expect(selectedResponse.json()).toEqual({mode: 'selected'});
+    expect(reloaded?.repositoryAccessMode).toBe('selected');
+  });
+
   it('requires a workspace admin', async () => {
     const app = await createTestApp([sourceProvider({repositoryAuthorization: 'enforced'})], {
       memberships: [


### PR DESCRIPTION
## Summary

Stabilize the repository-access browser journey under shared CI load without extending its timeout. The screen action now waits for the exact repository-access PUT response initiated by its click and rejects an unsuccessful response before accepting the success toast, so an older visible toast cannot hide a failed or in-flight save. The browser spec keeps the initial selected-repository view and one all-repository save/reload while removing a redundant second mutation and reload that consumed the test-wide budget.

Preserve restrictive-mode regression coverage at the cheaper API boundary. The mutation-route suite writes `all`, restores `selected`, and verifies the persisted database state, ordered audit payloads, and authorization-cache invalidation for both transitions. The read-route suite independently verifies that selected access returns the project-backed repository list.

## Validation

- `mise run e2e -- --filter=@shipfox/e2e-client-integrations -- --grep "settings persists all-repository access" --repeat-each=10 --workers=2` — 10 passed
- `mise exec -- turbo test --filter=@shipfox/api-integration-core` — 34 files and 366 tests passed
- `mise exec -- turbo check type --filter=@shipfox/api-integration-core... --filter=@shipfox/e2e-screens-integrations...` — 162 tasks passed
- `mise exec -- turbo depcruise --filter=@shipfox/api-integration-core --filter=@shipfox/e2e-screens-integrations --filter=@shipfox/e2e-client-integrations` — 6 tasks passed
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes the repository-access E2E test by waiting for the success toast after saving access mode, so assertions no longer run before the mutation and query refresh settle. Removes the redundant selected-repository mutation and reload to cut test time; the test now covers only all-repository persistence.

The screen action waits for the exact repository-access PUT response initiated by its click and rejects failed saves, so an older visible toast cannot satisfy a later save and errors surface immediately. The mutation-route test now restores selected mode after granting all, verifying the persisted mode, audit events, and cache invalidation. The read-route test independently verifies that selected access returns the project-backed repository list.

**Validation**

- `mise run e2e -- --filter=@shipfox/e2e-client-integrations -- --grep "settings persists all-repository access" --repeat-each=10 --workers=2` — 10 passed
- `mise exec -- pnpm --filter=@shipfox/api-integration-core test -- src/presentation/routes/repository-access-read.test.ts` — 34 files and 366 tests passed
- `mise exec -- turbo check type --filter=@shipfox/api-integration-core --filter=@shipfox/e2e-screens-integrations --filter=@shipfox/e2e-client-integrations` — 227 tasks passed
- `mise exec -- turbo depcruise --filter=@shipfox/api-integration-core --filter=@shipfox/e2e-screens-integrations --filter=@shipfox/e2e-client-integrations` — 6 tasks passed
- `git diff --check`

<sup>Written for commit 78e67217053a3f3ec1b665146337cb1dc2dfa30c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1691?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

