### PR TITLE
[api-integration-github] Fix review thread reads

### DIFF
--- a/.changeset/valid-review-threads.md
+++ b/.changeset/valid-review-threads.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-integration-github": patch
+---
+
+Fixes GitHub review-thread reads to use the provider's thread location fields.

--- a/libs/api/integration/github/src/core/agent-tools.test.ts
+++ b/libs/api/integration/github/src/core/agent-tools.test.ts
@@ -2149,6 +2149,11 @@ describe('github agent tool catalog', () => {
               {
                 id: 'PRRT_kwDOExample',
                 isResolved: false,
+                path: 'src/index.ts',
+                line: 42,
+                diffSide: 'RIGHT',
+                startLine: 40,
+                startDiffSide: 'RIGHT',
                 comments: {
                   nodes: [
                     {
@@ -2158,6 +2163,7 @@ describe('github agent tool catalog', () => {
                       author: {login: 'reviewer'},
                       path: 'src/index.ts',
                       line: 42,
+                      startLine: 40,
                     },
                   ],
                 },
@@ -2192,10 +2198,17 @@ describe('github agent tool catalog', () => {
       {owner: 'shipfox', repo: 'platform', pullNumber: 2, after: 'cursor-1'},
     );
     const query = graphql.mock.calls[0]?.[0];
+    const selectedFields = String(query)
+      .split('\n')
+      .map((line) => line.trim());
     expect(query).toContain('isResolved');
     expect(query).toContain('author');
     expect(query).toContain('path');
     expect(query).toContain('line');
+    expect(query).toContain('diffSide');
+    expect(query).toContain('startDiffSide');
+    expect(selectedFields).not.toContain('side');
+    expect(selectedFields).not.toContain('startSide');
     expect(result).toEqual({
       content: [{type: 'text', text: JSON.stringify(data)}],
       structuredContent: data,

--- a/libs/api/integration/github/src/core/agent-tools.test.ts
+++ b/libs/api/integration/github/src/core/agent-tools.test.ts
@@ -2198,15 +2198,20 @@ describe('github agent tool catalog', () => {
       {owner: 'shipfox', repo: 'platform', pullNumber: 2, after: 'cursor-1'},
     );
     const query = graphql.mock.calls[0]?.[0];
-    const selectedFields = String(query)
+    const queryText = String(query);
+    const threadFields = queryText
+      .slice(
+        queryText.indexOf('reviewThreads(first: 100, after: $after)'),
+        queryText.indexOf('comments(first: 100)'),
+      )
       .split('\n')
       .map((line) => line.trim());
     expect(query).toContain('isResolved');
     expect(query).toContain('author');
-    expect(query).toContain('path');
-    expect(query).toContain('line');
-    expect(query).toContain('diffSide');
-    expect(query).toContain('startDiffSide');
+    expect(threadFields).toEqual(
+      expect.arrayContaining(['path', 'line', 'diffSide', 'startLine', 'startDiffSide']),
+    );
+    const selectedFields = queryText.split('\n').map((line) => line.trim());
     expect(selectedFields).not.toContain('side');
     expect(selectedFields).not.toContain('startSide');
     expect(result).toEqual({

--- a/libs/api/integration/github/src/core/agent-tools.ts
+++ b/libs/api/integration/github/src/core/agent-tools.ts
@@ -98,6 +98,11 @@ const GET_PULL_REQUEST_REVIEW_THREADS_QUERY = `
           nodes {
             id
             isResolved
+            path
+            line
+            diffSide
+            startLine
+            startDiffSide
             comments(first: 100) {
               nodes {
                 id
@@ -108,9 +113,7 @@ const GET_PULL_REQUEST_REVIEW_THREADS_QUERY = `
                 }
                 path
                 line
-                side
                 startLine
-                startSide
                 createdAt
                 updatedAt
                 url


### PR DESCRIPTION
GitHub rejects the review-thread query because it selects REST-style side fields from `PullRequestReviewComment`. This breaks `pull_request_read.get_review_threads` and produces Sentry issue API-P.

This change reads side metadata from `PullRequestReviewThread` through `diffSide` and `startDiffSide`. It keeps the comment selection schema-valid and adds regression coverage for the field split. A patch Changeset records the package fix.

Sentry: https://shipfox.sentry.io/issues/API-P

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes GitHub review-thread reads that failed because the query selected REST-style `side`/`startSide` fields from `PullRequestReviewComment`. `pull_request_read.get_review_threads` now reads `diffSide`/`startDiffSide` from `PullRequestReviewThread` instead.

- Keeps comment selection schema-valid by dropping the removed fields.
- Strengthens regression coverage to assert thread-level location fields and absence of `side`/`startSide`.
- Adds a patch changeset for `@shipfox/api-integration-github`.

Sentry: https://shipfox.sentry.io/issues/API-P

<sup>Written for commit 516db557b4ead299b3f9ca48a97ec3e3a9febac0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1693?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

