### PR TITLE
[api-workflows] Validate direct tool inputs with the server-owned method

### DIFF
--- a/.changeset/validate-tool-methods.md
+++ b/.changeset/validate-tool-methods.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-workflows": patch
+---
+
+Validates direct workflow tool inputs with the server-selected method so method-specific schemas accept the correct arguments.

--- a/libs/api/workflows/src/core/step-config/complete-step-dispatch-config.test.ts
+++ b/libs/api/workflows/src/core/step-config/complete-step-dispatch-config.test.ts
@@ -565,12 +565,7 @@ describe('completeStepDispatchConfig', () => {
       config: {
         tool: {
           method: 'get',
-          input_schema: {
-            type: 'object',
-            properties: {method: {const: 'get'}},
-            required: ['method'],
-            additionalProperties: false,
-          },
+          input_schema: {type: 'object'},
         },
       },
       configPlan: {

--- a/libs/api/workflows/src/core/step-config/complete-step-dispatch-config.test.ts
+++ b/libs/api/workflows/src/core/step-config/complete-step-dispatch-config.test.ts
@@ -556,7 +556,45 @@ describe('completeStepDispatchConfig', () => {
     });
   });
 
-  it('validates fully resolved inputs with the server-owned method', async () => {
+  it('rejects a deferred non-object input before injecting the selected method', async () => {
+    const pending = step({
+      type: 'tool',
+      config: {
+        tool: {
+          method: 'get',
+          input_schema: {
+            type: 'object',
+            properties: {method: {const: 'get'}},
+            required: ['method'],
+            additionalProperties: false,
+          },
+        },
+      },
+      configPlan: {
+        tool: {
+          with: plannedField(template('steps.build.outputs.count')).segments,
+        },
+      },
+    });
+
+    const act = () =>
+      completeStepDispatchConfig({
+        step: pending,
+        context: {
+          ...context,
+          values: {steps: {build: {outputs: {count: 42}}}},
+        },
+        resolveAgentDefaults,
+        definitionId: 'def-1',
+      });
+
+    await expect(act()).rejects.toMatchObject({
+      name: 'ToolConfigInvalidError',
+      code: 'tool_config_invalid',
+    });
+  });
+
+  it('forwards the server-owned method for fully resolved inputs', async () => {
     const pending = step({
       type: 'tool',
       config: {
@@ -598,6 +636,38 @@ describe('completeStepDispatchConfig', () => {
           method: 'get_status',
           input_schema: methodConditionedToolInputSchema(),
           with: {owner: 'ShipfoxHQ', repo: 'shipfox', pull_number: 1},
+        },
+      },
+      configPlan: null,
+    });
+
+    const act = () =>
+      completeStepDispatchConfig({
+        step: pending,
+        context,
+        resolveAgentDefaults,
+        definitionId: 'def-1',
+      });
+
+    await expect(act()).rejects.toMatchObject({
+      name: 'ToolConfigInvalidError',
+      code: 'tool_config_invalid',
+    });
+  });
+
+  it('rejects selected methods that are absent from the provider input schema', async () => {
+    const pending = step({
+      type: 'tool',
+      config: {
+        tool: {
+          method: 'search',
+          input_schema: {
+            type: 'object',
+            additionalProperties: false,
+            properties: {query: {type: 'string'}},
+            required: ['query'],
+          },
+          with: {query: 'open issues'},
         },
       },
       configPlan: null,
@@ -708,6 +778,33 @@ describe('completeStepDispatchConfig', () => {
       });
 
     await expect(act()).rejects.toBeInstanceOf(ToolConfigInvalidError);
+  });
+
+  it('wraps provider input schema compilation failures', async () => {
+    const pending = step({
+      type: 'tool',
+      config: {
+        tool: {
+          input_schema: {required: ['query']},
+          with: {query: 'open issues'},
+        },
+      },
+      configPlan: null,
+    });
+
+    const act = () =>
+      completeStepDispatchConfig({
+        step: pending,
+        context,
+        resolveAgentDefaults,
+        definitionId: 'def-1',
+      });
+
+    await expect(act()).rejects.toMatchObject({
+      name: 'ToolConfigInvalidError',
+      code: 'tool_config_invalid',
+      message: expect.stringContaining('Tool input schema is invalid:'),
+    });
   });
 
   it('rejects invalid resolved working directories', async () => {

--- a/libs/api/workflows/src/core/step-config/complete-step-dispatch-config.test.ts
+++ b/libs/api/workflows/src/core/step-config/complete-step-dispatch-config.test.ts
@@ -12,7 +12,11 @@ import {createInterModuleKnownError} from '@shipfox/inter-module';
 import {agentThinkingSchema} from '@shipfox/workflow-document';
 import type {AgentDefaultsResolver} from '#core/agent-defaults.js';
 import type {Step} from '#core/entities/step.js';
-import {AgentConfigUnresolvableError, InterpolationUnresolvableError} from '#core/errors.js';
+import {
+  AgentConfigUnresolvableError,
+  InterpolationUnresolvableError,
+  ToolConfigInvalidError,
+} from '#core/errors.js';
 import {completeStepDispatchConfig} from './complete-step-dispatch-config.js';
 import type {WorkflowEvaluationContext} from './workflow-evaluation-context.js';
 
@@ -73,6 +77,26 @@ const context: WorkflowEvaluationContext = {
     },
   },
 };
+
+function methodConditionedToolInputSchema() {
+  return {
+    type: 'object',
+    additionalProperties: false,
+    properties: {
+      method: {type: 'string', enum: ['get', 'get_status', 'get_check_runs']},
+      owner: {type: 'string'},
+      repo: {type: 'string'},
+      pull_number: {type: 'integer'},
+      ref: {type: 'string'},
+    },
+    required: ['method', 'owner', 'repo', 'pull_number'],
+    oneOf: [
+      {properties: {method: {const: 'get'}}, required: []},
+      {properties: {method: {const: 'get_status'}}, required: ['ref']},
+      {properties: {method: {const: 'get_check_runs'}}, required: ['ref']},
+    ],
+  };
+}
 
 const resolveAgentDefaults: AgentDefaultsResolver = (params) => ({
   harness: params.harness ?? 'pi',
@@ -488,7 +512,7 @@ describe('completeStepDispatchConfig', () => {
             required: ['owner', 'count', 'enabled', 'options', 'method'],
             additionalProperties: false,
           },
-          with: {owner: 'acme'},
+          with: {owner: 'acme', method: 'create'},
           output_mappings: {identifier: {source: 'result.identifier'}},
         },
       },
@@ -530,6 +554,160 @@ describe('completeStepDispatchConfig', () => {
       },
       output_mappings: {identifier: {source: 'result.identifier'}},
     });
+  });
+
+  it('validates fully resolved inputs with the server-owned method', async () => {
+    const pending = step({
+      type: 'tool',
+      config: {
+        tool: {
+          method: 'get',
+          input_schema: methodConditionedToolInputSchema(),
+          with: {
+            owner: 'ShipfoxHQ',
+            repo: 'shipfox',
+            pull_number: 1,
+          },
+        },
+      },
+      configPlan: null,
+    });
+
+    const result = await completeStepDispatchConfig({
+      step: pending,
+      context,
+      resolveAgentDefaults,
+      definitionId: 'def-1',
+    });
+
+    expect(result.config.tool).toMatchObject({
+      with: {
+        method: 'get',
+        owner: 'ShipfoxHQ',
+        repo: 'shipfox',
+        pull_number: 1,
+      },
+    });
+  });
+
+  it('rejects a method-conditioned input without its required parent property', async () => {
+    const pending = step({
+      type: 'tool',
+      config: {
+        tool: {
+          method: 'get_status',
+          input_schema: methodConditionedToolInputSchema(),
+          with: {owner: 'ShipfoxHQ', repo: 'shipfox', pull_number: 1},
+        },
+      },
+      configPlan: null,
+    });
+
+    const act = () =>
+      completeStepDispatchConfig({
+        step: pending,
+        context,
+        resolveAgentDefaults,
+        definitionId: 'def-1',
+      });
+
+    await expect(act()).rejects.toMatchObject({
+      name: 'ToolConfigInvalidError',
+      code: 'tool_config_invalid',
+    });
+  });
+
+  it('validates deferred inputs against the selected method branch', async () => {
+    const pending = step({
+      type: 'tool',
+      config: {
+        tool: {
+          method: 'get_status',
+          input_schema: methodConditionedToolInputSchema(),
+          with: {owner: 'ShipfoxHQ', repo: 'shipfox', pull_number: 1},
+        },
+      },
+      configPlan: {
+        tool: {
+          with: {
+            ref: plannedField(template('steps.build.outputs.sha')).segments,
+          },
+        },
+      },
+    });
+
+    const result = await completeStepDispatchConfig({
+      step: pending,
+      context,
+      resolveAgentDefaults,
+      definitionId: 'def-1',
+    });
+
+    expect(result.config.tool).toMatchObject({
+      with: {
+        method: 'get_status',
+        owner: 'ShipfoxHQ',
+        repo: 'shipfox',
+        pull_number: 1,
+        ref: 'abc123',
+      },
+    });
+  });
+
+  it('keeps valid standalone tool inputs unchanged', async () => {
+    const pending = step({
+      type: 'tool',
+      config: {
+        tool: {
+          input_schema: {
+            type: 'object',
+            additionalProperties: false,
+            properties: {query: {type: 'string'}},
+            required: ['query'],
+          },
+          with: {query: 'open issues'},
+        },
+      },
+      configPlan: null,
+    });
+
+    const result = await completeStepDispatchConfig({
+      step: pending,
+      context,
+      resolveAgentDefaults,
+      definitionId: 'def-1',
+    });
+
+    expect(result.config.tool).toMatchObject({with: {query: 'open issues'}});
+    expect((result.config.tool as {with: object}).with).not.toHaveProperty('method');
+  });
+
+  it('rejects invalid standalone tool inputs', async () => {
+    const pending = step({
+      type: 'tool',
+      config: {
+        tool: {
+          input_schema: {
+            type: 'object',
+            additionalProperties: false,
+            properties: {query: {type: 'string'}},
+            required: ['query'],
+          },
+          with: {query: 42},
+        },
+      },
+      configPlan: null,
+    });
+
+    const act = () =>
+      completeStepDispatchConfig({
+        step: pending,
+        context,
+        resolveAgentDefaults,
+        definitionId: 'def-1',
+      });
+
+    await expect(act()).rejects.toBeInstanceOf(ToolConfigInvalidError);
   });
 
   it('rejects invalid resolved working directories', async () => {

--- a/libs/api/workflows/src/core/step-config/complete-step-dispatch-config.test.ts
+++ b/libs/api/workflows/src/core/step-config/complete-step-dispatch-config.test.ts
@@ -556,7 +556,10 @@ describe('completeStepDispatchConfig', () => {
     });
   });
 
-  it('rejects a deferred non-object input before injecting the selected method', async () => {
+  it.each([
+    {kind: 'scalar', value: 42},
+    {kind: 'array', value: ['a', 'b']},
+  ])('rejects a deferred $kind input before injecting the selected method', async ({value}) => {
     const pending = step({
       type: 'tool',
       config: {
@@ -572,7 +575,7 @@ describe('completeStepDispatchConfig', () => {
       },
       configPlan: {
         tool: {
-          with: plannedField(template('steps.build.outputs.count')).segments,
+          with: plannedField(template('steps.build.outputs.input')).segments,
         },
       },
     });
@@ -582,7 +585,7 @@ describe('completeStepDispatchConfig', () => {
         step: pending,
         context: {
           ...context,
-          values: {steps: {build: {outputs: {count: 42}}}},
+          values: {steps: {build: {outputs: {input: value}}}},
         },
         resolveAgentDefaults,
         definitionId: 'def-1',

--- a/libs/api/workflows/src/core/step-config/complete-step-dispatch-config.ts
+++ b/libs/api/workflows/src/core/step-config/complete-step-dispatch-config.ts
@@ -124,17 +124,20 @@ function completeToolConfig(params: {
   const baseWith = toolConfig.with;
   toolConfig.with = mergeToolWith(baseWith, toolPlan?.with, params, 'tool.with');
   const method = toolConfig.method;
-  const input = toolConfig.with ?? {};
-  const schema = withoutInjectedMethod(toolConfig.input_schema);
+  const input =
+    method === undefined
+      ? (toolConfig.with ?? {})
+      : {...(toolConfig.with as Record<string, unknown> | undefined), method};
   const ajv = new Ajv({
     strict: true,
+    strictRequired: false,
     coerceTypes: false,
     useDefaults: false,
     removeAdditional: false,
   });
   let valid = false;
   try {
-    const validate = ajv.compile(schema as AnySchema);
+    const validate = ajv.compile(toolConfig.input_schema as AnySchema);
     valid = validate(input) === true;
   } catch (error) {
     throw new ToolConfigInvalidError(
@@ -142,9 +145,7 @@ function completeToolConfig(params: {
     );
   }
   if (!valid) throw new ToolConfigInvalidError(`Tool input is invalid: ${ajv.errorsText()}`);
-  if (method !== undefined) {
-    toolConfig.with = {...(toolConfig.with as Record<string, unknown>), method};
-  }
+  if (method !== undefined) toolConfig.with = input;
   params.config.tool = toolConfig;
 }
 
@@ -202,17 +203,6 @@ function isFieldTemplate(value: unknown): value is readonly ResolvedFieldSegment
         (segment.kind === 'literal' || segment.kind === 'deferred'),
     )
   );
-}
-
-function withoutInjectedMethod(schema: unknown): unknown {
-  if (schema === null || typeof schema !== 'object' || Array.isArray(schema)) return schema;
-  const copy = {...(schema as Record<string, unknown>)};
-  if (copy.properties && typeof copy.properties === 'object' && !Array.isArray(copy.properties)) {
-    copy.properties = {...(copy.properties as Record<string, unknown>)};
-    delete (copy.properties as Record<string, unknown>).method;
-  }
-  if (Array.isArray(copy.required)) copy.required = copy.required.filter((key) => key !== 'method');
-  return copy;
 }
 
 function completeCheckoutConfig(params: {

--- a/libs/api/workflows/src/core/step-config/complete-step-dispatch-config.ts
+++ b/libs/api/workflows/src/core/step-config/complete-step-dispatch-config.ts
@@ -124,10 +124,14 @@ function completeToolConfig(params: {
   const baseWith = toolConfig.with;
   toolConfig.with = mergeToolWith(baseWith, toolPlan?.with, params, 'tool.with');
   const method = toolConfig.method;
-  const input =
-    method === undefined
-      ? (toolConfig.with ?? {})
-      : {...(toolConfig.with as Record<string, unknown> | undefined), method};
+  const input = toolConfig.with ?? {};
+  if (method !== undefined && (typeof input !== 'object' || Array.isArray(input))) {
+    throw new ToolConfigInvalidError(
+      'Tool input is invalid: expected an object when a method is selected',
+    );
+  }
+  const inputWithMethod =
+    method === undefined ? input : {...(input as Record<string, unknown>), method};
   const ajv = new Ajv({
     strict: true,
     strictRequired: false,
@@ -138,14 +142,14 @@ function completeToolConfig(params: {
   let valid = false;
   try {
     const validate = ajv.compile(toolConfig.input_schema as AnySchema);
-    valid = validate(input) === true;
+    valid = validate(inputWithMethod) === true;
   } catch (error) {
     throw new ToolConfigInvalidError(
       `Tool input schema is invalid: ${error instanceof Error ? error.message : String(error)}`,
     );
   }
   if (!valid) throw new ToolConfigInvalidError(`Tool input is invalid: ${ajv.errorsText()}`);
-  if (method !== undefined) toolConfig.with = input;
+  if (method !== undefined) toolConfig.with = inputWithMethod;
   params.config.tool = toolConfig;
 }
 


### PR DESCRIPTION
Direct workflow tool steps could fail before provider invocation when provider schemas use method-conditioned `oneOf` branches. Dispatch removed the selected method before validation, which made valid branches ambiguous and could trigger AJV's structural `strictRequired` lint.

Validate the complete provider schema with the server-owned method included. AJV strict mode remains enabled, with only `strictRequired` disabled, so runtime required checks and `tool_config_invalid` classification remain intact. The selected method is also the value sent to the provider when authored arguments contain `with.method`.

Includes a patch Changeset for `@shipfox/api-workflows` so the release pipeline can update Cloud's server package closure.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validates direct workflow tool inputs with the server-selected method so method-conditioned schemas accept the correct arguments instead of failing before provider invocation.

- Previously the method was stripped before validation, which made valid `oneOf` branches ambiguous and triggered AJV's structural `strictRequired` lint.
- Validation now runs against the full provider schema with the method included; AJV strict mode stays on with only `strictRequired` disabled, and schema compilation failures surface as `ToolConfigInvalidError`.
- Non-object tool inputs (scalars and arrays) are rejected before the method is injected, and the selected method is written into `with` alongside authored arguments.
- Adds a patch Changeset for `@shipfox/api-workflows` so Cloud's server package closure can be updated.

<sup>Written for commit d37f074572eae675c688a8cfc0e32052392652ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1697?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

