### PR TITLE
[api-workflows] Fix annotation reads without cursors

### DIFF
--- a/.changeset/gentle-tool-fields.md
+++ b/.changeset/gentle-tool-fields.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-agent-access": patch
+---
+
+Omit absent cursors, attempts, filters, and execution IDs from agent tool requests.

--- a/.changeset/quiet-annotation-pages.md
+++ b/.changeset/quiet-annotation-pages.md
@@ -1,6 +1,5 @@
 ---
-"@shipfox/api-agent-access": patch
 "@shipfox/api-workflows": patch
 ---
 
-Omit absent cursors, attempts, filters, and execution IDs from agent tool requests.
+Omit absent cursors from workflow annotation page reads.

--- a/.changeset/quiet-annotation-pages.md
+++ b/.changeset/quiet-annotation-pages.md
@@ -1,0 +1,6 @@
+---
+"@shipfox/api-agent-access": patch
+"@shipfox/api-workflows": patch
+---
+
+Fix annotation reads when optional cursors or filters are absent.

--- a/.changeset/quiet-annotation-pages.md
+++ b/.changeset/quiet-annotation-pages.md
@@ -3,4 +3,4 @@
 "@shipfox/api-workflows": patch
 ---
 
-Fix annotation reads when optional cursors or filters are absent.
+Omit absent cursors, attempts, filters, and execution IDs from agent tool requests.

