### PR TITLE
[runner-agent] Stabilize SVG rasterizer image verification

### DIFF
--- a/.changeset/calm-workers-initialize.md
+++ b/.changeset/calm-workers-initialize.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/runner-agent": patch
+---
+
+Stabilizes SVG rasterizer startup under emulation without extending render deadlines.

--- a/libs/runner/agent/src/core/pi-image-rasterizer.test.ts
+++ b/libs/runner/agent/src/core/pi-image-rasterizer.test.ts
@@ -247,6 +247,7 @@ describe('worker lifecycle', () => {
   });
 
   it('keeps queued work when another worker can recover from initialization failure', async () => {
+    vi.useFakeTimers();
     const workers: FakeRenderWorker[] = [];
     const rasterizer = createPiSvgRasterizer({
       workerFactory: (() => {

--- a/libs/runner/agent/src/core/pi-image-rasterizer.test.ts
+++ b/libs/runner/agent/src/core/pi-image-rasterizer.test.ts
@@ -221,6 +221,88 @@ describe('worker lifecycle', () => {
     await rasterizer.close();
   });
 
+  it.each([
+    'error',
+    'exit',
+  ] as const)('reports a worker %s before readiness as unavailable', async (event) => {
+    const workers: FakeRenderWorker[] = [];
+    const rasterizer = createPiSvgRasterizer({
+      workerFactory: (() => {
+        const worker = new FakeRenderWorker(renderPng, {autoReady: false});
+        workers.push(worker);
+        return worker;
+      }) as never,
+    });
+
+    const render = rasterizer.rasterize({base64: encodedSvg('<rect />')});
+    if (event === 'error') workers[0]?.emit(event, new Error('startup failed'));
+    else workers[0]?.emit(event, 1);
+
+    await expect(render).resolves.toMatchObject({
+      outcome: 'omitted',
+      reason: 'rasterizer_unavailable',
+    });
+    await vi.waitFor(() => expect(workers[0]?.terminated).toBe(true));
+    await rasterizer.close();
+  });
+
+  it('keeps queued work when another worker can recover from initialization failure', async () => {
+    const workers: FakeRenderWorker[] = [];
+    const rasterizer = createPiSvgRasterizer({
+      workerFactory: (() => {
+        const index = workers.length;
+        const worker = new FakeRenderWorker(index === 0 ? () => undefined : renderPng, {
+          autoReady: index !== 1,
+        });
+        workers.push(worker);
+        return worker;
+      }) as never,
+    });
+
+    const hanging = rasterizer.rasterize({base64: encodedSvg('<rect />')});
+    const queued = rasterizer.rasterize({base64: encodedSvg('<rect />')});
+    await vi.waitFor(() => expect(workers).toHaveLength(2));
+    workers[1]?.failInitialization();
+
+    await expect(queued).resolves.toMatchObject({outcome: 'converted'});
+    await vi.waitFor(() => expect(workers).toHaveLength(3));
+    await rasterizer.close();
+    await expect(hanging).resolves.toMatchObject({
+      outcome: 'omitted',
+      reason: 'rasterizer_unavailable',
+    });
+  });
+
+  it('bounds initialization after another worker drains the queue', async () => {
+    vi.useFakeTimers();
+    const workers: FakeRenderWorker[] = [];
+    const rasterizer = createPiSvgRasterizer({
+      workerFactory: (() => {
+        const worker = new FakeRenderWorker(renderPng, {autoReady: workers.length > 0});
+        workers.push(worker);
+        return worker;
+      }) as never,
+    });
+
+    const renders = [
+      rasterizer.rasterize({base64: encodedSvg('<rect />')}),
+      rasterizer.rasterize({base64: encodedSvg('<rect />')}),
+    ];
+    await vi.advanceTimersByTimeAsync(0);
+    await expect(Promise.all(renders)).resolves.toMatchObject([
+      {outcome: 'converted'},
+      {outcome: 'converted'},
+    ]);
+    expect(workers[0]?.terminated).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(PI_SVG_RASTERIZATION_LIMITS.resultBudgetMs);
+    expect(workers[0]?.terminated).toBe(true);
+    await expect(rasterizer.rasterize({base64: encodedSvg('<rect />')})).resolves.toMatchObject({
+      outcome: 'converted',
+    });
+    await rasterizer.close();
+  });
+
   it('discards a worker when initialization exhausts the result budget', async () => {
     vi.useFakeTimers();
     const workers: FakeRenderWorker[] = [];
@@ -244,6 +326,28 @@ describe('worker lifecycle', () => {
     const second = rasterizer.rasterize({base64: encodedSvg('<rect />')});
     await vi.advanceTimersByTimeAsync(0);
     await expect(second).resolves.toMatchObject({outcome: 'converted'});
+    await rasterizer.close();
+  });
+
+  it('reports synchronous worker construction failures as render errors', async () => {
+    const rasterizer = createPiSvgRasterizer({
+      workerFactory: (() => {
+        throw new Error('worker unavailable');
+      }) as never,
+    });
+
+    const results = await Promise.all([
+      rasterizer.rasterize({base64: encodedSvg('<rect />')}),
+      rasterizer.rasterize({base64: encodedSvg('<rect />')}),
+    ]);
+
+    expect(results).toMatchObject([
+      {outcome: 'omitted', reason: 'render_error'},
+      {outcome: 'omitted', reason: 'render_error'},
+    ]);
+    expect(
+      results.every((result) => result.durationMs < PI_SVG_RASTERIZATION_LIMITS.workerDeadlineMs),
+    ).toBe(true);
     await rasterizer.close();
   });
 

--- a/libs/runner/agent/src/core/pi-image-rasterizer.test.ts
+++ b/libs/runner/agent/src/core/pi-image-rasterizer.test.ts
@@ -12,6 +12,7 @@ import {inspectSvgPolicy} from './pi-svg-policy.js';
 const PNG_SIGNATURE = [137, 80, 78, 71, 13, 10, 26, 10];
 
 afterEach(async () => {
+  vi.useRealTimers();
   await closePiSvgRasterizer();
 });
 
@@ -168,11 +169,83 @@ describe('worker lifecycle', () => {
     expect(first).toMatchObject({outcome: 'omitted', reason: 'render_timeout'});
     expect(workers[0]?.terminated).toBe(true);
 
+    const second = rasterizer.rasterize({base64: encodedSvg('<rect />')});
     await vi.waitFor(() => expect(workers).toHaveLength(2));
-    const second = await rasterizer.rasterize({base64: encodedSvg('<rect />')});
-    expect(second.outcome).toBe('converted');
+    await expect(second).resolves.toMatchObject({outcome: 'converted'});
     await rasterizer.close();
   }, 10_000);
+
+  it('starts the worker deadline after initialization readiness', async () => {
+    vi.useFakeTimers();
+    const workers: FakeRenderWorker[] = [];
+    const rasterizer = createPiSvgRasterizer({
+      workerFactory: (() => {
+        const worker = new FakeRenderWorker(renderPng, {autoReady: false});
+        workers.push(worker);
+        return worker;
+      }) as never,
+    });
+
+    const render = rasterizer.rasterize({base64: encodedSvg('<rect />')});
+    let settled = false;
+    void render.then(() => {
+      settled = true;
+    });
+    await vi.advanceTimersByTimeAsync(PI_SVG_RASTERIZATION_LIMITS.workerDeadlineMs + 1);
+    expect(settled).toBe(false);
+
+    workers[0]?.signalReady();
+    await expect(render).resolves.toMatchObject({outcome: 'converted'});
+    await rasterizer.close();
+    vi.useRealTimers();
+  });
+
+  it('reports worker initialization failure as unavailable', async () => {
+    const workers: FakeRenderWorker[] = [];
+    const rasterizer = createPiSvgRasterizer({
+      workerFactory: (() => {
+        const worker = new FakeRenderWorker(renderPng, {autoReady: false});
+        workers.push(worker);
+        return worker;
+      }) as never,
+    });
+
+    const render = rasterizer.rasterize({base64: encodedSvg('<rect />')});
+    workers[0]?.failInitialization();
+
+    await expect(render).resolves.toMatchObject({
+      outcome: 'omitted',
+      reason: 'rasterizer_unavailable',
+    });
+    await vi.waitFor(() => expect(workers[0]?.terminated).toBe(true));
+    await rasterizer.close();
+  });
+
+  it('discards a worker when initialization exhausts the result budget', async () => {
+    vi.useFakeTimers();
+    const workers: FakeRenderWorker[] = [];
+    const rasterizer = createPiSvgRasterizer({
+      workerFactory: (() => {
+        const worker = new FakeRenderWorker(renderPng, {autoReady: workers.length > 0});
+        workers.push(worker);
+        return worker;
+      }) as never,
+    });
+
+    const first = rasterizer.rasterize({base64: encodedSvg('<rect />')});
+    await vi.advanceTimersByTimeAsync(PI_SVG_RASTERIZATION_LIMITS.resultBudgetMs);
+
+    await expect(first).resolves.toMatchObject({
+      outcome: 'omitted',
+      reason: 'result_budget_exhausted',
+    });
+    expect(workers[0]?.terminated).toBe(true);
+
+    const second = rasterizer.rasterize({base64: encodedSvg('<rect />')});
+    await vi.advanceTimersByTimeAsync(0);
+    await expect(second).resolves.toMatchObject({outcome: 'converted'});
+    await rasterizer.close();
+  });
 
   it('replaces a worker after a malformed protocol response', async () => {
     const workers: FakeRenderWorker[] = [];
@@ -191,8 +264,9 @@ describe('worker lifecycle', () => {
 
     const first = await rasterizer.rasterize({base64: encodedSvg('<rect />')});
     expect(first).toMatchObject({outcome: 'omitted', reason: 'render_error'});
+    const second = rasterizer.rasterize({base64: encodedSvg('<rect />')});
     await vi.waitFor(() => expect(workers).toHaveLength(2));
-    await expect(rasterizer.rasterize({base64: encodedSvg('<rect />')})).resolves.toMatchObject({
+    await expect(second).resolves.toMatchObject({
       outcome: 'converted',
     });
     await rasterizer.close();
@@ -221,8 +295,9 @@ describe('worker lifecycle', () => {
       outcome: 'omitted',
       reason: 'render_error',
     });
+    const second = rasterizer.rasterize({base64: encodedSvg('<rect />')});
     await vi.waitFor(() => expect(workers).toHaveLength(2));
-    await expect(rasterizer.rasterize({base64: encodedSvg('<rect />')})).resolves.toMatchObject({
+    await expect(second).resolves.toMatchObject({
       outcome: 'converted',
     });
     await rasterizer.close();
@@ -252,8 +327,9 @@ describe('worker lifecycle', () => {
     await expect(first).resolves.toMatchObject({outcome: 'converted'});
     await vi.waitFor(() => expect(workers).toHaveLength(2));
     workers[0]?.emit('exit', 1);
+    const replacement = rasterizer.rasterize({base64: encodedSvg('<rect />')});
     await vi.waitFor(() => expect(workers).toHaveLength(3));
-    await expect(rasterizer.rasterize({base64: encodedSvg('<rect />')})).resolves.toMatchObject({
+    await expect(replacement).resolves.toMatchObject({
       outcome: 'converted',
     });
     await rasterizer.close();
@@ -283,7 +359,7 @@ describe('worker lifecycle', () => {
       outcome: 'omitted',
       reason: 'render_error',
     });
-    await vi.waitFor(() => expect(workers).toHaveLength(2));
+    await vi.waitFor(() => expect(workers[0]?.terminated).toBe(true));
     await rasterizer.close();
   });
 
@@ -396,8 +472,20 @@ class FakeRenderWorker extends EventEmitter {
 
   constructor(
     private readonly behavior: (message: {requestId: number}, worker: FakeRenderWorker) => void,
+    options: {autoReady?: boolean} = {},
   ) {
     super();
+    if (options.autoReady !== false) {
+      queueMicrotask(() => this.signalReady());
+    }
+  }
+
+  signalReady(): void {
+    if (!this.terminated) this.emit('message', {type: 'ready'});
+  }
+
+  failInitialization(): void {
+    if (!this.terminated) this.emit('message', {type: 'initialization_failed'});
   }
 
   postMessage(message: unknown): void {

--- a/libs/runner/agent/src/core/pi-image-rasterizer.ts
+++ b/libs/runner/agent/src/core/pi-image-rasterizer.ts
@@ -63,7 +63,8 @@ type WorkerFailureReason =
   | 'render_error'
   | 'unsafe_svg'
   | 'protocol_failure';
-type WorkerResponse =
+type WorkerStartupResponse = {type: 'ready'} | {type: 'initialization_failed'};
+type WorkerRenderResponse =
   | {type: 'rendered'; requestId: number; png: ArrayBuffer}
   | {type: 'failed'; requestId: number; reason: WorkerFailureReason};
 type WorkerMessage = {type: 'render'; requestId: number; svg: ArrayBuffer};
@@ -86,6 +87,7 @@ type RenderTask = {
 
 type WorkerSlot = {
   worker: RenderWorker | undefined;
+  ready: boolean;
   task: RenderTask | undefined;
   timer: ReturnType<typeof setTimeout> | undefined;
   replacing: boolean;
@@ -125,10 +127,9 @@ export async function assertPiImageRasterizerAvailable(): Promise<void> {
   const rasterizer = createPiSvgRasterizer({workerUrl: PRODUCTION_WORKER_URL});
   try {
     const withoutText = await rasterizer.rasterize({base64: smokeSvgBase64(false)});
+    assertSmokeRenderConverted('without text', withoutText);
     const withText = await rasterizer.rasterize({base64: smokeSvgBase64(true)});
-    if (withoutText.outcome !== 'converted' || withText.outcome !== 'converted') {
-      throw new Error('Pi SVG rasterizer smoke render was omitted');
-    }
+    assertSmokeRenderConverted('with text', withText);
     if (Buffer.from(withoutText.png).equals(Buffer.from(withText.png))) {
       throw new Error('Pi SVG rasterizer smoke render did not retain text');
     }
@@ -198,6 +199,7 @@ class SvgRenderPool {
     {length: PI_SVG_RASTERIZATION_LIMITS.maxWorkers},
     () => ({
       worker: undefined,
+      ready: false,
       task: undefined,
       timer: undefined,
       replacing: false,
@@ -226,7 +228,8 @@ class SvgRenderPool {
         resolve({ok: false, reason: 'rasterizer_unavailable'});
         return;
       }
-      if (this.queue.length >= PI_SVG_RASTERIZATION_LIMITS.maxQueuedRenders) {
+      const queuedBeyondInitializingWorkers = this.queue.length - this.initializingWorkerCount();
+      if (queuedBeyondInitializingWorkers >= PI_SVG_RASTERIZATION_LIMITS.maxQueuedRenders) {
         resolve({ok: false, reason: 'pool_saturated'});
         return;
       }
@@ -275,7 +278,13 @@ class SvgRenderPool {
     if (this.closed) return;
     while (this.queue.length > 0) {
       const slot = this.availableSlot();
-      if (slot === undefined) return;
+      if (slot === undefined) {
+        if (this.initializingWorkerCount() >= this.queue.length) return;
+        const emptySlot = this.emptySlot();
+        if (emptySlot === undefined) return;
+        this.startWorker(emptySlot);
+        continue;
+      }
       const task = this.queue.shift();
       if (task === undefined) return;
       if (task.queueTimer !== undefined) clearTimeout(task.queueTimer);
@@ -285,7 +294,27 @@ class SvgRenderPool {
   }
 
   private availableSlot(): WorkerSlot | undefined {
-    return this.slots.find((slot) => !slot.replacing && slot.task === undefined);
+    return this.slots.find((slot) => !slot.replacing && slot.ready && slot.task === undefined);
+  }
+
+  private emptySlot(): WorkerSlot | undefined {
+    return this.slots.find((slot) => !slot.replacing && slot.worker === undefined);
+  }
+
+  private initializingWorkerCount(): number {
+    return this.slots.filter((slot) => !slot.replacing && slot.worker !== undefined && !slot.ready)
+      .length;
+  }
+
+  private startWorker(slot: WorkerSlot): void {
+    try {
+      const worker = this.workerFactory(this.workerUrl);
+      slot.worker = worker;
+      slot.ready = false;
+      attachWorker(this, slot, worker);
+    } catch {
+      this.resolveNextQueuedTask({ok: false, reason: 'render_error'});
+    }
   }
 
   private dispatch(slot: WorkerSlot, task: RenderTask): void {
@@ -296,17 +325,11 @@ class SvgRenderPool {
       return;
     }
 
-    let worker = slot.worker;
-    if (worker === undefined) {
-      try {
-        worker = this.workerFactory(this.workerUrl);
-        attachWorker(this, slot, worker);
-        slot.worker = worker;
-      } catch {
-        task.resolve({ok: false, reason: 'render_error'});
-        this.drain();
-        return;
-      }
+    const worker = slot.worker;
+    if (worker === undefined || !slot.ready) {
+      task.resolve({ok: false, reason: 'render_error'});
+      this.drain();
+      return;
     }
 
     slot.task = task;
@@ -367,6 +390,7 @@ class SvgRenderPool {
   private replaceWorker(slot: WorkerSlot, worker: RenderWorker): void {
     if (slot.worker !== worker) return;
     slot.worker = undefined;
+    slot.ready = false;
     slot.replacing = true;
     const termination = terminateWorker(worker);
     slot.termination = termination;
@@ -374,21 +398,33 @@ class SvgRenderPool {
       if (slot.termination === termination) slot.termination = undefined;
       slot.replacing = false;
       if (this.closed) return;
-      try {
-        const replacement = this.workerFactory(this.workerUrl);
-        attachWorker(this, slot, replacement);
-        slot.worker = replacement;
-      } catch {
-        slot.worker = undefined;
-      }
       this.drain();
     });
   }
 
   handleWorkerMessage(slot: WorkerSlot, worker: RenderWorker, value: unknown): void {
+    if (slot.worker !== worker) return;
+    if (!slot.ready) {
+      if (isWorkerStartupResponse(value) && value.type === 'ready') {
+        slot.ready = true;
+        this.drain();
+        return;
+      }
+      this.resolveNextQueuedTask({
+        ok: false,
+        reason:
+          isWorkerStartupResponse(value) && value.type === 'initialization_failed'
+            ? 'rasterizer_unavailable'
+            : 'render_error',
+      });
+      this.replaceWorker(slot, worker);
+      this.drain();
+      return;
+    }
+
     const task = slot.task;
-    if (task === undefined || slot.worker !== worker) return;
-    if (!isWorkerResponse(value) || value.requestId !== task.id) {
+    if (task === undefined) return;
+    if (!isWorkerRenderResponse(value) || value.requestId !== task.id) {
       this.finishTask(slot, worker, task, {ok: false, reason: 'render_error'}, true);
       return;
     }
@@ -429,6 +465,13 @@ class SvgRenderPool {
   }
 
   handleWorkerError(slot: WorkerSlot, worker: RenderWorker): void {
+    if (slot.worker !== worker) return;
+    if (!slot.ready) {
+      this.resolveNextQueuedTask({ok: false, reason: 'rasterizer_unavailable'});
+      this.replaceWorker(slot, worker);
+      this.drain();
+      return;
+    }
     const task = slot.task;
     if (task === undefined) {
       this.replaceWorker(slot, worker);
@@ -439,6 +482,12 @@ class SvgRenderPool {
 
   handleWorkerExit(slot: WorkerSlot, worker: RenderWorker): void {
     if (slot.worker !== worker) return;
+    if (!slot.ready) {
+      this.resolveNextQueuedTask({ok: false, reason: 'rasterizer_unavailable'});
+      this.replaceWorker(slot, worker);
+      this.drain();
+      return;
+    }
     const task = slot.task;
     if (task === undefined) {
       this.replaceWorker(slot, worker);
@@ -461,8 +510,29 @@ class SvgRenderPool {
       this.queue.splice(index, 1);
       task.queueTimer = undefined;
       task.resolve({ok: false, reason: 'result_budget_exhausted'});
+      this.discardSurplusInitializingWorkers();
       this.drain();
     }, remainingMs);
+  }
+
+  private discardSurplusInitializingWorkers(): void {
+    let surplus = this.initializingWorkerCount() - this.queue.length;
+    if (surplus <= 0) return;
+    for (const slot of this.slots) {
+      const worker = slot.worker;
+      if (surplus <= 0) return;
+      if (slot.replacing || worker === undefined || slot.ready) continue;
+      this.replaceWorker(slot, worker);
+      surplus -= 1;
+    }
+  }
+
+  private resolveNextQueuedTask(result: PoolResult): void {
+    const task = this.queue.shift();
+    if (task === undefined) return;
+    if (task.queueTimer !== undefined) clearTimeout(task.queueTimer);
+    task.queueTimer = undefined;
+    task.resolve(result);
   }
 }
 
@@ -488,7 +558,13 @@ function ignoreWorkerError(): void {
   return;
 }
 
-function isWorkerResponse(value: unknown): value is WorkerResponse {
+function isWorkerStartupResponse(value: unknown): value is WorkerStartupResponse {
+  if (typeof value !== 'object' || value === null) return false;
+  const type = (value as {type?: unknown}).type;
+  return type === 'ready' || type === 'initialization_failed';
+}
+
+function isWorkerRenderResponse(value: unknown): value is WorkerRenderResponse {
   if (typeof value !== 'object' || value === null) return false;
   const candidate = value as {
     type?: unknown;
@@ -573,6 +649,16 @@ function omitted(
     ...(inputBytes === undefined ? {} : {inputBytes}),
     durationMs: durationSince(startedAt),
   };
+}
+
+function assertSmokeRenderConverted(
+  label: string,
+  result: SvgRasterizationResult,
+): asserts result is Extract<SvgRasterizationResult, {outcome: 'converted'}> {
+  if (result.outcome === 'converted') return;
+  throw new Error(
+    `Pi SVG rasterizer smoke render ${label} was omitted: ${result.reason} after ${result.durationMs}ms`,
+  );
 }
 
 function durationSince(startedAt: number): number {

--- a/libs/runner/agent/src/core/pi-image-rasterizer.ts
+++ b/libs/runner/agent/src/core/pi-image-rasterizer.ts
@@ -10,6 +10,12 @@ import {
   PI_SVG_LICENSE_ASSET_FILENAME,
   PI_SVG_RASTERIZATION_LIMITS,
 } from './pi-svg-render-config.js';
+import type {
+  SvgRenderWorkerFailureReason,
+  SvgRenderWorkerRenderResponse,
+  SvgRenderWorkerRequest,
+  SvgRenderWorkerStartupResponse,
+} from './pi-svg-render-protocol.js';
 
 export {PI_SVG_RASTERIZATION_LIMITS} from './pi-svg-render-config.js';
 
@@ -56,18 +62,6 @@ export type SvgRasterizationResult =
       durationMs: number;
     };
 
-type WorkerFailureReason =
-  | 'external_resource'
-  | 'output_too_large'
-  | 'rasterizer_unavailable'
-  | 'render_error'
-  | 'unsafe_svg'
-  | 'protocol_failure';
-type WorkerStartupResponse = {type: 'ready'} | {type: 'initialization_failed'};
-type WorkerRenderResponse =
-  | {type: 'rendered'; requestId: number; png: ArrayBuffer}
-  | {type: 'failed'; requestId: number; reason: WorkerFailureReason};
-type WorkerMessage = {type: 'render'; requestId: number; svg: ArrayBuffer};
 type RenderWorker = Pick<Worker, 'on' | 'postMessage' | 'removeAllListeners' | 'terminate'> & {
   unref?: () => void;
 };
@@ -312,9 +306,19 @@ class SvgRenderPool {
       slot.worker = worker;
       slot.ready = false;
       attachWorker(this, slot, worker);
+      slot.timer = setTimeout(
+        () => this.failWorkerStartup(slot, worker),
+        PI_SVG_RASTERIZATION_LIMITS.resultBudgetMs,
+      );
     } catch {
       this.resolveNextQueuedTask({ok: false, reason: 'render_error'});
     }
+  }
+
+  private failWorkerStartup(slot: WorkerSlot, worker: RenderWorker): void {
+    if (slot.worker !== worker || slot.ready) return;
+    this.replaceWorker(slot, worker);
+    this.drain();
   }
 
   private dispatch(slot: WorkerSlot, task: RenderTask): void {
@@ -341,7 +345,7 @@ class SvgRenderPool {
     );
 
     const svg = arrayBufferOf(task.bytes);
-    const message: WorkerMessage = {type: 'render', requestId: task.id, svg};
+    const message: SvgRenderWorkerRequest = {type: 'render', requestId: task.id, svg};
     try {
       worker.postMessage(message, [svg]);
     } catch {
@@ -389,6 +393,8 @@ class SvgRenderPool {
 
   private replaceWorker(slot: WorkerSlot, worker: RenderWorker): void {
     if (slot.worker !== worker) return;
+    if (slot.timer !== undefined) clearTimeout(slot.timer);
+    slot.timer = undefined;
     slot.worker = undefined;
     slot.ready = false;
     slot.replacing = true;
@@ -405,20 +411,7 @@ class SvgRenderPool {
   handleWorkerMessage(slot: WorkerSlot, worker: RenderWorker, value: unknown): void {
     if (slot.worker !== worker) return;
     if (!slot.ready) {
-      if (isWorkerStartupResponse(value) && value.type === 'ready') {
-        slot.ready = true;
-        this.drain();
-        return;
-      }
-      this.resolveNextQueuedTask({
-        ok: false,
-        reason:
-          isWorkerStartupResponse(value) && value.type === 'initialization_failed'
-            ? 'rasterizer_unavailable'
-            : 'render_error',
-      });
-      this.replaceWorker(slot, worker);
-      this.drain();
+      this.handleWorkerStartupMessage(slot, worker, value);
       return;
     }
 
@@ -464,10 +457,28 @@ class SvgRenderPool {
     );
   }
 
+  private handleWorkerStartupMessage(slot: WorkerSlot, worker: RenderWorker, value: unknown): void {
+    if (isWorkerStartupResponse(value) && value.type === 'ready') {
+      if (slot.timer !== undefined) clearTimeout(slot.timer);
+      slot.timer = undefined;
+      slot.ready = true;
+      this.drain();
+      return;
+    }
+    this.failNextQueuedTaskWithoutAlternative(
+      slot,
+      isWorkerStartupResponse(value) && value.type === 'initialization_failed'
+        ? 'rasterizer_unavailable'
+        : 'render_error',
+    );
+    this.replaceWorker(slot, worker);
+    this.drain();
+  }
+
   handleWorkerError(slot: WorkerSlot, worker: RenderWorker): void {
     if (slot.worker !== worker) return;
     if (!slot.ready) {
-      this.resolveNextQueuedTask({ok: false, reason: 'rasterizer_unavailable'});
+      this.failNextQueuedTaskWithoutAlternative(slot, 'rasterizer_unavailable');
       this.replaceWorker(slot, worker);
       this.drain();
       return;
@@ -483,7 +494,7 @@ class SvgRenderPool {
   handleWorkerExit(slot: WorkerSlot, worker: RenderWorker): void {
     if (slot.worker !== worker) return;
     if (!slot.ready) {
-      this.resolveNextQueuedTask({ok: false, reason: 'rasterizer_unavailable'});
+      this.failNextQueuedTaskWithoutAlternative(slot, 'rasterizer_unavailable');
       this.replaceWorker(slot, worker);
       this.drain();
       return;
@@ -534,6 +545,16 @@ class SvgRenderPool {
     task.queueTimer = undefined;
     task.resolve(result);
   }
+
+  private failNextQueuedTaskWithoutAlternative(
+    failedSlot: WorkerSlot,
+    reason: SvgRasterizationReason,
+  ): void {
+    const hasAlternativeWorker = this.slots.some(
+      (slot) => slot !== failedSlot && slot.worker !== undefined,
+    );
+    if (!hasAlternativeWorker) this.resolveNextQueuedTask({ok: false, reason});
+  }
 }
 
 function attachWorker(pool: SvgRenderPool, slot: WorkerSlot, worker: RenderWorker): void {
@@ -558,13 +579,13 @@ function ignoreWorkerError(): void {
   return;
 }
 
-function isWorkerStartupResponse(value: unknown): value is WorkerStartupResponse {
+function isWorkerStartupResponse(value: unknown): value is SvgRenderWorkerStartupResponse {
   if (typeof value !== 'object' || value === null) return false;
   const type = (value as {type?: unknown}).type;
   return type === 'ready' || type === 'initialization_failed';
 }
 
-function isWorkerRenderResponse(value: unknown): value is WorkerRenderResponse {
+function isWorkerRenderResponse(value: unknown): value is SvgRenderWorkerRenderResponse {
   if (typeof value !== 'object' || value === null) return false;
   const candidate = value as {
     type?: unknown;
@@ -581,25 +602,26 @@ function isWorkerRenderResponse(value: unknown): value is WorkerRenderResponse {
     return false;
   }
   if (candidate.type === 'rendered') return candidate.png instanceof ArrayBuffer;
-  return (
-    candidate.reason === 'external_resource' ||
-    candidate.reason === 'output_too_large' ||
-    candidate.reason === 'rasterizer_unavailable' ||
-    candidate.reason === 'render_error' ||
-    candidate.reason === 'unsafe_svg' ||
-    candidate.reason === 'protocol_failure'
-  );
+  return isWorkerFailureReason(candidate.reason);
 }
 
-function shouldReplaceAfterFailure(reason: WorkerFailureReason): boolean {
-  return (
-    reason === 'rasterizer_unavailable' ||
-    reason === 'render_error' ||
-    reason === 'protocol_failure'
-  );
+const WORKER_FAILURE_REASONS = {
+  external_resource: true,
+  output_too_large: true,
+  protocol_failure: true,
+  render_error: true,
+  unsafe_svg: true,
+} satisfies Record<SvgRenderWorkerFailureReason, true>;
+
+function isWorkerFailureReason(value: unknown): value is SvgRenderWorkerFailureReason {
+  return typeof value === 'string' && Object.hasOwn(WORKER_FAILURE_REASONS, value);
 }
 
-function mapWorkerFailure(reason: WorkerFailureReason): SvgRasterizationReason {
+function shouldReplaceAfterFailure(reason: SvgRenderWorkerFailureReason): boolean {
+  return reason === 'render_error' || reason === 'protocol_failure';
+}
+
+function mapWorkerFailure(reason: SvgRenderWorkerFailureReason): SvgRasterizationReason {
   return reason === 'protocol_failure' ? 'render_error' : reason;
 }
 

--- a/libs/runner/agent/src/core/pi-svg-render-protocol.ts
+++ b/libs/runner/agent/src/core/pi-svg-render-protocol.ts
@@ -1,0 +1,22 @@
+export type SvgRenderWorkerFailureReason =
+  | 'external_resource'
+  | 'output_too_large'
+  | 'render_error'
+  | 'unsafe_svg'
+  | 'protocol_failure';
+
+export type SvgRenderWorkerRequest = {
+  type: 'render';
+  requestId: number;
+  svg: ArrayBuffer;
+};
+
+export type SvgRenderWorkerStartupResponse = {type: 'ready'} | {type: 'initialization_failed'};
+
+export type SvgRenderWorkerRenderResponse =
+  | {type: 'rendered'; requestId: number; png: ArrayBuffer}
+  | {type: 'failed'; requestId: number; reason: SvgRenderWorkerFailureReason};
+
+export type SvgRenderWorkerResponse =
+  | SvgRenderWorkerStartupResponse
+  | SvgRenderWorkerRenderResponse;

--- a/libs/runner/agent/src/core/pi-svg-render-worker.ts
+++ b/libs/runner/agent/src/core/pi-svg-render-worker.ts
@@ -29,18 +29,32 @@ type WorkerFailureReason =
   | 'render_error'
   | 'unsafe_svg'
   | 'protocol_failure';
-type RenderResponse =
+type WorkerStartupResponse = {type: 'ready'} | {type: 'initialization_failed'};
+type WorkerRenderResponse =
   | {type: 'rendered'; requestId: number; png: ArrayBuffer}
   | {type: 'failed'; requestId: number; reason: WorkerFailureReason};
+type WorkerResponse = WorkerStartupResponse | WorkerRenderResponse;
 
 if (parentPort === null) throw new Error('SVG render worker has no parent port');
 const port = parentPort;
 
-port.on('message', (message: unknown) => {
-  void handleMessage(message);
-});
+await startWorker();
 
-async function handleMessage(message: unknown): Promise<void> {
+async function startWorker(): Promise<void> {
+  try {
+    await initializeRenderer();
+  } catch {
+    post({type: 'initialization_failed'});
+    return;
+  }
+
+  port.on('message', (message: unknown) => {
+    handleMessage(message);
+  });
+  post({type: 'ready'});
+}
+
+function handleMessage(message: unknown): void {
   const requestId = requestIdOf(message);
   if (!isRenderRequest(message)) {
     post({type: 'failed', requestId, reason: 'protocol_failure'});
@@ -55,13 +69,6 @@ async function handleMessage(message: unknown): Promise<void> {
   }
 
   try {
-    await initializeRenderer();
-  } catch {
-    post({type: 'failed', requestId, reason: 'rasterizer_unavailable'});
-    return;
-  }
-
-  try {
     const response = renderSvg(requestId, svg);
     if (response.type === 'rendered') port.postMessage(response, [response.png]);
     else post(response);
@@ -70,7 +77,7 @@ async function handleMessage(message: unknown): Promise<void> {
   }
 }
 
-function renderSvg(requestId: number, svg: Uint8Array): RenderResponse {
+function renderSvg(requestId: number, svg: Uint8Array): WorkerRenderResponse {
   const renderer = new Resvg(svg, {
     font: fontOptions(),
   });
@@ -167,7 +174,7 @@ function fontOptions(): CustomFontsOptions {
   };
 }
 
-function renderPng(requestId: number, renderer: InstanceType<typeof Resvg>): RenderResponse {
+function renderPng(requestId: number, renderer: InstanceType<typeof Resvg>): WorkerRenderResponse {
   const rendered = renderer.render();
   try {
     const png = rendered.asPng();
@@ -201,6 +208,6 @@ function requestIdOf(value: unknown): number {
     : 0;
 }
 
-function post(response: RenderResponse): void {
+function post(response: WorkerResponse): void {
   port.postMessage(response);
 }

--- a/libs/runner/agent/src/core/pi-svg-render-worker.ts
+++ b/libs/runner/agent/src/core/pi-svg-render-worker.ts
@@ -2,6 +2,11 @@ import {readFile} from 'node:fs/promises';
 import {createRequire} from 'node:module';
 import {parentPort} from 'node:worker_threads';
 import {type CustomFontsOptions, initWasm, Resvg} from '@resvg/resvg-wasm';
+import type {
+  SvgRenderWorkerRenderResponse,
+  SvgRenderWorkerRequest,
+  SvgRenderWorkerResponse,
+} from './pi-svg-render-protocol.js';
 
 const sourceExtension = import.meta.url.endsWith('.ts') ? 'ts' : 'js';
 const {validatePngOutput} = await import(`./pi-png.${sourceExtension}`);
@@ -20,20 +25,6 @@ const require = createRequire(import.meta.url);
 let fontBuffers: Uint8Array[] | undefined;
 let fontFamily: string | undefined;
 let initialization: Promise<void> | undefined;
-
-type RenderRequest = {type: 'render'; requestId: number; svg: ArrayBuffer};
-type WorkerFailureReason =
-  | 'external_resource'
-  | 'output_too_large'
-  | 'rasterizer_unavailable'
-  | 'render_error'
-  | 'unsafe_svg'
-  | 'protocol_failure';
-type WorkerStartupResponse = {type: 'ready'} | {type: 'initialization_failed'};
-type WorkerRenderResponse =
-  | {type: 'rendered'; requestId: number; png: ArrayBuffer}
-  | {type: 'failed'; requestId: number; reason: WorkerFailureReason};
-type WorkerResponse = WorkerStartupResponse | WorkerRenderResponse;
 
 if (parentPort === null) throw new Error('SVG render worker has no parent port');
 const port = parentPort;
@@ -77,7 +68,7 @@ function handleMessage(message: unknown): void {
   }
 }
 
-function renderSvg(requestId: number, svg: Uint8Array): WorkerRenderResponse {
+function renderSvg(requestId: number, svg: Uint8Array): SvgRenderWorkerRenderResponse {
   const renderer = new Resvg(svg, {
     font: fontOptions(),
   });
@@ -174,7 +165,10 @@ function fontOptions(): CustomFontsOptions {
   };
 }
 
-function renderPng(requestId: number, renderer: InstanceType<typeof Resvg>): WorkerRenderResponse {
+function renderPng(
+  requestId: number,
+  renderer: InstanceType<typeof Resvg>,
+): SvgRenderWorkerRenderResponse {
   const rendered = renderer.render();
   try {
     const png = rendered.asPng();
@@ -188,9 +182,9 @@ function renderPng(requestId: number, renderer: InstanceType<typeof Resvg>): Wor
   }
 }
 
-function isRenderRequest(value: unknown): value is RenderRequest {
+function isRenderRequest(value: unknown): value is SvgRenderWorkerRequest {
   if (typeof value !== 'object' || value === null) return false;
-  const candidate = value as Partial<RenderRequest>;
+  const candidate = value as Partial<SvgRenderWorkerRequest>;
   return (
     candidate.type === 'render' &&
     typeof candidate.requestId === 'number' &&
@@ -208,6 +202,6 @@ function requestIdOf(value: unknown): number {
     : 0;
 }
 
-function post(response: WorkerResponse): void {
+function post(response: SvgRenderWorkerResponse): void {
   port.postMessage(response);
 }


### PR DESCRIPTION
The runner image build performs a real Pi SVG rasterizer smoke render to verify that the packaged worker, WASM, and fonts are usable. Under emulation, cold renderer initialization could consume the two-second render deadline and intermittently fail an otherwise valid image.

Make worker startup explicit: workers initialize their renderer before announcing readiness, and the render deadline starts only after that signal. The existing five-second total result budget and two-second render deadline remain unchanged. An independent watchdog bounds each initializer at the existing total budget, and failed initialization preserves queued work when another worker can serve it.

This keeps production-closure verification in the image build while separating variable cold-start cost from bounded render execution. The worker protocol now has one shared definition, and smoke failures report their reason and duration.

Validation:
- `turbo check type test build --filter=@shipfox/runner-agent...`: 126/126 tasks passed
- runner-agent tests: 384 passed
- `turbo image --filter=@shipfox/runner`: 34/34 tasks passed; production verification completed in 1.5s under linux/amd64-on-arm64 emulation
- `pnpm exec changeset status --since=origin/main`
- `git diff --check`

The exact linux/arm64-on-x64 emulation path from the original failure is left to hosted CI.