### PR TITLE
[api-database-policy] Keep boundary verification within CI test limits

### DIFF
--- a/tools/api-database-policy/src/api-database-boundaries.ts
+++ b/tools/api-database-policy/src/api-database-boundaries.ts
@@ -34,6 +34,11 @@ const sqlTemplateExpression = /\bsql(?:\.raw)?\s*`[^`]*$/su;
 const sqlCallExpression = /\bsql(?:\.raw)?\s*\([^\n]*$/u;
 const sqlKeywordExpression =
   /\b(?:SELECT\s+.+\s+FROM|TRUNCATE\s+(?:TABLE\s+)?[A-Za-z_"']|INSERT\s+INTO|UPDATE\s+[A-Za-z_"']+\s+SET|DELETE\s+FROM|(?:ALTER|DROP|CREATE)\s+(?:TABLE|TYPE|INDEX|VIEW|SEQUENCE|TRIGGER)|LOCK\s+TABLE)\b/iu;
+const sqlTagOrCallExpression = /\bsql(?:\.raw)?\s*(?:`|\()/u;
+const staticSqlCandidateExpression = new RegExp(
+  `(?:${sqlTagOrCallExpression.source}|${sqlKeywordExpression.source})`,
+  'iu',
+);
 const migrationSqlKeywordExpression = /\b(?:ALTER|DROP|CREATE)\b/iu;
 const referencesKeywordExpression = /\bREFERENCES\b/iu;
 const dynamicSqlKeywordExpression =
@@ -54,8 +59,6 @@ const namespaceImportExpression = /\*\s+as\s+([A-Za-z_$][\w$]*)/u;
 const defaultImportExpression = /^\s*([A-Za-z_$][\w$]*)/u;
 const dynamicSqlRawKeywordExpression =
   /\b(?:FROM|JOIN|INTO|UPDATE|TABLE|TRUNCATE|ALTER|DROP|CREATE)\b/iu;
-const staticSqlCandidateExpression =
-  /\bsql(?:\.raw)?\s*(?:`|\()|\b(?:SELECT|TRUNCATE|INSERT\s+INTO|UPDATE\s+[^\n]+\s+SET|DELETE\s+FROM|(?:ALTER|DROP|CREATE)\s+(?:TABLE|TYPE|INDEX|VIEW|SEQUENCE|TRIGGER)|LOCK\s+TABLE)\b/iu;
 
 export type DatabaseBoundaryRule =
   | 'direct-table-declaration'

--- a/tools/api-database-policy/src/api-database-boundaries.ts
+++ b/tools/api-database-policy/src/api-database-boundaries.ts
@@ -34,6 +34,7 @@ const sqlTemplateExpression = /\bsql(?:\.raw)?\s*`[^`]*$/su;
 const sqlCallExpression = /\bsql(?:\.raw)?\s*\([^\n]*$/u;
 const sqlKeywordExpression =
   /\b(?:SELECT\s+.+\s+FROM|TRUNCATE\s+(?:TABLE\s+)?[A-Za-z_"']|INSERT\s+INTO|UPDATE\s+[A-Za-z_"']+\s+SET|DELETE\s+FROM|(?:ALTER|DROP|CREATE)\s+(?:TABLE|TYPE|INDEX|VIEW|SEQUENCE|TRIGGER)|LOCK\s+TABLE)\b/iu;
+// Keep these openers aligned with the sqlTemplateExpression and sqlCallExpression acceptance checks.
 const sqlTagOrCallExpression = /\bsql(?:\.raw)?\s*(?:`|\()/u;
 const staticSqlCandidateExpression = new RegExp(
   `(?:${sqlTagOrCallExpression.source}|${sqlKeywordExpression.source})`,

--- a/tools/api-database-policy/src/api-database-boundaries.ts
+++ b/tools/api-database-policy/src/api-database-boundaries.ts
@@ -54,6 +54,8 @@ const namespaceImportExpression = /\*\s+as\s+([A-Za-z_$][\w$]*)/u;
 const defaultImportExpression = /^\s*([A-Za-z_$][\w$]*)/u;
 const dynamicSqlRawKeywordExpression =
   /\b(?:FROM|JOIN|INTO|UPDATE|TABLE|TRUNCATE|ALTER|DROP|CREATE)\b/iu;
+const staticSqlCandidateExpression =
+  /\bsql(?:\.raw)?\s*(?:`|\()|\b(?:SELECT|TRUNCATE|INSERT\s+INTO|UPDATE\s+[^\n]+\s+SET|DELETE\s+FROM|(?:ALTER|DROP|CREATE)\s+(?:TABLE|TYPE|INDEX|VIEW|SEQUENCE|TRIGGER)|LOCK\s+TABLE)\b/iu;
 
 export type DatabaseBoundaryRule =
   | 'direct-table-declaration'
@@ -129,7 +131,7 @@ interface AuditContext {
   units: DatabaseMigrationUnit[];
   objects: Map<string, DatabaseObject>;
   sortedNamespaces: readonly string[];
-  sqlObjectReferences: readonly SqlObjectReference[];
+  sqlObjectReferenceExpression: RegExp | undefined;
   namespaceOwners: Map<string, string>;
   ownerNamespaces: Map<string, Set<string>>;
   factories: Map<string, FactoryInfo>;
@@ -141,11 +143,6 @@ interface ObjectReference {
   name: string;
   index: number;
   kind: DatabaseObjectKind;
-}
-
-interface SqlObjectReference {
-  name: string;
-  expression: RegExp;
 }
 
 const namespaceSuggestion = (owner: string, namespace: string): string =>
@@ -491,12 +488,7 @@ function createAuditContext(
   const sortedNamespaces = [...namespaceOwners.keys()].sort(
     (left, right) => right.length - left.length || compareText(left, right),
   );
-  const sqlObjectReferences = [...objects.keys()]
-    .sort((left, right) => right.length - left.length || compareText(left, right))
-    .map((name) => ({
-      name,
-      expression: new RegExp(`(?<![A-Za-z0-9_$])${escapeRegExp(name)}(?![A-Za-z0-9_$])`, 'gu'),
-    }));
+  const sqlObjectReferenceExpression = buildSqlObjectReferenceExpression(objects);
 
   return {
     registry: options.registry,
@@ -504,13 +496,26 @@ function createAuditContext(
     units,
     objects,
     sortedNamespaces,
-    sqlObjectReferences,
+    sqlObjectReferenceExpression,
     namespaceOwners,
     ownerNamespaces,
     factories,
     packageOwners: new Map(),
     ownerPackages,
   };
+}
+
+function buildSqlObjectReferenceExpression(
+  objects: ReadonlyMap<string, DatabaseObject>,
+): RegExp | undefined {
+  const names = [...objects.keys()].sort(
+    (left, right) => right.length - left.length || compareText(left, right),
+  );
+  if (names.length === 0) return undefined;
+  return new RegExp(
+    `(?<![A-Za-z0-9_$])(?:${names.map(escapeRegExp).join('|')})(?![A-Za-z0-9_$])`,
+    'gu',
+  );
 }
 
 function ownerContextForPath(
@@ -1017,28 +1022,29 @@ function auditStaticRawSql(
   file: AuditFile,
   fileContext: FileOwnerContext,
 ): void {
-  for (const {name, expression} of context.sqlObjectReferences) {
-    expression.lastIndex = 0;
-    for (const match of file.source.matchAll(expression)) {
-      const offset = match.index ?? 0;
-      if (isSqlLikeReference(file.source, offset)) {
-        const reference = {kind: context.objects.get(name)?.kind ?? 'table', name, index: offset};
-        const target = objectByNamespace(context, name);
-        if (target?.owner && target.owner !== fileContext.owner) {
-          addFinding(
-            findings,
-            context,
-            file.path,
-            file.source,
-            offset,
-            name,
-            sqlRuleForObject(file.source, offset),
-            namespaceSuggestion(target.owner, target.namespace),
-            fileContext,
-          );
-        } else {
-          validateObjectReference(findings, context, file, reference, false);
-        }
+  const expression = context.sqlObjectReferenceExpression;
+  if (!expression || !staticSqlCandidateExpression.test(file.source)) return;
+  expression.lastIndex = 0;
+  for (const match of file.source.matchAll(expression)) {
+    const name = match[0];
+    const offset = match.index ?? 0;
+    if (isSqlLikeReference(file.source, offset)) {
+      const reference = {kind: context.objects.get(name)?.kind ?? 'table', name, index: offset};
+      const target = objectByNamespace(context, name);
+      if (target?.owner && target.owner !== fileContext.owner) {
+        addFinding(
+          findings,
+          context,
+          file.path,
+          file.source,
+          offset,
+          name,
+          sqlRuleForObject(file.source, offset),
+          namespaceSuggestion(target.owner, target.namespace),
+          fileContext,
+        );
+      } else {
+        validateObjectReference(findings, context, file, reference, false);
       }
     }
   }

--- a/tools/api-database-policy/test/api-database-boundary-fixtures.test.ts
+++ b/tools/api-database-policy/test/api-database-boundary-fixtures.test.ts
@@ -51,6 +51,11 @@ const fixtureRegistry: ApiDatabaseRegistry = {
   ],
   delegates: [],
 };
+const emptyObjectRegistry: ApiDatabaseRegistry = {
+  owners: fixtureRegistry.owners.slice(0, 1),
+  migrationUnits: fixtureRegistry.migrationUnits.slice(0, 1),
+  delegates: [],
+};
 const nonEmptyOutputPattern = /./u;
 
 async function writeFixture(
@@ -159,6 +164,14 @@ async function createFixtureRepository(rootDirectory: string): Promise<void> {
   );
   await writeFixture(
     rootDirectory,
+    'libs/api/alpha/src/raw-sql.ts',
+    [
+      "import {sql} from 'drizzle-orm';",
+      "export const selected = sql.raw('SELECT * FROM beta_owned');",
+    ].join('\n'),
+  );
+  await writeFixture(
+    rootDirectory,
     'libs/api/integrations/provider/src/db/schema/common.ts',
     [
       "import {pgTableCreator} from 'drizzle-orm/pg-core';",
@@ -173,6 +186,7 @@ async function createFixtureRepository(rootDirectory: string): Promise<void> {
       "import {sql} from 'drizzle-orm';",
       "export const providerTable = pgTable('local', {});",
       'export const sharedQuery = sql`SELECT * FROM integrations_core_owned`;',
+      "export const sharedRawQuery = sql.raw('SELECT * FROM integrations_core_owned');",
       'export const registeredQuery = sql`SELECT * FROM $' + '{providerTable}`;',
     ].join('\n'),
   );
@@ -240,6 +254,14 @@ describe('database boundary verifier fixtures', () => {
             finding.rule === 'foreign-key',
         ),
       );
+      assert.ok(
+        findings.some(
+          (finding) =>
+            finding.file === 'libs/api/alpha/src/raw-sql.ts' &&
+            finding.object === 'beta_owned' &&
+            finding.rule === 'foreign-raw-sql',
+        ),
+      );
       assert.doesNotMatch(
         findings
           .filter((finding) => finding.file.includes('/accepted.ts'))
@@ -260,6 +282,32 @@ describe('database boundary verifier fixtures', () => {
           .map((finding) => finding.rule)
           .join(','),
         nonEmptyOutputPattern,
+      );
+    } finally {
+      await rm(rootDirectory, {force: true, recursive: true});
+    }
+  });
+
+  test('skips static SQL auditing when the registry has no database objects', async () => {
+    const rootDirectory = await mkdtemp(join(tmpdir(), 'shipfox-api-database-empty-'));
+    try {
+      await writeFixture(rootDirectory, 'libs/api/alpha/package.json', '{"name":"@fixture/alpha"}');
+      await writeFixture(rootDirectory, 'libs/api/alpha/drizzle.config.ts', 'export default {}');
+      await writeFixture(
+        rootDirectory,
+        'libs/api/alpha/src/query.ts',
+        [
+          "import {sql} from 'drizzle-orm';",
+          'export const query = sql`SELECT * FROM beta_owned`;',
+        ].join('\n'),
+      );
+
+      assert.deepEqual(
+        await auditApiDatabaseBoundaries({
+          registry: emptyObjectRegistry,
+          rootDirectory,
+        }),
+        [],
       );
     } finally {
       await rm(rootDirectory, {force: true, recursive: true});

--- a/tools/api-database-policy/test/api-database-boundary-fixtures.test.ts
+++ b/tools/api-database-policy/test/api-database-boundary-fixtures.test.ts
@@ -165,10 +165,17 @@ async function createFixtureRepository(rootDirectory: string): Promise<void> {
   await writeFixture(
     rootDirectory,
     'libs/api/alpha/src/raw-sql.ts',
-    [
-      "import {sql} from 'drizzle-orm';",
-      "export const selected = sql.raw('SELECT * FROM beta_owned');",
-    ].join('\n'),
+    ["export const selected = sql.raw('beta_owned');"].join('\n'),
+  );
+  await writeFixture(
+    rootDirectory,
+    'libs/api/alpha/src/keyword-sql.ts',
+    ["export const selected = 'SELECT * FROM beta_owned';"].join('\n'),
+  );
+  await writeFixture(
+    rootDirectory,
+    'libs/api/alpha/src/template-sql.ts',
+    ['const selected = sql`beta_owned`;'].join('\n'),
   );
   await writeFixture(
     rootDirectory,
@@ -186,7 +193,7 @@ async function createFixtureRepository(rootDirectory: string): Promise<void> {
       "import {sql} from 'drizzle-orm';",
       "export const providerTable = pgTable('local', {});",
       'export const sharedQuery = sql`SELECT * FROM integrations_core_owned`;',
-      "export const sharedRawQuery = sql.raw('SELECT * FROM integrations_core_owned');",
+      "export const sharedRawQuery = sql.raw('integrations_core_owned');",
       'export const registeredQuery = sql`SELECT * FROM $' + '{providerTable}`;',
     ].join('\n'),
   );
@@ -254,14 +261,17 @@ describe('database boundary verifier fixtures', () => {
             finding.rule === 'foreign-key',
         ),
       );
-      assert.ok(
-        findings.some(
-          (finding) =>
-            finding.file === 'libs/api/alpha/src/raw-sql.ts' &&
-            finding.object === 'beta_owned' &&
-            finding.rule === 'foreign-raw-sql',
-        ),
-      );
+      for (const file of ['raw-sql.ts', 'keyword-sql.ts', 'template-sql.ts']) {
+        assert.ok(
+          findings.some(
+            (finding) =>
+              finding.file === `libs/api/alpha/src/${file}` &&
+              finding.object === 'beta_owned' &&
+              finding.rule === 'foreign-raw-sql',
+          ),
+          `fixture did not report foreign raw SQL in ${file}`,
+        );
+      }
       assert.doesNotMatch(
         findings
           .filter((finding) => finding.file.includes('/accepted.ts'))


### PR DESCRIPTION
The API database boundary test began timing out in CI after the Usage database objects expanded the repository scan. This keeps the existing SQL-context and ownership checks while making the static SQL audit use a single combined object matcher and an inexpensive candidate prefilter.\n\nValidated locally with `mise exec -- pnpm --filter @shipfox/api-database-policy check`, `mise exec -- turbo type --filter=@shipfox/api-database-policy... --concurrency=4`, `mise exec -- pnpm check:api-database-boundaries`, and `mise exec -- turbo test --filter=@shipfox/api-database-policy... --concurrency=4`; the focused package suite passed all 32 tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
API database boundary tests were timing out in CI because the Usage database objects expanded the repository scan. The audit now skips files without likely SQL and scans known object names with one combined matcher instead of checking every object separately, while preserving the existing SQL-context and ownership checks. Adds fixture tests for `sql.raw` calls and for registries without database objects.

<sup>Written for commit 0f3c5dbdf1d35e2b6dd37510a35bb2600c056fba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1692?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