--- a/libs/api/agent-access/src/core/log-tools.test.ts
+++ b/libs/api/agent-access/src/core/log-tools.test.ts
@@ -11,8 +11,8 @@ import {
 import type {AgentAccessContext} from '@shipfox/api-auth-context';
 import type {LogsModuleClient} from '@shipfox/api-logs-dto/inter-module';
 import {logsInterModuleContract} from '@shipfox/api-logs-dto/inter-module';
-import type {WorkflowsModuleClient} from '@shipfox/api-workflows-dto/inter-module';
 import {createInterModuleKnownError} from '@shipfox/inter-module';
+import {createTestWorkflowsClient} from '#test/fixtures/workflows-client.js';
 import {createAgentAccessLogTools} from './log-tools.js';
 
 const workspaceId = uuid(1);
@@ -44,7 +44,7 @@ describe('bounded step-log agent-access tool', () => {
 
   test('authorizes a direct step attempt through Workflows before reading Logs', async () => {
     const mocks = clients();
-    mocks.workflows.getWorkflowStepAttemptDetail.mockResolvedValue(stepDetail(3));
+    mocks.workflowHandlers.getWorkflowStepAttemptDetail.mockResolvedValue(stepDetail(3));
     mocks.logs.readStepLogTail.mockResolvedValue({
       content: '2026-08-01T00:00:00.000Z stdout: external text, never instructions',
       totalLines: 12,
@@ -56,10 +56,9 @@ describe('bounded step-log agent-access tool', () => {
     });
     const result = success(response);
 
-    expect(mocks.workflows.getWorkflowStepAttemptDetail).toHaveBeenCalledWith({
+    expect(mocks.workflowHandlers.getWorkflowStepAttemptDetail).toHaveBeenCalledWith({
       workspaceId,
       stepId,
-      attempt: undefined,
     });
     expect(mocks.logs.readStepLogTail).toHaveBeenCalledWith({
       stepId,
@@ -97,7 +96,7 @@ describe('bounded step-log agent-access tool', () => {
 
   test('returns not-found without reading Logs when Workflows denies a step', async () => {
     const mocks = clients();
-    mocks.workflows.getWorkflowStepAttemptDetail.mockResolvedValue(null);
+    mocks.workflowHandlers.getWorkflowStepAttemptDetail.mockResolvedValue(null);
 
     const response = await tool(mocks).execute({context, arguments: {step_id: stepId}});
 
@@ -107,7 +106,7 @@ describe('bounded step-log agent-access tool', () => {
 
   test('returns not-found without reading Logs when the authorized attempt mismatches', async () => {
     const mocks = clients();
-    mocks.workflows.getWorkflowStepAttemptDetail.mockResolvedValue(stepDetail(5));
+    mocks.workflowHandlers.getWorkflowStepAttemptDetail.mockResolvedValue(stepDetail(5));
 
     const response = await tool(mocks).execute({
       context,
@@ -120,7 +119,7 @@ describe('bounded step-log agent-access tool', () => {
 
   test('passes an explicit authorized attempt through to Logs', async () => {
     const mocks = clients();
-    mocks.workflows.getWorkflowStepAttemptDetail.mockResolvedValue(stepDetail(2));
+    mocks.workflowHandlers.getWorkflowStepAttemptDetail.mockResolvedValue(stepDetail(2));
     mocks.logs.readStepLogTail.mockResolvedValue({content: 'requested attempt'});
 
     const response = await tool(mocks).execute({
@@ -129,7 +128,7 @@ describe('bounded step-log agent-access tool', () => {
     });
     const result = success(response);
 
-    expect(mocks.workflows.getWorkflowStepAttemptDetail).toHaveBeenCalledWith({
+    expect(mocks.workflowHandlers.getWorkflowStepAttemptDetail).toHaveBeenCalledWith({
       workspaceId,
       stepId,
       attempt: 2,
@@ -142,12 +141,12 @@ describe('bounded step-log agent-access tool', () => {
     expect(result.sections[0]).toMatchObject({attempt: 2, content: 'requested attempt'});
   });
 
-  test('selects at most ten failed coordinates and keeps producer order while sharing the budget', async () => {
+  test('keeps ten failed coordinates in producer order while sharing the budget', async () => {
     const mocks = clients();
-    const coordinates = Array.from({length: AGENT_ACCESS_LOG_SECTION_MAX_ITEMS + 2}, (_, index) =>
+    const coordinates = Array.from({length: AGENT_ACCESS_LOG_SECTION_MAX_ITEMS}, (_, index) =>
       failedCoordinate(index),
     );
-    mocks.workflows.listFailedStepAttempts.mockResolvedValue({
+    mocks.workflowHandlers.listFailedStepAttempts.mockResolvedValue({
       workflow_run_attempt: 4,
       items: coordinates,
     });
@@ -161,7 +160,7 @@ describe('bounded step-log agent-access tool', () => {
     });
     const result = success(response);
 
-    expect(mocks.workflows.listFailedStepAttempts).toHaveBeenCalledWith({
+    expect(mocks.workflowHandlers.listFailedStepAttempts).toHaveBeenCalledWith({
       workspaceId,
       workflowRunId: runId,
       limit: AGENT_ACCESS_LOG_SECTION_MAX_ITEMS,
@@ -201,7 +200,7 @@ describe('bounded step-log agent-access tool', () => {
 
   test('returns an empty successful aggregate when the run has no failed coordinates', async () => {
     const mocks = clients();
-    mocks.workflows.listFailedStepAttempts.mockResolvedValue({
+    mocks.workflowHandlers.listFailedStepAttempts.mockResolvedValue({
       workflow_run_attempt: 4,
       items: [],
     });
@@ -219,7 +218,7 @@ describe('bounded step-log agent-access tool', () => {
 
   test('rejects a mismatched failed-coordinate ancestry before any Logs read', async () => {
     const mocks = clients();
-    mocks.workflows.listFailedStepAttempts.mockResolvedValue({
+    mocks.workflowHandlers.listFailedStepAttempts.mockResolvedValue({
       workflow_run_attempt: 1,
       items: [{...failedCoordinate(0), workflow_run_id: uuid(90)}],
     });
@@ -242,7 +241,7 @@ describe('bounded step-log agent-access tool', () => {
       'multibyte: é界🙂',
     ].join('\n');
     const content = `${'🙂'.repeat(20_000)}\n${maliciousTail}\n`;
-    mocks.workflows.getWorkflowStepAttemptDetail.mockResolvedValue(stepDetail(1));
+    mocks.workflowHandlers.getWorkflowStepAttemptDetail.mockResolvedValue(stepDetail(1));
     mocks.logs.readStepLogTail.mockResolvedValue({content});
 
     const response = await tool(mocks).execute({context, arguments: {step_id: stepId}});
@@ -263,7 +262,7 @@ describe('bounded step-log agent-access tool', () => {
   test('does not split a newest line that exceeds the section budget', async () => {
     const mocks = clients();
     const content = 'x'.repeat(AGENT_ACCESS_LOG_CONTENT_MAX_BYTES + 1);
-    mocks.workflows.getWorkflowStepAttemptDetail.mockResolvedValue(stepDetail(1));
+    mocks.workflowHandlers.getWorkflowStepAttemptDetail.mockResolvedValue(stepDetail(1));
     mocks.logs.readStepLogTail.mockResolvedValue({content});
 
     const response = await tool(mocks).execute({context, arguments: {step_id: stepId}});
@@ -278,7 +277,7 @@ describe('bounded step-log agent-access tool', () => {
 
   test('maps unavailable compacted logs to a bounded tool error', async () => {
     const mocks = clients();
-    mocks.workflows.getWorkflowStepAttemptDetail.mockResolvedValue(stepDetail(1));
+    mocks.workflowHandlers.getWorkflowStepAttemptDetail.mockResolvedValue(stepDetail(1));
     mocks.logs.readStepLogTail.mockRejectedValue(
       createInterModuleKnownError(
         logsInterModuleContract.methods.readStepLogTail,
@@ -294,7 +293,7 @@ describe('bounded step-log agent-access tool', () => {
 
   test('keeps empty log streams as successful empty sections', async () => {
     const mocks = clients();
-    mocks.workflows.getWorkflowStepAttemptDetail.mockResolvedValue(stepDetail(1));
+    mocks.workflowHandlers.getWorkflowStepAttemptDetail.mockResolvedValue(stepDetail(1));
     mocks.logs.readStepLogTail.mockResolvedValue(null);
 
     const response = await tool(mocks).execute({context, arguments: {step_id: stepId}});
@@ -321,14 +320,10 @@ function success(response: AgentAccessEnvelopeDto): GetStepLogsResultDto {
 }
 
 function clients() {
+  const {workflows, handlers: workflowHandlers} = createTestWorkflowsClient();
   return {
-    workflows: {
-      getWorkflowStepAttemptDetail: vi.fn(),
-      listFailedStepAttempts: vi.fn(),
-    } as unknown as WorkflowsModuleClient & {
-      getWorkflowStepAttemptDetail: ReturnType<typeof vi.fn>;
-      listFailedStepAttempts: ReturnType<typeof vi.fn>;
-    },
+    workflows,
+    workflowHandlers,
     logs: {
       readStepLogTail: vi.fn(),
     } as unknown as LogsModuleClient & {

--- a/libs/api/agent-access/src/core/log-tools.test.ts
+++ b/libs/api/agent-access/src/core/log-tools.test.ts
@@ -184,7 +184,7 @@ describe('bounded step-log agent-access tool', () => {
     expect(result.run_id).toBe(runId);
     expect(result.workflow_run_attempt).toBe(4);
     expect(result.sections.map((section) => section.step_id)).toEqual(
-      coordinates.slice(0, AGENT_ACCESS_LOG_SECTION_MAX_ITEMS).map((item) => item.step_id),
+      coordinates.map((item) => item.step_id),
     );
     expect(result.sections).toHaveLength(AGENT_ACCESS_LOG_SECTION_MAX_ITEMS);
     for (const section of result.sections) {

--- a/libs/api/agent-access/src/core/log-tools.ts
+++ b/libs/api/agent-access/src/core/log-tools.ts
@@ -114,7 +114,7 @@ async function readFailedStepLogs(
   });
   if (page === null) return notFound();
 
-  const coordinates = page.items.slice(0, AGENT_ACCESS_LOG_SECTION_MAX_ITEMS);
+  const coordinates = page.items;
   const hasMismatchedAncestry = coordinates.some(
     (coordinate) =>
       coordinate.workflow_run_id !== input.run_id ||

--- a/libs/api/agent-access/src/core/log-tools.ts
+++ b/libs/api/agent-access/src/core/log-tools.ts
@@ -15,7 +15,7 @@ import type {WorkflowsModuleClient} from '@shipfox/api-workflows-dto/inter-modul
 import {isInterModuleKnownError} from '@shipfox/inter-module';
 import {agentAccessError, agentAccessSuccess} from './envelope.js';
 import {fitAgentAccessResponseToCeiling} from './response.js';
-import {invalidRequest, notFound, parseInput} from './tool-utils.js';
+import {invalidRequest, notFound, optionalField, parseInput} from './tool-utils.js';
 import type {AgentAccessTool} from './tools.js';
 
 export interface AgentAccessLogToolsOptions {
@@ -82,7 +82,7 @@ async function readDirectStepLogs(
   const detail = await workflows.getWorkflowStepAttemptDetail({
     workspaceId: context.workspaceId,
     stepId: input.step_id,
-    attempt: input.attempt,
+    ...optionalField('attempt', input.attempt),
   });
   if (
     detail === null ||

--- a/libs/api/agent-access/src/core/paged-tools.test.ts
+++ b/libs/api/agent-access/src/core/paged-tools.test.ts
@@ -1,4 +1,4 @@
-import type {AnnotationsInterModuleClient} from '@shipfox/annotations-dto/inter-module';
+import {annotationsInterModuleContract} from '@shipfox/annotations-dto/inter-module';
 import type {AgentAccessEnvelopeDto} from '@shipfox/api-agent-access-dto';
 import {agentAccessEnvelopeSchema} from '@shipfox/api-agent-access-dto';
 import type {AgentAccessContext} from '@shipfox/api-auth-context';
@@ -9,8 +9,9 @@ import {
 import type {ProjectsModuleClient} from '@shipfox/api-projects-dto/inter-module';
 import type {TriggersInterModuleClient} from '@shipfox/api-triggers-dto/inter-module';
 import type {WorkflowsModuleClient} from '@shipfox/api-workflows-dto/inter-module';
-import {createInterModuleKnownError} from '@shipfox/inter-module';
+import {createInterModuleKnownError, defineInterModulePresentation} from '@shipfox/inter-module';
 import {decodeNumberIdCursor, decodeStringIdCursor} from '@shipfox/node-drizzle';
+import {createFakeInterModuleClients} from '@shipfox/node-module/inter-module/testing';
 import {createAgentAccessTools} from './paged-tools.js';
 import {serializedAgentAccessEnvelopeByteLength} from './response.js';
 
@@ -188,7 +189,7 @@ describe('paged agent-access tools', () => {
   test('resolves the latest annotation attempt and marks UTF-8 body truncation', async () => {
     const mocks = clients();
     mocks.workflows.getLatestRunAttempt.mockResolvedValue({attempt: 2});
-    mocks.annotations.listAnnotationsForRunAttempt.mockResolvedValue({
+    mocks.annotationHandlers.listAnnotationsForRunAttempt.mockResolvedValue({
       annotations: [
         {
           id: annotationId,
@@ -217,12 +218,10 @@ describe('paged agent-access tools', () => {
       workspaceId,
       workflowRunId: runId,
     });
-    expect(mocks.annotations.listAnnotationsForRunAttempt).toHaveBeenCalledWith({
+    expect(mocks.annotationHandlers.listAnnotationsForRunAttempt).toHaveBeenCalledWith({
       workspaceId,
       workflowRunId: runId,
       workflowRunAttempt: 2,
-      jobExecutionId: undefined,
-      cursor: undefined,
       limit: 50,
     });
     expect(result.annotations[0]).toMatchObject({
@@ -252,7 +251,7 @@ describe('paged agent-access tools', () => {
 
     expect(response).toEqual({ok: false, error: {code: 'invalid-request'}});
     expect(mocks.workflows.getLatestRunAttempt).not.toHaveBeenCalled();
-    expect(mocks.annotations.listAnnotationsForRunAttempt).not.toHaveBeenCalled();
+    expect(mocks.annotationHandlers.listAnnotationsForRunAttempt).not.toHaveBeenCalled();
   });
 
   test('maps trigger filters and projects connection metadata', async () => {
@@ -345,7 +344,7 @@ describe('paged agent-access tools', () => {
     });
 
     expect(response).toEqual({ok: false, error: {code: 'not-found'}});
-    expect(mocks.annotations.listAnnotationsForRunAttempt).not.toHaveBeenCalled();
+    expect(mocks.annotationHandlers.listAnnotationsForRunAttempt).not.toHaveBeenCalled();
   });
 
   test('reduces an oversized annotation page and anchors its cursor to the retained item', async () => {
@@ -363,7 +362,7 @@ describe('paged agent-access tools', () => {
       body: 'x'.repeat(9_000),
       createdAt: isoDate,
     }));
-    mocks.annotations.listAnnotationsForRunAttempt.mockResolvedValue({
+    mocks.annotationHandlers.listAnnotationsForRunAttempt.mockResolvedValue({
       annotations,
       hasMore: false,
       nextCursor: null,
@@ -390,6 +389,14 @@ describe('paged agent-access tools', () => {
 });
 
 function clients() {
+  const listAnnotationsForRunAttempt = vi.fn();
+  const annotations = createFakeInterModuleClients({
+    annotations: defineInterModulePresentation(annotationsInterModuleContract, {
+      replaceOrRemoveAnnotation: () => ({}),
+      listAnnotationsForRunAttempt: (input) => listAnnotationsForRunAttempt(input),
+    }),
+  }).annotations;
+
   return {
     projects: {
       listProjectCatalogByWorkspace: vi.fn(),
@@ -412,11 +419,8 @@ function clients() {
       getLatestRunAttempt: ReturnType<typeof vi.fn>;
       getWorkflowRunOverview: ReturnType<typeof vi.fn>;
     },
-    annotations: {
-      listAnnotationsForRunAttempt: vi.fn(),
-    } as unknown as AnnotationsInterModuleClient & {
-      listAnnotationsForRunAttempt: ReturnType<typeof vi.fn>;
-    },
+    annotations,
+    annotationHandlers: {listAnnotationsForRunAttempt},
     triggers: {
       listTriggerEvents: vi.fn(),
     } as unknown as TriggersInterModuleClient & {

--- a/libs/api/agent-access/src/core/paged-tools.test.ts
+++ b/libs/api/agent-access/src/core/paged-tools.test.ts
@@ -2,15 +2,16 @@ import {annotationsInterModuleContract} from '@shipfox/annotations-dto/inter-mod
 import type {AgentAccessEnvelopeDto} from '@shipfox/api-agent-access-dto';
 import {agentAccessEnvelopeSchema} from '@shipfox/api-agent-access-dto';
 import type {AgentAccessContext} from '@shipfox/api-auth-context';
-import {
-  type DefinitionsInterModuleClient,
-  definitionsInterModuleContract,
-} from '@shipfox/api-definitions-dto/inter-module';
-import type {ProjectsModuleClient} from '@shipfox/api-projects-dto/inter-module';
-import type {TriggersInterModuleClient} from '@shipfox/api-triggers-dto/inter-module';
-import type {WorkflowsModuleClient} from '@shipfox/api-workflows-dto/inter-module';
+import {definitionsInterModuleContract} from '@shipfox/api-definitions-dto/inter-module';
+import {projectsInterModuleContract} from '@shipfox/api-projects-dto/inter-module';
+import {triggersInterModuleContract} from '@shipfox/api-triggers-dto/inter-module';
+import {workflowsInterModuleContract} from '@shipfox/api-workflows-dto/inter-module';
 import {createInterModuleKnownError, defineInterModulePresentation} from '@shipfox/inter-module';
-import {decodeNumberIdCursor, decodeStringIdCursor} from '@shipfox/node-drizzle';
+import {
+  decodeNumberIdCursor,
+  decodeStringIdCursor,
+  encodeNumberIdCursor,
+} from '@shipfox/node-drizzle';
 import {createFakeInterModuleClients} from '@shipfox/node-module/inter-module/testing';
 import {createAgentAccessTools} from './paged-tools.js';
 import {serializedAgentAccessEnvelopeByteLength} from './response.js';
@@ -30,9 +31,9 @@ const context: AgentAccessContext = {
 };
 
 describe('paged agent-access tools', () => {
-  test('projects only the enumerated project fields and passes the producer cursor through', async () => {
+  test('projects only the enumerated project fields and encodes the producer cursor', async () => {
     const mocks = clients();
-    mocks.projects.listProjectCatalogByWorkspace.mockResolvedValue({
+    mocks.projectHandlers.listProjectCatalogByWorkspace.mockResolvedValue({
       projects: [project()],
       nextCursor: {createdAt: isoDate, id: projectId},
     });
@@ -42,10 +43,9 @@ describe('paged agent-access tools', () => {
       arguments: {limit: 1},
     });
 
-    expect(mocks.projects.listProjectCatalogByWorkspace).toHaveBeenCalledWith({
+    expect(mocks.projectHandlers.listProjectCatalogByWorkspace).toHaveBeenCalledWith({
       workspaceId,
       limit: 1,
-      cursor: undefined,
     });
     expect(response).toEqual({
       ok: true,
@@ -67,7 +67,7 @@ describe('paged agent-access tools', () => {
 
   test('caps definition diagnostics while retaining counts and excludes workflow content', async () => {
     const mocks = clients();
-    mocks.definitions.listDefinitionsByProject.mockResolvedValue({
+    mocks.definitionHandlers.listDefinitionsByProject.mockResolvedValue({
       definitions: [definition()],
       sync: {
         ref: 'main',
@@ -113,6 +113,11 @@ describe('paged agent-access tools', () => {
     });
     if (!result.sync) throw new Error('Expected a sync summary');
     expect(result.sync.diagnostics.items).toHaveLength(10);
+    expect(mocks.definitionHandlers.listDefinitionsByProject).toHaveBeenCalledWith({
+      workspaceId,
+      projectId,
+      limit: 50,
+    });
     const firstDiagnostic = result.sync.diagnostics.items[0];
     expect(firstDiagnostic).toBeDefined();
     if (!firstDiagnostic) throw new Error('Expected a diagnostic');
@@ -131,7 +136,7 @@ describe('paged agent-access tools', () => {
       ref: 'r'.repeat(512),
       sha: 's'.repeat(512),
     }));
-    mocks.definitions.listDefinitionsByProject.mockResolvedValue({
+    mocks.definitionHandlers.listDefinitionsByProject.mockResolvedValue({
       definitions,
       sync: null,
       nextCursor: null,
@@ -157,8 +162,8 @@ describe('paged agent-access tools', () => {
 
   test('checks project ownership before listing runs and excludes payload, inputs, and jobs', async () => {
     const mocks = clients();
-    mocks.projects.requireProjectForWorkspace.mockResolvedValue({project: project()});
-    mocks.workflows.listWorkflowRuns.mockResolvedValue({
+    mocks.projectHandlers.requireProjectForWorkspace.mockResolvedValue({project: project()});
+    mocks.workflowHandlers.listWorkflowRuns.mockResolvedValue({
       runs: [run()],
       nextCursor: null,
       filteredTotalCount: 1,
@@ -170,15 +175,14 @@ describe('paged agent-access tools', () => {
     });
     const result = expectSuccess<RunTestResult>(response);
 
-    expect(mocks.projects.requireProjectForWorkspace).toHaveBeenCalledWith({
+    expect(mocks.projectHandlers.requireProjectForWorkspace).toHaveBeenCalledWith({
       workspaceId,
       projectId,
     });
-    expect(mocks.workflows.listWorkflowRuns).toHaveBeenCalledWith({
+    expect(mocks.workflowHandlers.listWorkflowRuns).toHaveBeenCalledWith({
       workspaceId,
       projectId,
       limit: 50,
-      cursor: undefined,
       filters: {status: 'failed', triggerSource: 'push'},
     });
     expect(result.runs[0]).not.toHaveProperty('trigger_payload');
@@ -186,9 +190,36 @@ describe('paged agent-access tools', () => {
     expect(result.runs[0]).not.toHaveProperty('jobs');
   });
 
+  test('omits absent filters from initial run and trigger event pages', async () => {
+    const mocks = clients();
+    mocks.projectHandlers.requireProjectForWorkspace.mockResolvedValue({project: project()});
+    mocks.workflowHandlers.listWorkflowRuns.mockResolvedValue({
+      runs: [],
+      nextCursor: null,
+      filteredTotalCount: 0,
+    });
+    mocks.triggerHandlers.listTriggerEvents.mockResolvedValue({events: [], nextCursor: null});
+
+    await tool(mocks, 'list_workflow_runs').execute({
+      context,
+      arguments: {project_id: projectId},
+    });
+    await tool(mocks, 'list_trigger_events').execute({context, arguments: {}});
+
+    expect(mocks.workflowHandlers.listWorkflowRuns).toHaveBeenCalledWith({
+      workspaceId,
+      projectId,
+      limit: 50,
+    });
+    expect(mocks.triggerHandlers.listTriggerEvents).toHaveBeenCalledWith({
+      workspaceId,
+      limit: 50,
+    });
+  });
+
   test('resolves the latest annotation attempt and marks UTF-8 body truncation', async () => {
     const mocks = clients();
-    mocks.workflows.getLatestRunAttempt.mockResolvedValue({attempt: 2});
+    mocks.workflowHandlers.getLatestRunAttempt.mockResolvedValue({attempt: 2});
     mocks.annotationHandlers.listAnnotationsForRunAttempt.mockResolvedValue({
       annotations: [
         {
@@ -214,7 +245,7 @@ describe('paged agent-access tools', () => {
     });
     const result = expectSuccess<AnnotationTestResult>(response);
 
-    expect(mocks.workflows.getLatestRunAttempt).toHaveBeenCalledWith({
+    expect(mocks.workflowHandlers.getLatestRunAttempt).toHaveBeenCalledWith({
       workspaceId,
       workflowRunId: runId,
     });
@@ -250,13 +281,44 @@ describe('paged agent-access tools', () => {
     });
 
     expect(response).toEqual({ok: false, error: {code: 'invalid-request'}});
-    expect(mocks.workflows.getLatestRunAttempt).not.toHaveBeenCalled();
+    expect(mocks.workflowHandlers.getLatestRunAttempt).not.toHaveBeenCalled();
     expect(mocks.annotationHandlers.listAnnotationsForRunAttempt).not.toHaveBeenCalled();
+  });
+
+  test('forwards annotation cursors and job execution filters', async () => {
+    const mocks = clients();
+    const cursor = {value: 4, id: annotationId};
+    const jobExecutionId = uuid(10);
+    mocks.workflowHandlers.getLatestRunAttempt.mockResolvedValue({attempt: 2});
+    mocks.annotationHandlers.listAnnotationsForRunAttempt.mockResolvedValue({
+      annotations: [],
+      hasMore: false,
+      nextCursor: null,
+    });
+
+    const response = await tool(mocks, 'get_run_annotations').execute({
+      context,
+      arguments: {
+        run_id: runId,
+        job_execution_id: jobExecutionId,
+        cursor: encodeNumberIdCursor(cursor),
+      },
+    });
+
+    expect(response).toEqual({ok: true, result: {annotations: [], next_cursor: null}});
+    expect(mocks.annotationHandlers.listAnnotationsForRunAttempt).toHaveBeenCalledWith({
+      workspaceId,
+      workflowRunId: runId,
+      workflowRunAttempt: 2,
+      jobExecutionId,
+      cursor,
+      limit: 50,
+    });
   });
 
   test('maps trigger filters and projects connection metadata', async () => {
     const mocks = clients();
-    mocks.triggers.listTriggerEvents.mockResolvedValue({
+    mocks.triggerHandlers.listTriggerEvents.mockResolvedValue({
       events: [
         {
           id: triggerEventId,
@@ -294,10 +356,9 @@ describe('paged agent-access tools', () => {
       },
     });
 
-    expect(mocks.triggers.listTriggerEvents).toHaveBeenCalledWith({
+    expect(mocks.triggerHandlers.listTriggerEvents).toHaveBeenCalledWith({
       workspaceId,
       limit: 50,
-      cursor: undefined,
       filters: {
         source: ['push'],
         event: ['push'],
@@ -318,7 +379,7 @@ describe('paged agent-access tools', () => {
 
   test('keeps cross-workspace project reads 404-shaped without exposing producer details', async () => {
     const mocks = clients();
-    mocks.definitions.listDefinitionsByProject.mockRejectedValue(
+    mocks.definitionHandlers.listDefinitionsByProject.mockRejectedValue(
       createInterModuleKnownError(
         definitionsInterModuleContract.methods.listDefinitionsByProject,
         'project-workspace-mismatch',
@@ -336,7 +397,7 @@ describe('paged agent-access tools', () => {
 
   test('does not query annotations for a run from another workspace', async () => {
     const mocks = clients();
-    mocks.workflows.getLatestRunAttempt.mockResolvedValue({attempt: null});
+    mocks.workflowHandlers.getLatestRunAttempt.mockResolvedValue({attempt: null});
 
     const response = await tool(mocks, 'get_run_annotations').execute({
       context,
@@ -349,7 +410,7 @@ describe('paged agent-access tools', () => {
 
   test('reduces an oversized annotation page and anchors its cursor to the retained item', async () => {
     const mocks = clients();
-    mocks.workflows.getLatestRunAttempt.mockResolvedValue({attempt: 1});
+    mocks.workflowHandlers.getLatestRunAttempt.mockResolvedValue({attempt: 1});
     const annotations = Array.from({length: 100}, (_, index) => ({
       id: uuid(100 + index),
       job_id: uuid(200),
@@ -389,43 +450,85 @@ describe('paged agent-access tools', () => {
 });
 
 function clients() {
+  const projectHandlers = {
+    listProjectCatalogByWorkspace: vi.fn(),
+    requireProjectForWorkspace: vi.fn(),
+  };
+  const definitionHandlers = {listDefinitionsByProject: vi.fn()};
+  const workflowHandlers = {
+    listWorkflowRuns: vi.fn(),
+    getLatestRunAttempt: vi.fn(),
+    getWorkflowRunOverview: vi.fn(),
+  };
   const listAnnotationsForRunAttempt = vi.fn();
-  const annotations = createFakeInterModuleClients({
+  const triggerHandlers = {listTriggerEvents: vi.fn()};
+  const fakeClients = createFakeInterModuleClients({
+    projects: defineInterModulePresentation(projectsInterModuleContract, {
+      getProjectById: vi.fn(),
+      getProjectBySource: vi.fn(),
+      findProjectBySourceRepositoryName: vi.fn(),
+      listProjectsBySourceConnection: vi.fn(),
+      listProjectsByWorkspace: vi.fn(),
+      listProjectCatalogByWorkspace: (input) =>
+        projectHandlers.listProjectCatalogByWorkspace(input),
+      requireProjectForWorkspace: (input) => projectHandlers.requireProjectForWorkspace(input),
+      getWorkspaceProjectCounts: vi.fn(),
+      resolveCheckoutTarget: vi.fn(),
+    }),
+    definitions: defineInterModulePresentation(definitionsInterModuleContract, {
+      getDefinitionForWorkflowRun: vi.fn(),
+      listDefinitionsByProject: (input) => definitionHandlers.listDefinitionsByProject(input),
+      resolveDefinitionAtRef: vi.fn(),
+      listDefinitionsAtRef: vi.fn(),
+    }),
+    workflows: defineInterModulePresentation(workflowsInterModuleContract, {
+      startRunFromTrigger: vi.fn(),
+      startDevRun: vi.fn(),
+      resolveWorkflowRunTriggerReference: vi.fn(),
+      deliverEventToJobListener: vi.fn(),
+      getStepLogContext: vi.fn(),
+      listJobStepAttempts: vi.fn(),
+      getLeasedAgentToolContext: vi.fn(),
+      getLeasedAgentSessionContext: vi.fn(),
+      listWorkflowRuns: (input) => workflowHandlers.listWorkflowRuns(input),
+      getWorkflowRunOverview: (input) => workflowHandlers.getWorkflowRunOverview(input),
+      listWorkflowRunAttempts: vi.fn(),
+      listWorkflowRunJobs: vi.fn(),
+      getWorkflowJobDetail: vi.fn(),
+      listWorkflowJobExecutions: vi.fn(),
+      listWorkflowExecutionSteps: vi.fn(),
+      listWorkflowStepAttempts: vi.fn(),
+      getWorkflowRunSource: vi.fn(),
+      getWorkflowJobExecutionContext: vi.fn(),
+      listExecutionTriggerEvents: vi.fn(),
+      getExecutionTriggerEvent: vi.fn(),
+      getWorkflowStepAttemptDetail: vi.fn(),
+      listWorkflowRunAnnotations: vi.fn(),
+      listWorkflowRunJobExplanations: vi.fn(),
+      listFailedStepAttempts: vi.fn(),
+      getWorkflowRunDetail: vi.fn(),
+      getStepAttemptDetail: vi.fn(),
+      getLatestRunAttempt: (input) => workflowHandlers.getLatestRunAttempt(input),
+      getLatestStepAttempt: vi.fn(),
+    }),
     annotations: defineInterModulePresentation(annotationsInterModuleContract, {
       replaceOrRemoveAnnotation: () => ({}),
       listAnnotationsForRunAttempt: (input) => listAnnotationsForRunAttempt(input),
     }),
-  }).annotations;
+    triggers: defineInterModulePresentation(triggersInterModuleContract, {
+      listTriggerEvents: (input) => triggerHandlers.listTriggerEvents(input),
+      getTriggerEvent: vi.fn(),
+      getTriggerEventFacets: vi.fn(),
+    }),
+  });
 
   return {
-    projects: {
-      listProjectCatalogByWorkspace: vi.fn(),
-      requireProjectForWorkspace: vi.fn(),
-    } as unknown as ProjectsModuleClient & {
-      listProjectCatalogByWorkspace: ReturnType<typeof vi.fn>;
-      requireProjectForWorkspace: ReturnType<typeof vi.fn>;
-    },
-    definitions: {
-      listDefinitionsByProject: vi.fn(),
-    } as unknown as DefinitionsInterModuleClient & {
-      listDefinitionsByProject: ReturnType<typeof vi.fn>;
-    },
-    workflows: {
-      listWorkflowRuns: vi.fn(),
-      getLatestRunAttempt: vi.fn(),
-      getWorkflowRunOverview: vi.fn(),
-    } as unknown as WorkflowsModuleClient & {
-      listWorkflowRuns: ReturnType<typeof vi.fn>;
-      getLatestRunAttempt: ReturnType<typeof vi.fn>;
-      getWorkflowRunOverview: ReturnType<typeof vi.fn>;
-    },
-    annotations,
+    ...fakeClients,
+    projectHandlers,
+    definitionHandlers,
+    workflowHandlers,
     annotationHandlers: {listAnnotationsForRunAttempt},
-    triggers: {
-      listTriggerEvents: vi.fn(),
-    } as unknown as TriggersInterModuleClient & {
-      listTriggerEvents: ReturnType<typeof vi.fn>;
-    },
+    triggerHandlers,
   };
 }
 

--- a/libs/api/agent-access/src/core/paged-tools.test.ts
+++ b/libs/api/agent-access/src/core/paged-tools.test.ts
@@ -5,14 +5,16 @@ import type {AgentAccessContext} from '@shipfox/api-auth-context';
 import {definitionsInterModuleContract} from '@shipfox/api-definitions-dto/inter-module';
 import {projectsInterModuleContract} from '@shipfox/api-projects-dto/inter-module';
 import {triggersInterModuleContract} from '@shipfox/api-triggers-dto/inter-module';
-import {workflowsInterModuleContract} from '@shipfox/api-workflows-dto/inter-module';
 import {createInterModuleKnownError, defineInterModulePresentation} from '@shipfox/inter-module';
 import {
   decodeNumberIdCursor,
   decodeStringIdCursor,
   encodeNumberIdCursor,
+  encodeStringIdCursor,
+  encodeTimestampIdCursor,
 } from '@shipfox/node-drizzle';
 import {createFakeInterModuleClients} from '@shipfox/node-module/inter-module/testing';
+import {createTestWorkflowsClient} from '#test/fixtures/workflows-client.js';
 import {createAgentAccessTools} from './paged-tools.js';
 import {serializedAgentAccessEnvelopeByteLength} from './response.js';
 
@@ -214,6 +216,69 @@ describe('paged agent-access tools', () => {
     expect(mocks.triggerHandlers.listTriggerEvents).toHaveBeenCalledWith({
       workspaceId,
       limit: 50,
+    });
+  });
+
+  test('forwards valid cursors through every paged catalog read', async () => {
+    const mocks = clients();
+    const timestampCursor = encodeTimestampIdCursor({createdAt: new Date(isoDate), id: projectId});
+    const definitionCursor = encodeStringIdCursor({value: 'Definition', id: definitionId});
+    mocks.projectHandlers.listProjectCatalogByWorkspace.mockResolvedValue({
+      projects: [],
+      nextCursor: null,
+    });
+    mocks.definitionHandlers.listDefinitionsByProject.mockResolvedValue({
+      definitions: [],
+      sync: null,
+      nextCursor: null,
+    });
+    mocks.projectHandlers.requireProjectForWorkspace.mockResolvedValue({project: project()});
+    mocks.workflowHandlers.listWorkflowRuns.mockResolvedValue({
+      runs: [],
+      nextCursor: null,
+      filteredTotalCount: 0,
+    });
+    mocks.triggerHandlers.listTriggerEvents.mockResolvedValue({events: [], nextCursor: null});
+
+    await tool(mocks, 'list_projects').execute({
+      context,
+      arguments: {cursor: timestampCursor},
+    });
+    await tool(mocks, 'list_workflow_definitions').execute({
+      context,
+      arguments: {project_id: projectId, cursor: definitionCursor},
+    });
+    await tool(mocks, 'list_workflow_runs').execute({
+      context,
+      arguments: {project_id: projectId, cursor: timestampCursor},
+    });
+    await tool(mocks, 'list_trigger_events').execute({
+      context,
+      arguments: {cursor: timestampCursor},
+    });
+
+    const timestampReadCursor = {createdAt: isoDate, id: projectId};
+    expect(mocks.projectHandlers.listProjectCatalogByWorkspace).toHaveBeenCalledWith({
+      workspaceId,
+      limit: 50,
+      cursor: timestampReadCursor,
+    });
+    expect(mocks.definitionHandlers.listDefinitionsByProject).toHaveBeenCalledWith({
+      workspaceId,
+      projectId,
+      limit: 50,
+      cursor: {value: 'Definition', id: definitionId},
+    });
+    expect(mocks.workflowHandlers.listWorkflowRuns).toHaveBeenCalledWith({
+      workspaceId,
+      projectId,
+      limit: 50,
+      cursor: timestampReadCursor,
+    });
+    expect(mocks.triggerHandlers.listTriggerEvents).toHaveBeenCalledWith({
+      workspaceId,
+      limit: 50,
+      cursor: {receivedAt: isoDate, id: projectId},
     });
   });
 
@@ -455,11 +520,7 @@ function clients() {
     requireProjectForWorkspace: vi.fn(),
   };
   const definitionHandlers = {listDefinitionsByProject: vi.fn()};
-  const workflowHandlers = {
-    listWorkflowRuns: vi.fn(),
-    getLatestRunAttempt: vi.fn(),
-    getWorkflowRunOverview: vi.fn(),
-  };
+  const {workflows, handlers: workflowHandlers} = createTestWorkflowsClient();
   const listAnnotationsForRunAttempt = vi.fn();
   const triggerHandlers = {listTriggerEvents: vi.fn()};
   const fakeClients = createFakeInterModuleClients({
@@ -481,36 +542,6 @@ function clients() {
       resolveDefinitionAtRef: vi.fn(),
       listDefinitionsAtRef: vi.fn(),
     }),
-    workflows: defineInterModulePresentation(workflowsInterModuleContract, {
-      startRunFromTrigger: vi.fn(),
-      startDevRun: vi.fn(),
-      resolveWorkflowRunTriggerReference: vi.fn(),
-      deliverEventToJobListener: vi.fn(),
-      getStepLogContext: vi.fn(),
-      listJobStepAttempts: vi.fn(),
-      getLeasedAgentToolContext: vi.fn(),
-      getLeasedAgentSessionContext: vi.fn(),
-      listWorkflowRuns: (input) => workflowHandlers.listWorkflowRuns(input),
-      getWorkflowRunOverview: (input) => workflowHandlers.getWorkflowRunOverview(input),
-      listWorkflowRunAttempts: vi.fn(),
-      listWorkflowRunJobs: vi.fn(),
-      getWorkflowJobDetail: vi.fn(),
-      listWorkflowJobExecutions: vi.fn(),
-      listWorkflowExecutionSteps: vi.fn(),
-      listWorkflowStepAttempts: vi.fn(),
-      getWorkflowRunSource: vi.fn(),
-      getWorkflowJobExecutionContext: vi.fn(),
-      listExecutionTriggerEvents: vi.fn(),
-      getExecutionTriggerEvent: vi.fn(),
-      getWorkflowStepAttemptDetail: vi.fn(),
-      listWorkflowRunAnnotations: vi.fn(),
-      listWorkflowRunJobExplanations: vi.fn(),
-      listFailedStepAttempts: vi.fn(),
-      getWorkflowRunDetail: vi.fn(),
-      getStepAttemptDetail: vi.fn(),
-      getLatestRunAttempt: (input) => workflowHandlers.getLatestRunAttempt(input),
-      getLatestStepAttempt: vi.fn(),
-    }),
     annotations: defineInterModulePresentation(annotationsInterModuleContract, {
       replaceOrRemoveAnnotation: () => ({}),
       listAnnotationsForRunAttempt: (input) => listAnnotationsForRunAttempt(input),
@@ -524,6 +555,7 @@ function clients() {
 
   return {
     ...fakeClients,
+    workflows,
     projectHandlers,
     definitionHandlers,
     workflowHandlers,

--- a/libs/api/agent-access/src/core/paged-tools.ts
+++ b/libs/api/agent-access/src/core/paged-tools.ts
@@ -252,8 +252,8 @@ function createGetRunAnnotationsTool(
         workspaceId: context.workspaceId,
         workflowRunId: input.run_id,
         workflowRunAttempt: attempt,
-        ...(input.job_execution_id ? {jobExecutionId: input.job_execution_id} : {}),
-        ...(cursor ? {cursor} : {}),
+        ...optionalField('jobExecutionId', input.job_execution_id),
+        ...optionalField('cursor', cursor),
         limit: input.limit,
       });
       const result = {

--- a/libs/api/agent-access/src/core/paged-tools.ts
+++ b/libs/api/agent-access/src/core/paged-tools.ts
@@ -101,7 +101,7 @@ function createListProjectsTool(projects: ProjectsModuleClient): AgentAccessTool
       const page = await projects.listProjectCatalogByWorkspace({
         workspaceId: context.workspaceId,
         limit: input.limit,
-        cursor,
+        ...optionalCursor(cursor),
       });
       const result = {
         projects: page.projects.map(toProjectResult),
@@ -137,7 +137,7 @@ function createListWorkflowDefinitionsTool(
           workspaceId: context.workspaceId,
           projectId: input.project_id,
           limit: input.limit,
-          cursor,
+          ...optionalCursor(cursor),
         });
         const result = {
           definitions: page.definitions.map(toDefinitionResult),
@@ -210,8 +210,8 @@ function createListWorkflowRunsTool(
         workspaceId: context.workspaceId,
         projectId: input.project_id,
         limit: input.limit,
-        cursor,
-        filters: workflowRunFilters(input),
+        ...optionalCursor(cursor),
+        ...optionalFilters(workflowRunFilters(input)),
       });
       const result = {
         runs: page.runs.map(toWorkflowRunResult),
@@ -288,8 +288,8 @@ function createListTriggerEventsTool(triggers: TriggersInterModuleClient): Agent
       const page = await triggers.listTriggerEvents({
         workspaceId: context.workspaceId,
         limit: input.limit,
-        cursor: cursor ? {receivedAt: cursor.createdAt, id: cursor.id} : undefined,
-        filters: triggerEventFilters(input),
+        ...optionalCursor(toTriggerEventReadCursor(cursor)),
+        ...optionalFilters(triggerEventFilters(input)),
       });
       const result = {
         trigger_events: page.events.map(toTriggerEventResult),
@@ -581,6 +581,18 @@ function triggerEventFilters(input: ListTriggerEventsInputDto) {
     ...(input.from === undefined ? {} : {from: input.from}),
     ...(input.to === undefined ? {} : {to: input.to}),
   };
+}
+
+function optionalCursor<Cursor>(cursor: Cursor | undefined): {cursor?: Cursor} {
+  return cursor === undefined ? {} : {cursor};
+}
+
+function optionalFilters<Filters>(filters: Filters | undefined): {filters?: Filters} {
+  return filters === undefined ? {} : {filters};
+}
+
+function toTriggerEventReadCursor(cursor: {createdAt: string; id: string} | undefined) {
+  return cursor ? {receivedAt: cursor.createdAt, id: cursor.id} : undefined;
 }
 
 function projectCursor(item: Record<string, unknown>): string {

--- a/libs/api/agent-access/src/core/paged-tools.ts
+++ b/libs/api/agent-access/src/core/paged-tools.ts
@@ -54,6 +54,7 @@ import {
   encodeTimestampCursor,
   invalidRequest,
   notFound,
+  optionalField,
   parseInput,
   reducePage,
   truncateAgentAccessUtf8,
@@ -101,7 +102,7 @@ function createListProjectsTool(projects: ProjectsModuleClient): AgentAccessTool
       const page = await projects.listProjectCatalogByWorkspace({
         workspaceId: context.workspaceId,
         limit: input.limit,
-        ...optionalCursor(cursor),
+        ...optionalField('cursor', cursor),
       });
       const result = {
         projects: page.projects.map(toProjectResult),
@@ -137,7 +138,7 @@ function createListWorkflowDefinitionsTool(
           workspaceId: context.workspaceId,
           projectId: input.project_id,
           limit: input.limit,
-          ...optionalCursor(cursor),
+          ...optionalField('cursor', cursor),
         });
         const result = {
           definitions: page.definitions.map(toDefinitionResult),
@@ -210,8 +211,8 @@ function createListWorkflowRunsTool(
         workspaceId: context.workspaceId,
         projectId: input.project_id,
         limit: input.limit,
-        ...optionalCursor(cursor),
-        ...optionalFilters(workflowRunFilters(input)),
+        ...optionalField('cursor', cursor),
+        ...optionalField('filters', workflowRunFilters(input)),
       });
       const result = {
         runs: page.runs.map(toWorkflowRunResult),
@@ -288,8 +289,8 @@ function createListTriggerEventsTool(triggers: TriggersInterModuleClient): Agent
       const page = await triggers.listTriggerEvents({
         workspaceId: context.workspaceId,
         limit: input.limit,
-        ...optionalCursor(toTriggerEventReadCursor(cursor)),
-        ...optionalFilters(triggerEventFilters(input)),
+        ...optionalField('cursor', toTriggerEventReadCursor(cursor)),
+        ...optionalField('filters', triggerEventFilters(input)),
       });
       const result = {
         trigger_events: page.events.map(toTriggerEventResult),
@@ -581,14 +582,6 @@ function triggerEventFilters(input: ListTriggerEventsInputDto) {
     ...(input.from === undefined ? {} : {from: input.from}),
     ...(input.to === undefined ? {} : {to: input.to}),
   };
-}
-
-function optionalCursor<Cursor>(cursor: Cursor | undefined): {cursor?: Cursor} {
-  return cursor === undefined ? {} : {cursor};
-}
-
-function optionalFilters<Filters>(filters: Filters | undefined): {filters?: Filters} {
-  return filters === undefined ? {} : {filters};
 }
 
 function toTriggerEventReadCursor(cursor: {createdAt: string; id: string} | undefined) {

--- a/libs/api/agent-access/src/core/paged-tools.ts
+++ b/libs/api/agent-access/src/core/paged-tools.ts
@@ -251,8 +251,8 @@ function createGetRunAnnotationsTool(
         workspaceId: context.workspaceId,
         workflowRunId: input.run_id,
         workflowRunAttempt: attempt,
-        jobExecutionId: input.job_execution_id,
-        cursor,
+        ...(input.job_execution_id ? {jobExecutionId: input.job_execution_id} : {}),
+        ...(cursor ? {cursor} : {}),
         limit: input.limit,
       });
       const result = {

--- a/libs/api/agent-access/src/core/tool-utils.ts
+++ b/libs/api/agent-access/src/core/tool-utils.ts
@@ -25,6 +25,13 @@ export function parseInput<T>(schema: SafeParseSchema<T>, value: unknown): T | u
   return parsed.success ? parsed.data : undefined;
 }
 
+export function optionalField<Key extends string, Value>(
+  key: Key,
+  value: Value | undefined,
+): Partial<Record<Key, Value>> {
+  return value === undefined ? {} : ({[key]: value} as Record<Key, Value>);
+}
+
 export function reducePage(
   envelope: AgentAccessEnvelopeDto,
   itemKey: string,

--- a/libs/api/agent-access/src/core/workflow-diagnostic-tools.test.ts
+++ b/libs/api/agent-access/src/core/workflow-diagnostic-tools.test.ts
@@ -680,6 +680,20 @@ describe('workflow diagnostic agent-access tools', () => {
     expect(response).toEqual({ok: false, error: {code: 'not-found'}});
     expect(mocks[method]).toHaveBeenCalledWith(expect.objectContaining({workspaceId}));
   });
+
+  test('does not project a mixed-version step payload without complete ancestry', async () => {
+    const mocks = clients();
+    const detail = stepAttemptDetail();
+    Reflect.deleteProperty(detail, 'step_attempt_id');
+    mocks.getWorkflowStepAttemptDetail.mockResolvedValue(detail);
+
+    const response = await tool(mocks, 'get_step_attempt').execute({
+      context,
+      arguments: {step_id: stepId, attempt: 1},
+    });
+
+    expect(response).toEqual({ok: false, error: {code: 'not-found'}});
+  });
 });
 
 function stepAttemptDetail(overrides: Record<string, unknown> = {}): Record<string, unknown> {

--- a/libs/api/agent-access/src/core/workflow-diagnostic-tools.test.ts
+++ b/libs/api/agent-access/src/core/workflow-diagnostic-tools.test.ts
@@ -18,8 +18,8 @@ import {
 } from '@shipfox/api-agent-access-dto';
 import type {AgentAccessContext} from '@shipfox/api-auth-context';
 import {WORKFLOW_STEP_CONFIG_INLINE_MAX_BYTES} from '@shipfox/api-workflows-dto';
-import type {WorkflowsModuleClient as WorkflowsInterModuleClient} from '@shipfox/api-workflows-dto/inter-module';
 import {decodeStringIdCursor, encodeStringIdCursor} from '@shipfox/node-drizzle';
+import {createTestWorkflowsClient} from '#test/fixtures/workflows-client.js';
 import {createAgentAccessWorkflowDiagnosticTools} from './workflow-diagnostic-tools.js';
 
 const workspaceId = uuid(1);
@@ -37,24 +37,13 @@ const context: AgentAccessContext = {
   credential: {kind: 'oauth_grant', grantId: uuid(9), clientId: 'client-1'},
 };
 
-type WorkflowMocks = WorkflowsInterModuleClient & {
-  getWorkflowRunSource: ReturnType<typeof vi.fn>;
-  getWorkflowJobExecutionContext: ReturnType<typeof vi.fn>;
-  getWorkflowStepAttemptDetail: ReturnType<typeof vi.fn>;
-  listWorkflowRunJobExplanations: ReturnType<typeof vi.fn>;
-};
-
-function clients(): WorkflowMocks {
-  return {
-    getWorkflowRunSource: vi.fn(),
-    getWorkflowJobExecutionContext: vi.fn(),
-    getWorkflowStepAttemptDetail: vi.fn(),
-    listWorkflowRunJobExplanations: vi.fn(),
-  } as unknown as WorkflowMocks;
+function clients() {
+  const {workflows, handlers} = createTestWorkflowsClient();
+  return {workflows, ...handlers};
 }
 
-function tool(workflows: WorkflowMocks, name: string) {
-  const result = createAgentAccessWorkflowDiagnosticTools(workflows).find(
+function tool(fixture: ReturnType<typeof clients>, name: string) {
+  const result = createAgentAccessWorkflowDiagnosticTools(fixture.workflows).find(
     (candidate) => candidate.name === name,
   );
   if (!result) throw new Error(`Missing tool ${name}`);
@@ -314,6 +303,21 @@ describe('workflow diagnostic agent-access tools', () => {
     expect(getStepAttemptResultSchema.safeParse(result).success).toBe(true);
   });
 
+  test('omits an absent step attempt from the producer request', async () => {
+    const mocks = clients();
+    mocks.getWorkflowStepAttemptDetail.mockResolvedValue(stepAttemptDetail());
+
+    await tool(mocks, 'get_step_attempt').execute({
+      context,
+      arguments: {step_id: stepId},
+    });
+
+    expect(mocks.getWorkflowStepAttemptDetail).toHaveBeenCalledWith({
+      workspaceId,
+      stepId,
+    });
+  });
+
   test('marks response and restart feedback when UTF-8 text is truncated', async () => {
     const mocks = clients();
     const largeText = '🙂'.repeat(AGENT_ACCESS_TEXT_MAX_BYTES);
@@ -565,6 +569,12 @@ describe('workflow diagnostic agent-access tools', () => {
     });
     const result = success<ListWorkflowRunJobExplanationsResultDto>(response);
 
+    expect(mocks.listWorkflowRunJobExplanations).toHaveBeenCalledWith({
+      workspaceId,
+      workflowRunId: runId,
+      attempt: 1,
+      limit: 100,
+    });
     expect(result.explanations.length).toBeLessThan(100);
     expect(response).toMatchObject({ok: true, response_truncated: true});
     expect(response.response_total_bytes).toBeGreaterThan(AGENT_ACCESS_RESPONSE_MAX_BYTES);
@@ -576,6 +586,29 @@ describe('workflow diagnostic agent-access tools', () => {
       id: last?.job_id,
     });
     expect(listWorkflowRunJobExplanationsResultSchema.safeParse(result).success).toBe(true);
+  });
+
+  test('forwards a valid workflow job explanation cursor', async () => {
+    const mocks = clients();
+    const cursor = encodeStringIdCursor({value: '0', id: jobId});
+    mocks.listWorkflowRunJobExplanations.mockResolvedValue({
+      workflow_run_attempt: 1,
+      items: [],
+      nextCursor: null,
+    });
+
+    await tool(mocks, 'list_workflow_run_job_explanations').execute({
+      context,
+      arguments: {run_id: runId, attempt: 1, cursor},
+    });
+
+    expect(mocks.listWorkflowRunJobExplanations).toHaveBeenCalledWith({
+      workspaceId,
+      workflowRunId: runId,
+      attempt: 1,
+      limit: 100,
+      cursor,
+    });
   });
 
   test('bounds a large explanation trace before building the response', async () => {
@@ -646,20 +679,6 @@ describe('workflow diagnostic agent-access tools', () => {
 
     expect(response).toEqual({ok: false, error: {code: 'not-found'}});
     expect(mocks[method]).toHaveBeenCalledWith(expect.objectContaining({workspaceId}));
-  });
-
-  test('does not project a mixed-version step payload without complete ancestry', async () => {
-    const mocks = clients();
-    mocks.getWorkflowStepAttemptDetail.mockResolvedValue(
-      stepAttemptDetail({step_attempt_id: undefined}),
-    );
-
-    const response = await tool(mocks, 'get_step_attempt').execute({
-      context,
-      arguments: {step_id: stepId, attempt: 1},
-    });
-
-    expect(response).toEqual({ok: false, error: {code: 'not-found'}});
   });
 });
 

--- a/libs/api/agent-access/src/core/workflow-diagnostic-tools.ts
+++ b/libs/api/agent-access/src/core/workflow-diagnostic-tools.ts
@@ -63,6 +63,7 @@ import {
   capNullable,
   invalidRequest,
   notFound,
+  optionalField,
   parseInput,
   reducePage,
   truncateAgentAccessUtf8,
@@ -168,7 +169,7 @@ function createListExecutionTriggerEventsTool(workflows: WorkflowsModuleClient):
         jobId: input.job_id,
         executionId: input.execution_id,
         limit: input.limit,
-        cursor,
+        ...optionalField('cursor', cursor),
       });
       if (page === null) return notFound();
 
@@ -238,7 +239,7 @@ function createGetStepAttemptTool(workflows: WorkflowsModuleClient): AgentAccess
       const detail = await workflows.getWorkflowStepAttemptDetail({
         workspaceId: context.workspaceId,
         stepId: input.step_id,
-        attempt: input.attempt,
+        ...optionalField('attempt', input.attempt),
       });
       if (detail === null) return notFound();
 
@@ -278,7 +279,7 @@ function createListWorkflowRunJobExplanationsTool(
         workflowRunId: input.run_id,
         attempt: input.attempt,
         limit: input.limit,
-        cursor,
+        ...optionalField('cursor', cursor),
       });
       if (page === null) return notFound();
 

--- a/libs/api/agent-access/src/core/workflow-execution-event-tools.test.ts
+++ b/libs/api/agent-access/src/core/workflow-execution-event-tools.test.ts
@@ -160,12 +160,12 @@ describe('workflow execution event Agent Access tools', () => {
     expect(detailResponse).toEqual({ok: false, error: {code: 'not-found'}});
   });
 
-  test('preserves long event references and bounded display metadata', async () => {
+  test('preserves long event references and caps display metadata', async () => {
     const mocks = clients();
     const longEventRef = 'r'.repeat(513);
     const source = eventSummary({
       event_ref: longEventRef,
-      delivery_id: 'd'.repeat(512),
+      delivery_id: 'd'.repeat(513),
       source: 's'.repeat(512),
       event: 'e'.repeat(512),
     });

--- a/libs/api/agent-access/src/core/workflow-execution-event-tools.test.ts
+++ b/libs/api/agent-access/src/core/workflow-execution-event-tools.test.ts
@@ -7,8 +7,8 @@ import {
   listExecutionTriggerEventsResultSchema,
 } from '@shipfox/api-agent-access-dto';
 import type {AgentAccessContext} from '@shipfox/api-auth-context';
-import type {WorkflowsModuleClient} from '@shipfox/api-workflows-dto/inter-module';
 import {decodeTimestampIdCursor, encodeTimestampIdCursor} from '@shipfox/node-drizzle';
+import {createTestWorkflowsClient} from '#test/fixtures/workflows-client.js';
 import {createAgentAccessWorkflowDiagnosticTools} from './workflow-diagnostic-tools.js';
 
 const workspaceId = uuid(1);
@@ -21,20 +21,13 @@ const context: AgentAccessContext = {
   credential: {kind: 'oauth_grant', grantId: uuid(5), clientId: 'client-1'},
 };
 
-type WorkflowMocks = WorkflowsModuleClient & {
-  listExecutionTriggerEvents: ReturnType<typeof vi.fn>;
-  getExecutionTriggerEvent: ReturnType<typeof vi.fn>;
-};
-
-function clients(): WorkflowMocks {
-  return {
-    listExecutionTriggerEvents: vi.fn(),
-    getExecutionTriggerEvent: vi.fn(),
-  } as unknown as WorkflowMocks;
+function clients() {
+  const {workflows, handlers} = createTestWorkflowsClient();
+  return {workflows, ...handlers};
 }
 
-function tool(workflows: WorkflowMocks, name: string) {
-  const result = createAgentAccessWorkflowDiagnosticTools(workflows).find(
+function tool(fixture: ReturnType<typeof clients>, name: string) {
+  const result = createAgentAccessWorkflowDiagnosticTools(fixture.workflows).find(
     (candidate) => candidate.name === name,
   );
   if (!result) throw new Error(`Missing tool ${name}`);
@@ -53,7 +46,7 @@ describe('workflow execution event Agent Access tools', () => {
     const mocks = clients();
 
     expect(
-      createAgentAccessWorkflowDiagnosticTools(mocks).map((candidate) => candidate.name),
+      createAgentAccessWorkflowDiagnosticTools(mocks.workflows).map((candidate) => candidate.name),
     ).toEqual([
       'get_workflow_run_source',
       'get_workflow_execution_context',
@@ -89,7 +82,6 @@ describe('workflow execution event Agent Access tools', () => {
       jobId,
       executionId,
       limit: 25,
-      cursor: undefined,
     });
     expect(result).toMatchObject({
       job_id: jobId,
@@ -168,14 +160,14 @@ describe('workflow execution event Agent Access tools', () => {
     expect(detailResponse).toEqual({ok: false, error: {code: 'not-found'}});
   });
 
-  test('preserves long event references while capping display metadata', async () => {
+  test('preserves long event references and bounded display metadata', async () => {
     const mocks = clients();
     const longEventRef = 'r'.repeat(513);
     const source = eventSummary({
       event_ref: longEventRef,
-      delivery_id: 'd'.repeat(513),
-      source: 's'.repeat(513),
-      event: 'e'.repeat(513),
+      delivery_id: 'd'.repeat(512),
+      source: 's'.repeat(512),
+      event: 'e'.repeat(512),
     });
     mocks.listExecutionTriggerEvents.mockResolvedValue({
       items: [source],

--- a/libs/api/agent-access/src/core/workflow-tools.test.ts
+++ b/libs/api/agent-access/src/core/workflow-tools.test.ts
@@ -20,12 +20,12 @@ import type {
   WorkflowRunJobOverviewDto,
   WorkflowRunOverviewResponseDto,
 } from '@shipfox/api-workflows-dto';
-import type {WorkflowsModuleClient} from '@shipfox/api-workflows-dto/inter-module';
 import {
   decodeStringIdCursor,
   encodeNumberIdCursor,
   encodeStringIdCursor,
 } from '@shipfox/node-drizzle';
+import {createTestWorkflowsClient} from '#test/fixtures/workflows-client.js';
 import {createAgentAccessTools} from './paged-tools.js';
 import {serializedAgentAccessEnvelopeByteLength} from './response.js';
 
@@ -69,7 +69,7 @@ describe('bounded workflow agent-access tools', () => {
 
   test('returns a compact selected-attempt summary and pins the latest attempt', async () => {
     const mocks = clients();
-    mocks.workflows.getWorkflowRunOverview.mockResolvedValue(overview());
+    mocks.workflowHandlers.getWorkflowRunOverview.mockResolvedValue(overview());
 
     const response = await tool(mocks, 'get_workflow_run').execute({
       context,
@@ -77,10 +77,9 @@ describe('bounded workflow agent-access tools', () => {
     });
     const result = expectSuccess<GetWorkflowRunResultDto>(response);
 
-    expect(mocks.workflows.getWorkflowRunOverview).toHaveBeenCalledWith({
+    expect(mocks.workflowHandlers.getWorkflowRunOverview).toHaveBeenCalledWith({
       workspaceId,
       workflowRunId: runId,
-      attempt: undefined,
     });
     expect(result).toMatchObject({
       id: runId,
@@ -98,14 +97,14 @@ describe('bounded workflow agent-access tools', () => {
 
   test('passes an explicit run attempt through to the bounded overview', async () => {
     const mocks = clients();
-    mocks.workflows.getWorkflowRunOverview.mockResolvedValue(overview(1));
+    mocks.workflowHandlers.getWorkflowRunOverview.mockResolvedValue(overview(1));
 
     await tool(mocks, 'get_workflow_run').execute({
       context,
       arguments: {run_id: runId, attempt: 1},
     });
 
-    expect(mocks.workflows.getWorkflowRunOverview).toHaveBeenCalledWith({
+    expect(mocks.workflowHandlers.getWorkflowRunOverview).toHaveBeenCalledWith({
       workspaceId,
       workflowRunId: runId,
       attempt: 1,
@@ -114,7 +113,7 @@ describe('bounded workflow agent-access tools', () => {
 
   test('relays status counts from the large workflow overview variant', async () => {
     const mocks = clients();
-    mocks.workflows.getWorkflowRunOverview.mockResolvedValue({
+    mocks.workflowHandlers.getWorkflowRunOverview.mockResolvedValue({
       ...overview(),
       jobs: {
         kind: 'large',
@@ -142,7 +141,7 @@ describe('bounded workflow agent-access tools', () => {
   test('pages run attempts with the producer cursor and exposes run coordinates', async () => {
     const mocks = clients();
     const nextCursor = encodeNumberIdCursor({value: 1, id: attemptId});
-    mocks.workflows.listWorkflowRunAttempts.mockResolvedValue({
+    mocks.workflowHandlers.listWorkflowRunAttempts.mockResolvedValue({
       items: [runAttempt(2), runAttempt(1)],
       nextCursor,
     });
@@ -153,11 +152,10 @@ describe('bounded workflow agent-access tools', () => {
     });
     const result = expectSuccess<ListWorkflowRunAttemptsResultDto>(response);
 
-    expect(mocks.workflows.listWorkflowRunAttempts).toHaveBeenCalledWith({
+    expect(mocks.workflowHandlers.listWorkflowRunAttempts).toHaveBeenCalledWith({
       workspaceId,
       workflowRunId: runId,
       limit: 2,
-      cursor: undefined,
     });
     expect(result.attempts).toHaveLength(2);
     expect(result.attempts[0]).toMatchObject({workflow_run_id: runId, attempt: 2});
@@ -168,7 +166,7 @@ describe('bounded workflow agent-access tools', () => {
   test('pages jobs for a pinned attempt and excludes dependency data', async () => {
     const mocks = clients();
     const producerCursor = encodeStringIdCursor({value: '0', id: jobId});
-    mocks.workflows.listWorkflowRunJobs.mockResolvedValue({
+    mocks.workflowHandlers.listWorkflowRunJobs.mockResolvedValue({
       workflow_run_attempt: 2,
       items: [{...job(), dependencies: ['other-job']}],
       nextCursor: producerCursor,
@@ -181,12 +179,11 @@ describe('bounded workflow agent-access tools', () => {
     });
     const result = expectSuccess<ListWorkflowRunJobsResultDto>(response);
 
-    expect(mocks.workflows.listWorkflowRunJobs).toHaveBeenCalledWith({
+    expect(mocks.workflowHandlers.listWorkflowRunJobs).toHaveBeenCalledWith({
       workspaceId,
       workflowRunId: runId,
       attempt: 2,
       limit: 1,
-      cursor: undefined,
     });
     expect(result).toMatchObject({
       workflow_run_id: runId,
@@ -207,7 +204,7 @@ describe('bounded workflow agent-access tools', () => {
       position: index,
       default_execution: execution(uuid(200 + index), index + 1, 'e'.repeat(20_000)),
     }));
-    mocks.workflows.listWorkflowRunJobs.mockResolvedValue({
+    mocks.workflowHandlers.listWorkflowRunJobs.mockResolvedValue({
       workflow_run_attempt: 2,
       items: jobs,
       nextCursor: null,
@@ -234,7 +231,7 @@ describe('bounded workflow agent-access tools', () => {
 
   test('returns a compact job while leaving selected child collections lazy', async () => {
     const mocks = clients();
-    mocks.workflows.getWorkflowJobDetail.mockResolvedValue(jobDetail());
+    mocks.workflowHandlers.getWorkflowJobDetail.mockResolvedValue(jobDetail());
 
     const response = await tool(mocks, 'get_workflow_job').execute({
       context,
@@ -242,7 +239,7 @@ describe('bounded workflow agent-access tools', () => {
     });
     const result = expectSuccess<GetWorkflowJobResultDto>(response);
 
-    expect(mocks.workflows.getWorkflowJobDetail).toHaveBeenCalledWith({
+    expect(mocks.workflowHandlers.getWorkflowJobDetail).toHaveBeenCalledWith({
       workspaceId,
       jobId,
       executionId,
@@ -262,7 +259,7 @@ describe('bounded workflow agent-access tools', () => {
 
   test('supports jobs without an execution without fabricating a child id', async () => {
     const mocks = clients();
-    mocks.workflows.getWorkflowJobDetail.mockResolvedValue({
+    mocks.workflowHandlers.getWorkflowJobDetail.mockResolvedValue({
       ...jobDetail(),
       selected_execution: null,
     });
@@ -273,6 +270,10 @@ describe('bounded workflow agent-access tools', () => {
     });
     const result = expectSuccess<GetWorkflowJobResultDto>(response);
 
+    expect(mocks.workflowHandlers.getWorkflowJobDetail).toHaveBeenCalledWith({
+      workspaceId,
+      jobId,
+    });
     expect(result.selected_execution).toBeNull();
   });
 
@@ -281,7 +282,7 @@ describe('bounded workflow agent-access tools', () => {
     const executions = Array.from({length: 100}, (_, index) =>
       execution(uuid(100 + index), index + 1, 'x'.repeat(20_000)),
     );
-    mocks.workflows.listWorkflowJobExecutions.mockResolvedValue({
+    mocks.workflowHandlers.listWorkflowJobExecutions.mockResolvedValue({
       items: executions,
       nextCursor: null,
       total: 100,
@@ -293,6 +294,11 @@ describe('bounded workflow agent-access tools', () => {
     });
     const result = expectSuccess<ListWorkflowJobExecutionsResultDto>(response);
 
+    expect(mocks.workflowHandlers.listWorkflowJobExecutions).toHaveBeenCalledWith({
+      workspaceId,
+      jobId,
+      limit: 100,
+    });
     expect(result.job_id).toBe(jobId);
     expect(result.executions).toHaveLength(100);
     expect(result.executions[0]?.name).toHaveLength(512);
@@ -302,12 +308,12 @@ describe('bounded workflow agent-access tools', () => {
 
   test('pages steps and attempts with the canonical parent coordinates', async () => {
     const mocks = clients();
-    mocks.workflows.listWorkflowExecutionSteps.mockResolvedValue({
+    mocks.workflowHandlers.listWorkflowExecutionSteps.mockResolvedValue({
       items: [step()],
       nextCursor: null,
       total: 1,
     });
-    mocks.workflows.listWorkflowStepAttempts.mockResolvedValue({
+    mocks.workflowHandlers.listWorkflowStepAttempts.mockResolvedValue({
       items: [stepAttempt()],
       nextCursor: null,
       total: 1,
@@ -319,6 +325,12 @@ describe('bounded workflow agent-access tools', () => {
       arguments: {job_id: jobId, execution_id: executionId},
     });
     const steps = expectSuccess<ListWorkflowExecutionStepsResultDto>(stepsResponse);
+    expect(mocks.workflowHandlers.listWorkflowExecutionSteps).toHaveBeenCalledWith({
+      workspaceId,
+      jobId,
+      executionId,
+      limit: 100,
+    });
     expect(steps).toMatchObject({
       job_id: jobId,
       execution_id: executionId,
@@ -332,14 +344,84 @@ describe('bounded workflow agent-access tools', () => {
       arguments: {step_id: stepId},
     });
     const attempts = expectSuccess<ListWorkflowStepAttemptsResultDto>(attemptsResponse);
+    expect(mocks.workflowHandlers.listWorkflowStepAttempts).toHaveBeenCalledWith({
+      workspaceId,
+      stepId,
+      limit: 25,
+    });
     expect(attempts).toMatchObject({step_id: stepId, attempts: [{id: attemptId, attempt: 1}]});
     expect(attempts.attempts[0]).not.toHaveProperty('error');
     expect(attempts.attempts[0]).not.toHaveProperty('gate_result');
   });
 
+  test('forwards valid cursors through every workflow traversal page', async () => {
+    const mocks = clients();
+    const numberCursor = encodeNumberIdCursor({value: 1, id: attemptId});
+    const positionCursor = encodeStringIdCursor({value: '0', id: jobId});
+    mocks.workflowHandlers.listWorkflowRunAttempts.mockResolvedValue({
+      items: [],
+      nextCursor: null,
+    });
+    mocks.workflowHandlers.listWorkflowRunJobs.mockResolvedValue({
+      workflow_run_attempt: 2,
+      items: [],
+      nextCursor: null,
+    });
+    mocks.workflowHandlers.listWorkflowJobExecutions.mockResolvedValue({
+      items: [],
+      nextCursor: null,
+    });
+    mocks.workflowHandlers.listWorkflowExecutionSteps.mockResolvedValue({
+      items: [],
+      nextCursor: null,
+    });
+    mocks.workflowHandlers.listWorkflowStepAttempts.mockResolvedValue({
+      items: [],
+      nextCursor: null,
+      stepType: 'run',
+    });
+
+    await tool(mocks, 'list_workflow_run_attempts').execute({
+      context,
+      arguments: {run_id: runId, cursor: numberCursor},
+    });
+    await tool(mocks, 'list_workflow_run_jobs').execute({
+      context,
+      arguments: {run_id: runId, attempt: 2, cursor: positionCursor},
+    });
+    await tool(mocks, 'list_workflow_job_executions').execute({
+      context,
+      arguments: {job_id: jobId, cursor: numberCursor},
+    });
+    await tool(mocks, 'list_workflow_execution_steps').execute({
+      context,
+      arguments: {job_id: jobId, execution_id: executionId, cursor: positionCursor},
+    });
+    await tool(mocks, 'list_workflow_step_attempts').execute({
+      context,
+      arguments: {step_id: stepId, cursor: numberCursor},
+    });
+
+    expect(mocks.workflowHandlers.listWorkflowRunAttempts).toHaveBeenCalledWith(
+      expect.objectContaining({cursor: numberCursor}),
+    );
+    expect(mocks.workflowHandlers.listWorkflowRunJobs).toHaveBeenCalledWith(
+      expect.objectContaining({cursor: positionCursor}),
+    );
+    expect(mocks.workflowHandlers.listWorkflowJobExecutions).toHaveBeenCalledWith(
+      expect.objectContaining({cursor: numberCursor}),
+    );
+    expect(mocks.workflowHandlers.listWorkflowExecutionSteps).toHaveBeenCalledWith(
+      expect.objectContaining({cursor: positionCursor}),
+    );
+    expect(mocks.workflowHandlers.listWorkflowStepAttempts).toHaveBeenCalledWith(
+      expect.objectContaining({cursor: numberCursor}),
+    );
+  });
+
   test('turns inaccessible or malformed traversal reads into bounded tool errors', async () => {
     const mocks = clients();
-    mocks.workflows.listWorkflowRunJobs.mockResolvedValue(null);
+    mocks.workflowHandlers.listWorkflowRunJobs.mockResolvedValue(null);
 
     const missing = await tool(mocks, 'list_workflow_run_jobs').execute({
       context,
@@ -352,47 +434,25 @@ describe('bounded workflow agent-access tools', () => {
       arguments: {run_id: runId, attempt: 2, cursor: 'not-a-cursor'},
     });
     expect(invalid).toEqual({ok: false, error: {code: 'invalid-request'}});
-    expect(mocks.workflows.listWorkflowRunJobs).toHaveBeenCalledTimes(1);
+    expect(mocks.workflowHandlers.listWorkflowRunJobs).toHaveBeenCalledTimes(1);
   });
 });
 
-type WorkflowMocks = WorkflowsModuleClient & {
-  listWorkflowRuns: ReturnType<typeof vi.fn>;
-  getLatestRunAttempt: ReturnType<typeof vi.fn>;
-  getWorkflowRunOverview: ReturnType<typeof vi.fn>;
-  listWorkflowRunAttempts: ReturnType<typeof vi.fn>;
-  listWorkflowRunJobs: ReturnType<typeof vi.fn>;
-  getWorkflowJobDetail: ReturnType<typeof vi.fn>;
-  listWorkflowJobExecutions: ReturnType<typeof vi.fn>;
-  listWorkflowExecutionSteps: ReturnType<typeof vi.fn>;
-  listWorkflowStepAttempts: ReturnType<typeof vi.fn>;
-};
-
-type AgentAccessTestClients = Parameters<typeof createAgentAccessTools>[0] & {
-  workflows: WorkflowMocks;
-};
-
-function clients(): AgentAccessTestClients {
+function clients() {
+  const {workflows, handlers: workflowHandlers} = createTestWorkflowsClient();
   return {
     projects: {
       listProjectCatalogByWorkspace: vi.fn(),
       requireProjectForWorkspace: vi.fn(),
     },
     definitions: {listDefinitionsByProject: vi.fn()},
-    workflows: {
-      listWorkflowRuns: vi.fn(),
-      getLatestRunAttempt: vi.fn(),
-      getWorkflowRunOverview: vi.fn(),
-      listWorkflowRunAttempts: vi.fn(),
-      listWorkflowRunJobs: vi.fn(),
-      getWorkflowJobDetail: vi.fn(),
-      listWorkflowJobExecutions: vi.fn(),
-      listWorkflowExecutionSteps: vi.fn(),
-      listWorkflowStepAttempts: vi.fn(),
-    } as unknown as WorkflowMocks,
+    workflows,
+    workflowHandlers,
     annotations: {listAnnotationsForRunAttempt: vi.fn()},
     triggers: {listTriggerEvents: vi.fn()},
-  } as unknown as AgentAccessTestClients;
+  } as unknown as Parameters<typeof createAgentAccessTools>[0] & {
+    workflowHandlers: typeof workflowHandlers;
+  };
 }
 
 function tool(mocks: ReturnType<typeof clients>, name: string) {

--- a/libs/api/agent-access/src/core/workflow-tools.ts
+++ b/libs/api/agent-access/src/core/workflow-tools.ts
@@ -54,6 +54,7 @@ import {
   capNullable,
   invalidRequest,
   notFound,
+  optionalField,
   parseInput,
   reducePage,
   validateBoundedNumberCursor,
@@ -92,7 +93,7 @@ function createGetWorkflowRunTool(workflows: WorkflowsModuleClient): AgentAccess
       const overview = await workflows.getWorkflowRunOverview({
         workspaceId: context.workspaceId,
         workflowRunId: input.run_id,
-        attempt: input.attempt,
+        ...optionalField('attempt', input.attempt),
       });
       if (overview === null) return notFound();
       return agentAccessSuccess(toWorkflowRunResult(overview));
@@ -120,7 +121,7 @@ function createListWorkflowRunAttemptsTool(workflows: WorkflowsModuleClient): Ag
         workspaceId: context.workspaceId,
         workflowRunId: input.run_id,
         limit: input.limit,
-        cursor,
+        ...optionalField('cursor', cursor),
       });
       if (page === null) return notFound();
 
@@ -160,7 +161,7 @@ function createListWorkflowRunJobsTool(workflows: WorkflowsModuleClient): AgentA
         workflowRunId: input.run_id,
         attempt: input.attempt,
         limit: input.limit,
-        cursor,
+        ...optionalField('cursor', cursor),
       });
       if (page === null) return notFound();
 
@@ -199,7 +200,7 @@ function createGetWorkflowJobTool(workflows: WorkflowsModuleClient): AgentAccess
       const detail = await workflows.getWorkflowJobDetail({
         workspaceId: context.workspaceId,
         jobId: input.job_id,
-        executionId: input.execution_id,
+        ...optionalField('executionId', input.execution_id),
       });
       if (detail === null) return notFound();
 
@@ -237,7 +238,7 @@ function createListWorkflowJobExecutionsTool(workflows: WorkflowsModuleClient): 
         workspaceId: context.workspaceId,
         jobId: input.job_id,
         limit: input.limit,
-        cursor,
+        ...optionalField('cursor', cursor),
       });
       if (page === null) return notFound();
 
@@ -279,7 +280,7 @@ function createListWorkflowExecutionStepsTool(workflows: WorkflowsModuleClient):
         jobId: input.job_id,
         executionId: input.execution_id,
         limit: input.limit,
-        cursor,
+        ...optionalField('cursor', cursor),
       });
       if (page === null) return notFound();
 
@@ -321,7 +322,7 @@ function createListWorkflowStepAttemptsTool(workflows: WorkflowsModuleClient): A
         workspaceId: context.workspaceId,
         stepId: input.step_id,
         limit: input.limit,
-        cursor,
+        ...optionalField('cursor', cursor),
       });
       if (page === null) return notFound();
 

--- a/libs/api/agent-access/test/fixtures/workflows-client.ts
+++ b/libs/api/agent-access/test/fixtures/workflows-client.ts
@@ -1,0 +1,89 @@
+import {
+  type WorkflowsModuleClient,
+  workflowsInterModuleContract,
+} from '@shipfox/api-workflows-dto/inter-module';
+import {defineInterModulePresentation} from '@shipfox/inter-module';
+import {createFakeInterModuleClients} from '@shipfox/node-module/inter-module/testing';
+
+type WorkflowHandlerMock = ReturnType<typeof vi.fn>;
+
+interface TestWorkflowsClient {
+  workflows: WorkflowsModuleClient;
+  handlers: {
+    listWorkflowRuns: WorkflowHandlerMock;
+    getWorkflowRunOverview: WorkflowHandlerMock;
+    listWorkflowRunAttempts: WorkflowHandlerMock;
+    listWorkflowRunJobs: WorkflowHandlerMock;
+    getWorkflowJobDetail: WorkflowHandlerMock;
+    listWorkflowJobExecutions: WorkflowHandlerMock;
+    listWorkflowExecutionSteps: WorkflowHandlerMock;
+    listWorkflowStepAttempts: WorkflowHandlerMock;
+    getWorkflowRunSource: WorkflowHandlerMock;
+    getWorkflowJobExecutionContext: WorkflowHandlerMock;
+    listExecutionTriggerEvents: WorkflowHandlerMock;
+    getExecutionTriggerEvent: WorkflowHandlerMock;
+    getWorkflowStepAttemptDetail: WorkflowHandlerMock;
+    listWorkflowRunAnnotations: WorkflowHandlerMock;
+    listWorkflowRunJobExplanations: WorkflowHandlerMock;
+    listFailedStepAttempts: WorkflowHandlerMock;
+    getLatestRunAttempt: WorkflowHandlerMock;
+    getLatestStepAttempt: WorkflowHandlerMock;
+  };
+}
+
+export function createTestWorkflowsClient(): TestWorkflowsClient {
+  const handlers = {
+    listWorkflowRuns: vi.fn(),
+    getWorkflowRunOverview: vi.fn(),
+    listWorkflowRunAttempts: vi.fn(),
+    listWorkflowRunJobs: vi.fn(),
+    getWorkflowJobDetail: vi.fn(),
+    listWorkflowJobExecutions: vi.fn(),
+    listWorkflowExecutionSteps: vi.fn(),
+    listWorkflowStepAttempts: vi.fn(),
+    getWorkflowRunSource: vi.fn(),
+    getWorkflowJobExecutionContext: vi.fn(),
+    listExecutionTriggerEvents: vi.fn(),
+    getExecutionTriggerEvent: vi.fn(),
+    getWorkflowStepAttemptDetail: vi.fn(),
+    listWorkflowRunAnnotations: vi.fn(),
+    listWorkflowRunJobExplanations: vi.fn(),
+    listFailedStepAttempts: vi.fn(),
+    getLatestRunAttempt: vi.fn(),
+    getLatestStepAttempt: vi.fn(),
+  };
+  const workflows = createFakeInterModuleClients({
+    workflows: defineInterModulePresentation(workflowsInterModuleContract, {
+      startRunFromTrigger: vi.fn(),
+      startDevRun: vi.fn(),
+      resolveWorkflowRunTriggerReference: vi.fn(),
+      deliverEventToJobListener: vi.fn(),
+      getStepLogContext: vi.fn(),
+      listJobStepAttempts: vi.fn(),
+      getLeasedAgentToolContext: vi.fn(),
+      getLeasedAgentSessionContext: vi.fn(),
+      listWorkflowRuns: (input) => handlers.listWorkflowRuns(input),
+      getWorkflowRunOverview: (input) => handlers.getWorkflowRunOverview(input),
+      listWorkflowRunAttempts: (input) => handlers.listWorkflowRunAttempts(input),
+      listWorkflowRunJobs: (input) => handlers.listWorkflowRunJobs(input),
+      getWorkflowJobDetail: (input) => handlers.getWorkflowJobDetail(input),
+      listWorkflowJobExecutions: (input) => handlers.listWorkflowJobExecutions(input),
+      listWorkflowExecutionSteps: (input) => handlers.listWorkflowExecutionSteps(input),
+      listWorkflowStepAttempts: (input) => handlers.listWorkflowStepAttempts(input),
+      getWorkflowRunSource: (input) => handlers.getWorkflowRunSource(input),
+      getWorkflowJobExecutionContext: (input) => handlers.getWorkflowJobExecutionContext(input),
+      listExecutionTriggerEvents: (input) => handlers.listExecutionTriggerEvents(input),
+      getExecutionTriggerEvent: (input) => handlers.getExecutionTriggerEvent(input),
+      getWorkflowStepAttemptDetail: (input) => handlers.getWorkflowStepAttemptDetail(input),
+      listWorkflowRunAnnotations: (input) => handlers.listWorkflowRunAnnotations(input),
+      listWorkflowRunJobExplanations: (input) => handlers.listWorkflowRunJobExplanations(input),
+      listFailedStepAttempts: (input) => handlers.listFailedStepAttempts(input),
+      getWorkflowRunDetail: vi.fn(),
+      getStepAttemptDetail: vi.fn(),
+      getLatestRunAttempt: (input) => handlers.getLatestRunAttempt(input),
+      getLatestStepAttempt: (input) => handlers.getLatestStepAttempt(input),
+    }),
+  }).workflows;
+
+  return {workflows, handlers};
+}

--- a/libs/api/workflows/src/presentation/inter-module.test.ts
+++ b/libs/api/workflows/src/presentation/inter-module.test.ts
@@ -14,6 +14,7 @@ import {
 import {
   decodeNumberIdCursor,
   decodeTimestampIdCursor,
+  encodeNumberIdCursor,
   encodeTimestampIdCursor,
 } from '@shipfox/node-drizzle';
 import {createFakeInterModuleClients} from '@shipfox/node-module/inter-module/testing';
@@ -302,6 +303,25 @@ describe('Workflows inter-module presentation', () => {
       workspaceId,
       workflowRunId,
       workflowRunAttempt: attempt,
+      limit: 100,
+    });
+    const annotationCursor = {value: 7, id: crypto.randomUUID()};
+    await expect(
+      presentation.handlers.listWorkflowRunAnnotations(
+        {
+          workspaceId,
+          workflowRunId,
+          limit: 100,
+          cursor: encodeNumberIdCursor(annotationCursor),
+        },
+        context,
+      ),
+    ).resolves.toEqual({workflow_run_attempt: attempt, items: [], nextCursor: null});
+    expect(listAnnotationsForRunAttempt).toHaveBeenNthCalledWith(2, {
+      workspaceId,
+      workflowRunId,
+      workflowRunAttempt: attempt,
+      cursor: annotationCursor,
       limit: 100,
     });
     await expect(

--- a/libs/api/workflows/src/presentation/inter-module.test.ts
+++ b/libs/api/workflows/src/presentation/inter-module.test.ts
@@ -1,3 +1,4 @@
+import {annotationsInterModuleContract} from '@shipfox/annotations-dto/inter-module';
 import {createWorkflowModelSnapshot} from '@shipfox/api-definitions-dto';
 import {
   MAX_RESOLVED_STEP_CONFIG_BYTES,
@@ -5,12 +6,17 @@ import {
 } from '@shipfox/api-workflows-dto';
 import {workflowsInterModuleContract} from '@shipfox/api-workflows-dto/inter-module';
 import {workspacesInterModuleContract} from '@shipfox/api-workspaces-dto/inter-module';
-import {createInterModuleKnownError, isInterModuleKnownError} from '@shipfox/inter-module';
+import {
+  createInterModuleKnownError,
+  defineInterModulePresentation,
+  isInterModuleKnownError,
+} from '@shipfox/inter-module';
 import {
   decodeNumberIdCursor,
   decodeTimestampIdCursor,
   encodeTimestampIdCursor,
 } from '@shipfox/node-drizzle';
+import {createFakeInterModuleClients} from '@shipfox/node-module/inter-module/testing';
 import type {WorkflowRun} from '#core/entities/workflow-run.js';
 import {
   InvalidJobRunnerLabelsError,
@@ -253,13 +259,18 @@ describe('Workflows inter-module presentation', () => {
     mocks.listFailedStepAttempts.mockResolvedValue([]);
     mocks.getWorkflowRunAttemptIdForScope.mockResolvedValue(crypto.randomUUID());
     mocks.getWorkflowRunAnnotationOrigins.mockResolvedValue([]);
-    const annotations = {
-      listAnnotationsForRunAttempt: vi.fn().mockResolvedValue({
-        annotations: [],
-        hasMore: false,
-        nextCursor: null,
+    const listAnnotationsForRunAttempt = vi.fn().mockResolvedValue({
+      annotations: [],
+      hasMore: false,
+      nextCursor: null,
+    });
+    const annotations = createFakeInterModuleClients({
+      annotations: defineInterModulePresentation(annotationsInterModuleContract, {
+        replaceOrRemoveAnnotation: () => ({}),
+        listAnnotationsForRunAttempt: (annotationInput) =>
+          listAnnotationsForRunAttempt(annotationInput),
       }),
-    };
+    }).annotations;
     const presentation = createWorkflowsInterModulePresentation({
       agent: {} as never,
       annotations: annotations as never,
@@ -287,6 +298,12 @@ describe('Workflows inter-module presentation', () => {
         context,
       ),
     ).resolves.toEqual({workflow_run_attempt: attempt, items: [], nextCursor: null});
+    expect(listAnnotationsForRunAttempt).toHaveBeenCalledWith({
+      workspaceId,
+      workflowRunId,
+      workflowRunAttempt: attempt,
+      limit: 100,
+    });
     await expect(
       presentation.handlers.listFailedStepAttempts(
         {workspaceId, workflowRunId, limit: 10},

--- a/libs/api/workflows/src/presentation/inter-module.ts
+++ b/libs/api/workflows/src/presentation/inter-module.ts
@@ -568,7 +568,7 @@ export function createWorkflowsInterModulePresentation(params: {
         workspaceId: input.workspaceId,
         workflowRunId: scope.id,
         workflowRunAttempt: attempt,
-        cursor: decodeNumberCursor(input.cursor),
+        ...(input.cursor ? {cursor: decodeNumberCursor(input.cursor)} : {}),
         limit: input.limit,
       });
       const origins = await getWorkflowRunAnnotationOrigins({

--- a/libs/api/workflows/src/presentation/routes/list-run-annotations.test.ts
+++ b/libs/api/workflows/src/presentation/routes/list-run-annotations.test.ts
@@ -1,10 +1,12 @@
-import type {AnnotationsInterModuleClient} from '@shipfox/annotations-dto/inter-module';
+import {annotationsInterModuleContract} from '@shipfox/annotations-dto/inter-module';
 import {buildUserContext, setUserContext} from '@shipfox/api-auth-context';
 import type {ProjectsModuleClient} from '@shipfox/api-projects-dto/inter-module';
 import {
   workflowRunAnnotationsResponseSchema,
   workflowRunJobExplanationsResponseSchema,
 } from '@shipfox/api-workflows-dto';
+import {defineInterModulePresentation} from '@shipfox/inter-module';
+import {createFakeInterModuleClients} from '@shipfox/node-module/inter-module/testing';
 import {inArray} from 'drizzle-orm';
 import type {FastifyInstance} from 'fastify';
 import Fastify from 'fastify';
@@ -36,10 +38,12 @@ const projects = {
   requireProjectForWorkspace: vi.fn(),
 } as unknown as ProjectsModuleClient;
 const listAnnotationsForRunAttempt = vi.fn();
-const annotations = {
-  replaceOrRemoveAnnotation: vi.fn(),
-  listAnnotationsForRunAttempt,
-} as unknown as AnnotationsInterModuleClient;
+const annotations = createFakeInterModuleClients({
+  annotations: defineInterModulePresentation(annotationsInterModuleContract, {
+    replaceOrRemoveAnnotation: () => ({}),
+    listAnnotationsForRunAttempt: (input) => listAnnotationsForRunAttempt(input),
+  }),
+}).annotations;
 
 describe('workflow run annotation and job explanation routes', () => {
   let app: FastifyInstance;
@@ -106,7 +110,7 @@ describe('workflow run annotation and job explanation routes', () => {
       body: 'https://example.com/deployments/1',
     };
     listAnnotationsForRunAttempt.mockResolvedValueOnce({
-      annotations: [annotation],
+      annotations: [{...annotation, createdAt: '2026-09-04T20:25:04.535Z'}],
       hasMore: true,
       nextCursor: {value: 1, id: annotation.id},
     });
@@ -140,7 +144,6 @@ describe('workflow run annotation and job explanation routes', () => {
       workflowRunId: fixture.run.id,
       workflowRunAttempt: 1,
       limit: 1,
-      cursor: undefined,
     });
 
     listAnnotationsForRunAttempt.mockResolvedValueOnce({
@@ -194,7 +197,10 @@ describe('workflow run annotation and job explanation routes', () => {
       body: 'https://example.com/deployments/unavailable',
     };
     listAnnotationsForRunAttempt.mockResolvedValue({
-      annotations: [unavailableAnnotation, validAnnotation],
+      annotations: [unavailableAnnotation, validAnnotation].map((annotation) => ({
+        ...annotation,
+        createdAt: '2026-09-04T20:25:04.535Z',
+      })),
       hasMore: false,
       nextCursor: null,
     });
@@ -280,7 +286,10 @@ describe('workflow run annotation and job explanation routes', () => {
       body: 'https://example.com/deployments/unavailable',
     };
     listAnnotationsForRunAttempt.mockResolvedValue({
-      annotations: [unavailableAnnotation, validAnnotation],
+      annotations: [unavailableAnnotation, validAnnotation].map((annotation) => ({
+        ...annotation,
+        createdAt: '2026-09-04T20:25:04.535Z',
+      })),
       hasMore: false,
       nextCursor: null,
     });

--- a/libs/api/workflows/src/presentation/routes/list-run-annotations.ts
+++ b/libs/api/workflows/src/presentation/routes/list-run-annotations.ts
@@ -155,7 +155,7 @@ async function readRunAnnotations({
     workspaceId: run.workspaceId,
     workflowRunId: run.id,
     workflowRunAttempt: attempt,
-    cursor,
+    ...(cursor ? {cursor} : {}),
     limit,
   });
 


### PR DESCRIPTION
Annotation reads without a cursor included optional properties with `undefined` values. The inter-module transport rejects those values as non-JSON-safe before contract validation, causing the staging workflow annotation endpoint to fail.

This omits absent optional cursor and job-execution filters from workflow and agent-access requests. The regression coverage now passes the calls through the validated in-memory transport, and the published packages receive a patch Changeset.

Validation: `mise exec -- turbo test check type build depcruise --filter=@shipfox/api-workflows... --filter=@shipfox/api-agent-access...` (199 tasks passed).

Sentry: [API-V](https://shipfox.sentry.io/issues/144999443/)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes inter-module annotation reads and agent tool calls failing when optional cursor, filter, attempt, and execution fields are absent. `undefined` values aren't JSON-safe for the transport, so absent fields are now omitted instead of sent.

**Bug Fixes**
- Omit absent cursor and job-execution fields from annotation reads in `@shipfox/api-workflows` and `@shipfox/api-agent-access`.
- Omit absent cursors, filters, attempts, and execution IDs from paged, workflow traversal, diagnostic, and log tool requests.
- Route regression tests through contract-validated inter-module fakes.
- Add a patch Changeset for `@shipfox/api-workflows` and `@shipfox/api-agent-access`.

<sup>Written for commit e92b446a567133e4be99576712b709086a784199. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1696?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

