### PR TITLE
Add web-search usage counts and shared token normalization

### DIFF
--- a/.changeset/usage-segment-searches.md
+++ b/.changeset/usage-segment-searches.md
@@ -4,3 +4,5 @@
 ---
 
 Adds web-search quantities to Usage segments and exports shared per-dialect token-class normalization.
+
+Roll out Usage consumers before producers. Drain the Usage outbox before rollback. If rollback follows new event writes, redeploy this version before replaying those events.

--- a/.changeset/usage-segment-searches.md
+++ b/.changeset/usage-segment-searches.md
@@ -1,0 +1,6 @@
+---
+"@shipfox/api-usage": minor
+"@shipfox/api-usage-dto": minor
+---
+
+Adds web-search quantities to Usage segments and exports shared per-dialect token-class normalization.

--- a/.changeset/usage-segment-searches.md
+++ b/.changeset/usage-segment-searches.md
@@ -4,5 +4,3 @@
 ---
 
 Adds web-search quantities to Usage segments and exports shared per-dialect token-class normalization.
-
-Roll out Usage consumers before producers. Drain the Usage outbox before rollback. If rollback follows new event writes, redeploy this version before replaying those events.

--- a/libs/api/usage-dto/src/events.test.ts
+++ b/libs/api/usage-dto/src/events.test.ts
@@ -6,6 +6,7 @@ import {
   usageInferenceSegmentRecordedEventSchema,
   usageJobExecutionRecordedEventSchema,
 } from './events.js';
+import {inferenceSegmentInputSchema} from './schemas/usage.js';
 
 const ids = {
   workspaceId: crypto.randomUUID(),
@@ -104,6 +105,25 @@ describe('Usage event contracts', () => {
     expect(() =>
       usageInferenceSegmentRecordedEventSchema.parse({...validSegment, version: 1, extra: true}),
     ).toThrow();
+  });
+
+  it('accepts the maximum persisted web-search count', () => {
+    const {id, recordedAt, ...validInputSegment} = validSegment;
+    void id;
+    void recordedAt;
+    expect(
+      inferenceSegmentInputSchema.parse({
+        ...validInputSegment,
+        webSearchRequests: 2_147_483_647,
+      }),
+    ).toEqual({...validInputSegment, webSearchRequests: 2_147_483_647});
+    expect(
+      usageInferenceSegmentRecordedEventSchema.parse({
+        ...validSegment,
+        webSearchRequests: 2_147_483_647,
+        version: 1,
+      }),
+    ).toMatchObject({webSearchRequests: 2_147_483_647});
   });
 
   it('rejects invalid inference windows and unsafe counters', () => {

--- a/libs/api/usage-dto/src/events.test.ts
+++ b/libs/api/usage-dto/src/events.test.ts
@@ -67,6 +67,7 @@ const validSegment = {
   cacheCreationTokens: 0,
   cacheReadTokens: 4,
   reasoningTokens: 6,
+  webSearchRequests: 1,
   recordedAt: '2026-09-04T10:01:00.000Z',
 };
 

--- a/libs/api/usage-dto/src/events.test.ts
+++ b/libs/api/usage-dto/src/events.test.ts
@@ -87,6 +87,14 @@ describe('Usage event contracts', () => {
       ...validSegment,
       version: 1,
     });
+
+    const {webSearchRequests, ...legacySegment} = validSegment;
+    void webSearchRequests;
+    expect(usageInferenceSegmentRecordedEventSchema.parse({...legacySegment, version: 1})).toEqual({
+      ...legacySegment,
+      webSearchRequests: 0,
+      version: 1,
+    });
   });
 
   it('rejects unknown fields and non-v1 event versions', () => {
@@ -124,6 +132,13 @@ describe('Usage event contracts', () => {
       usageInferenceSegmentRecordedEventSchema.parse({
         ...validSegment,
         inputTokens: Number.MAX_SAFE_INTEGER + 1,
+        version: 1,
+      }),
+    ).toThrow();
+    expect(() =>
+      usageInferenceSegmentRecordedEventSchema.parse({
+        ...validSegment,
+        webSearchRequests: 2_147_483_648,
         version: 1,
       }),
     ).toThrow();

--- a/libs/api/usage-dto/src/index.ts
+++ b/libs/api/usage-dto/src/index.ts
@@ -9,12 +9,15 @@ export {
   usageJobExecutionRecordedEventSchema,
 } from './events.js';
 export {
+  type InferenceSegmentDialect,
   type InferenceSegmentInputDto,
   type InferenceSegmentUsageDto,
   type InferenceSegmentUsageHttpDto,
+  inferenceSegmentDialects,
   inferenceSegmentInputSchema,
   inferenceSegmentUsageHttpSchema,
   inferenceSegmentUsageSchema,
+  isOpenAiInferenceDialect,
   type JobExecutionUsageDto,
   type JobExecutionUsageHttpDto,
   type JobExecutionUsageResponseDto,
@@ -23,6 +26,7 @@ export {
   jobExecutionUsageSchema,
   MAX_INFERENCE_SEGMENTS_BATCH_SIZE,
   MAX_USAGE_REPLAY_LIMIT,
+  MAX_WEB_SEARCH_REQUESTS,
   type RecordedJobExecutionUsageDto,
   type RunUsageResponseDto,
   recordedJobExecutionUsageSchema,

--- a/libs/api/usage-dto/src/index.ts
+++ b/libs/api/usage-dto/src/index.ts
@@ -32,3 +32,7 @@ export {
   usageJobExecutionStatusSchema,
   usageRunResponseSchema,
 } from './schemas/usage.js';
+export {
+  type NormalisedTokenClasses,
+  normaliseTokenClasses,
+} from './token-classes.js';

--- a/libs/api/usage-dto/src/inter-module.test.ts
+++ b/libs/api/usage-dto/src/inter-module.test.ts
@@ -23,6 +23,7 @@ const segmentInput = (segmentKey: string) => ({
   cacheCreationTokens: 0,
   cacheReadTokens: 0,
   reasoningTokens: 0,
+  webSearchRequests: 0,
 });
 
 describe('usageInterModuleContract', () => {

--- a/libs/api/usage-dto/src/schemas/usage.ts
+++ b/libs/api/usage-dto/src/schemas/usage.ts
@@ -8,6 +8,26 @@ const usageCountSchema = z.number().int().nonnegative().max(Number.MAX_SAFE_INTE
 
 export const MAX_USAGE_REPLAY_LIMIT = 500;
 export const MAX_INFERENCE_SEGMENTS_BATCH_SIZE = 1_000;
+export const MAX_WEB_SEARCH_REQUESTS = 2_147_483_647;
+
+export const inferenceSegmentDialects = [
+  'anthropic-messages',
+  'openai-completions',
+  'openai-responses',
+] as const;
+export type InferenceSegmentDialect = (typeof inferenceSegmentDialects)[number];
+
+const openAiInferenceDialectSet: ReadonlySet<InferenceSegmentDialect> = new Set([
+  'openai-completions',
+  'openai-responses',
+]);
+
+export function isOpenAiInferenceDialect(dialect: InferenceSegmentDialect): boolean {
+  return openAiInferenceDialectSet.has(dialect);
+}
+
+const inferenceSegmentDialectSchema = z.enum(inferenceSegmentDialects);
+const webSearchRequestCountSchema = usageCountSchema.max(MAX_WEB_SEARCH_REQUESTS).default(0);
 
 export const usageJobExecutionStateSchema = z.enum(['queued', 'running', 'terminated']);
 export const usageJobExecutionStatusSchema = z.enum(['succeeded', 'failed', 'cancelled']);
@@ -69,7 +89,7 @@ const inferenceSegmentInputObjectSchema = z
     stepAttemptId: idSchema,
     upstream: nonEmptyStringSchema,
     model: nonEmptyStringSchema,
-    dialect: z.enum(['anthropic-messages', 'openai-completions', 'openai-responses']),
+    dialect: inferenceSegmentDialectSchema,
     windowStart: inferenceWindowDateTimeSchema,
     windowEnd: inferenceWindowDateTimeSchema,
     requestCount: usageCountSchema,
@@ -78,7 +98,7 @@ const inferenceSegmentInputObjectSchema = z
     cacheCreationTokens: usageCountSchema,
     cacheReadTokens: usageCountSchema,
     reasoningTokens: usageCountSchema,
-    webSearchRequests: usageCountSchema,
+    webSearchRequests: webSearchRequestCountSchema,
   })
   .strict();
 
@@ -144,7 +164,7 @@ const inferenceSegmentUsageHttpObjectSchema = z
     step_attempt_id: idSchema,
     upstream: nonEmptyStringSchema,
     model: nonEmptyStringSchema,
-    dialect: z.enum(['anthropic-messages', 'openai-completions', 'openai-responses']),
+    dialect: inferenceSegmentDialectSchema,
     window_start: inferenceWindowDateTimeSchema,
     window_end: inferenceWindowDateTimeSchema,
     request_count: usageCountSchema,
@@ -153,7 +173,7 @@ const inferenceSegmentUsageHttpObjectSchema = z
     cache_creation_tokens: usageCountSchema,
     cache_read_tokens: usageCountSchema,
     reasoning_tokens: usageCountSchema,
-    web_search_requests: usageCountSchema,
+    web_search_requests: webSearchRequestCountSchema,
     recorded_at: dateTimeSchema,
   })
   .strict();

--- a/libs/api/usage-dto/src/schemas/usage.ts
+++ b/libs/api/usage-dto/src/schemas/usage.ts
@@ -78,6 +78,7 @@ const inferenceSegmentInputObjectSchema = z
     cacheCreationTokens: usageCountSchema,
     cacheReadTokens: usageCountSchema,
     reasoningTokens: usageCountSchema,
+    webSearchRequests: usageCountSchema,
   })
   .strict();
 
@@ -152,6 +153,7 @@ const inferenceSegmentUsageHttpObjectSchema = z
     cache_creation_tokens: usageCountSchema,
     cache_read_tokens: usageCountSchema,
     reasoning_tokens: usageCountSchema,
+    web_search_requests: usageCountSchema,
     recorded_at: dateTimeSchema,
   })
   .strict();

--- a/libs/api/usage-dto/src/token-classes.test.ts
+++ b/libs/api/usage-dto/src/token-classes.test.ts
@@ -1,0 +1,60 @@
+import {normaliseTokenClasses} from './index.js';
+
+const baseSegment = {
+  inputTokens: 100,
+  outputTokens: 30,
+  cacheCreationTokens: 5,
+  cacheReadTokens: 20,
+  reasoningTokens: 9,
+};
+
+describe('normaliseTokenClasses', () => {
+  it('keeps Anthropic reported input and cache-write classes separate', () => {
+    expect(normaliseTokenClasses({...baseSegment, dialect: 'anthropic-messages'})).toEqual({
+      inputTokens: 100,
+      cachedInputTokens: 20,
+      cacheWriteTokens: 5,
+      outputTokens: 30,
+      totalTokens: 155,
+      cacheHitRate: 20 / 120,
+    });
+  });
+
+  it.each([
+    'openai-completions',
+    'openai-responses',
+  ] as const)('subtracts cached input from the OpenAI %s input subset', (dialect) => {
+    expect(normaliseTokenClasses({...baseSegment, dialect})).toEqual({
+      inputTokens: 80,
+      cachedInputTokens: 20,
+      cacheWriteTokens: 0,
+      outputTokens: 30,
+      totalTokens: 130,
+      cacheHitRate: 0.2,
+    });
+  });
+
+  it.each([
+    'anthropic-messages',
+    'openai-completions',
+    'openai-responses',
+  ] as const)('returns zero cache classes and a zero hit rate for an empty %s segment', (dialect) => {
+    expect(
+      normaliseTokenClasses({
+        dialect,
+        inputTokens: 0,
+        outputTokens: 0,
+        cacheCreationTokens: 0,
+        cacheReadTokens: 0,
+        reasoningTokens: 0,
+      }),
+    ).toEqual({
+      inputTokens: 0,
+      cachedInputTokens: 0,
+      cacheWriteTokens: 0,
+      outputTokens: 0,
+      totalTokens: 0,
+      cacheHitRate: 0,
+    });
+  });
+});

--- a/libs/api/usage-dto/src/token-classes.test.ts
+++ b/libs/api/usage-dto/src/token-classes.test.ts
@@ -34,6 +34,24 @@ describe('normaliseTokenClasses', () => {
     });
   });
 
+  it('clamps an OpenAI cache subset that exceeds reported input', () => {
+    expect(
+      normaliseTokenClasses({
+        ...baseSegment,
+        dialect: 'openai-responses',
+        inputTokens: 10,
+        cacheReadTokens: 20,
+      }),
+    ).toEqual({
+      inputTokens: 0,
+      cachedInputTokens: 20,
+      cacheWriteTokens: 0,
+      outputTokens: 30,
+      totalTokens: 50,
+      cacheHitRate: 1,
+    });
+  });
+
   it.each([
     'anthropic-messages',
     'openai-completions',

--- a/libs/api/usage-dto/src/token-classes.ts
+++ b/libs/api/usage-dto/src/token-classes.ts
@@ -1,0 +1,49 @@
+import type {InferenceSegmentInputDto} from './schemas/usage.js';
+
+/** The four token classes used for display and pricing, plus derived totals. */
+export interface NormalisedTokenClasses {
+  inputTokens: number;
+  cachedInputTokens: number;
+  cacheWriteTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+  cacheHitRate: number;
+}
+
+type TokenClassSegment = Pick<
+  InferenceSegmentInputDto,
+  | 'dialect'
+  | 'inputTokens'
+  | 'outputTokens'
+  | 'cacheCreationTokens'
+  | 'cacheReadTokens'
+  | 'reasoningTokens'
+>;
+
+/**
+ * Maps dialect-specific reported counts to the four priced token classes.
+ *
+ * Reasoning tokens are retained in the raw segment for detail views, but are
+ * not added here because they are already included in the reported output
+ * count used for display and pricing.
+ */
+export function normaliseTokenClasses(segment: TokenClassSegment): NormalisedTokenClasses {
+  const isOpenAiDialect =
+    segment.dialect === 'openai-completions' || segment.dialect === 'openai-responses';
+  const cachedInputTokens = segment.cacheReadTokens;
+  const inputTokens = isOpenAiDialect
+    ? segment.inputTokens - cachedInputTokens
+    : segment.inputTokens;
+  const cacheWriteTokens = isOpenAiDialect ? 0 : segment.cacheCreationTokens;
+  const outputTokens = segment.outputTokens;
+  const totalInputTokens = inputTokens + cachedInputTokens;
+
+  return {
+    inputTokens,
+    cachedInputTokens,
+    cacheWriteTokens,
+    outputTokens,
+    totalTokens: inputTokens + cachedInputTokens + cacheWriteTokens + outputTokens,
+    cacheHitRate: totalInputTokens === 0 ? 0 : cachedInputTokens / totalInputTokens,
+  };
+}

--- a/libs/api/usage-dto/src/token-classes.ts
+++ b/libs/api/usage-dto/src/token-classes.ts
@@ -1,4 +1,4 @@
-import type {InferenceSegmentInputDto} from './schemas/usage.js';
+import {type InferenceSegmentInputDto, isOpenAiInferenceDialect} from './schemas/usage.js';
 
 /** The four token classes used for display and pricing, plus derived totals. */
 export interface NormalisedTokenClasses {
@@ -28,11 +28,10 @@ type TokenClassSegment = Pick<
  * count used for display and pricing.
  */
 export function normaliseTokenClasses(segment: TokenClassSegment): NormalisedTokenClasses {
-  const isOpenAiDialect =
-    segment.dialect === 'openai-completions' || segment.dialect === 'openai-responses';
+  const isOpenAiDialect = isOpenAiInferenceDialect(segment.dialect);
   const cachedInputTokens = segment.cacheReadTokens;
   const inputTokens = isOpenAiDialect
-    ? segment.inputTokens - cachedInputTokens
+    ? Math.max(0, segment.inputTokens - cachedInputTokens)
     : segment.inputTokens;
   const cacheWriteTokens = isOpenAiDialect ? 0 : segment.cacheCreationTokens;
   const outputTokens = segment.outputTokens;

--- a/libs/api/usage/drizzle/0001_fat_mach_iv.sql
+++ b/libs/api/usage/drizzle/0001_fat_mach_iv.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "usage_inference_segments" ADD COLUMN "web_search_requests" integer DEFAULT 0 NOT NULL;

--- a/libs/api/usage/drizzle/meta/0001_snapshot.json
+++ b/libs/api/usage/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,688 @@
+{
+  "id": "39869091-86f5-4f98-afd1-601112fbe1ea",
+  "prevId": "e57d5db7-8f6e-4754-bf8a-99cef3ecd152",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.usage_inference_segments": {
+      "name": "usage_inference_segments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "segment_key": {
+          "name": "segment_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow_run_id": {
+          "name": "workflow_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow_run_attempt_id": {
+          "name": "workflow_run_attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_execution_id": {
+          "name": "job_execution_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_id": {
+          "name": "step_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_attempt_id": {
+          "name": "step_attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "upstream": {
+          "name": "upstream",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dialect": {
+          "name": "dialect",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_start": {
+          "name": "window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_end": {
+          "name": "window_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cache_creation_tokens": {
+          "name": "cache_creation_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reasoning_tokens": {
+          "name": "reasoning_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "web_search_requests": {
+          "name": "web_search_requests",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "usage_inference_segments_segment_key_recorded_unique": {
+          "name": "usage_inference_segments_segment_key_recorded_unique",
+          "columns": [
+            {
+              "expression": "segment_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recorded_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "usage_inference_segments_workspace_recorded_idx": {
+          "name": "usage_inference_segments_workspace_recorded_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recorded_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "usage_inference_segments_recorded_id_idx": {
+          "name": "usage_inference_segments_recorded_id_idx",
+          "columns": [
+            {
+              "expression": "recorded_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "usage_inference_segments_workflow_run_idx": {
+          "name": "usage_inference_segments_workflow_run_idx",
+          "columns": [
+            {
+              "expression": "workflow_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "usage_inference_segments_job_execution_idx": {
+          "name": "usage_inference_segments_job_execution_idx",
+          "columns": [
+            {
+              "expression": "job_execution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "usage_inference_segments_step_attempt_idx": {
+          "name": "usage_inference_segments_step_attempt_idx",
+          "columns": [
+            {
+              "expression": "step_attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.usage_job_executions": {
+      "name": "usage_job_executions",
+      "schema": "",
+      "columns": {
+        "job_execution_id": {
+          "name": "job_execution_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow_run_id": {
+          "name": "workflow_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow_run_attempt_id": {
+          "name": "workflow_run_attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "job_key": {
+          "name": "job_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_number": {
+          "name": "run_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_labels": {
+          "name": "requested_labels",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runner_labels": {
+          "name": "runner_labels",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template_key": {
+          "name": "template_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provisioner_id": {
+          "name": "provisioner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provisioner_scope": {
+          "name": "provisioner_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_kind": {
+          "name": "provider_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "launch_kind": {
+          "name": "launch_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runner_class": {
+          "name": "runner_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runner_arch": {
+          "name": "runner_arch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runner_cpu": {
+          "name": "runner_cpu",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "managed": {
+          "name": "managed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "queued_at": {
+          "name": "queued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "queued_at_known": {
+          "name": "queued_at_known",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_expired_at": {
+          "name": "lease_expired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_reason": {
+          "name": "status_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancellation_reason": {
+          "name": "cancellation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_seconds": {
+          "name": "duration_seconds",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "usage_job_executions_workspace_recorded_idx": {
+          "name": "usage_job_executions_workspace_recorded_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recorded_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "usage_job_executions_recorded_job_execution_idx": {
+          "name": "usage_job_executions_recorded_job_execution_idx",
+          "columns": [
+            {
+              "expression": "recorded_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "job_execution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "usage_job_executions_workflow_run_idx": {
+          "name": "usage_job_executions_workflow_run_idx",
+          "columns": [
+            {
+              "expression": "workflow_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "usage_job_executions_job_execution_idx": {
+          "name": "usage_job_executions_job_execution_idx",
+          "columns": [
+            {
+              "expression": "job_execution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.usage_outbox": {
+      "name": "usage_outbox",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ordering_key": {
+          "name": "ordering_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "dispatched_at": {
+          "name": "dispatched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dispatch_attempts": {
+          "name": "dispatch_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_dispatch_at": {
+          "name": "next_dispatch_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_dispatch_error": {
+          "name": "last_dispatch_error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_dispatch_failed_at": {
+          "name": "last_dispatch_failed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dead_lettered_at": {
+          "name": "dead_lettered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "usage_outbox_pending_idx": {
+          "name": "usage_outbox_pending_idx",
+          "columns": [
+            {
+              "expression": "next_dispatch_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"dispatched_at\" IS NULL AND \"dead_lettered_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "usage_outbox_dispatched_retention_idx": {
+          "name": "usage_outbox_dispatched_retention_idx",
+          "columns": [
+            {
+              "expression": "dispatched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"dispatched_at\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/libs/api/usage/drizzle/meta/_journal.json
+++ b/libs/api/usage/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1788532232412,
       "tag": "0000_initial",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1788598553628,
+      "tag": "0001_fat_mach_iv",
+      "breakpoints": true
     }
   ]
 }

--- a/libs/api/usage/src/db/inference-segments.ts
+++ b/libs/api/usage/src/db/inference-segments.ts
@@ -94,6 +94,7 @@ export function recordInferenceSegments(params: {
           cacheCreationTokens: segment.cacheCreationTokens,
           cacheReadTokens: segment.cacheReadTokens,
           reasoningTokens: segment.reasoningTokens,
+          webSearchRequests: segment.webSearchRequests,
           recordedAt,
         })
         .returning();
@@ -222,6 +223,7 @@ export function toInferenceSegmentUsage(row: UsageInferenceSegmentRow): Inferenc
     cacheCreationTokens: row.cacheCreationTokens,
     cacheReadTokens: row.cacheReadTokens,
     reasoningTokens: row.reasoningTokens,
+    webSearchRequests: row.webSearchRequests,
     recordedAt: row.recordedAt.toISOString(),
   };
 }

--- a/libs/api/usage/src/db/schema/inference-segments.ts
+++ b/libs/api/usage/src/db/schema/inference-segments.ts
@@ -1,5 +1,5 @@
 import {sql} from 'drizzle-orm';
-import {bigint, index, text, timestamp, uniqueIndex, uuid} from 'drizzle-orm/pg-core';
+import {bigint, index, integer, text, timestamp, uniqueIndex, uuid} from 'drizzle-orm/pg-core';
 import {pgTable} from './common.js';
 
 export const usageInferenceSegments = pgTable(
@@ -29,6 +29,7 @@ export const usageInferenceSegments = pgTable(
     cacheCreationTokens: bigint('cache_creation_tokens', {mode: 'number'}).notNull(),
     cacheReadTokens: bigint('cache_read_tokens', {mode: 'number'}).notNull(),
     reasoningTokens: bigint('reasoning_tokens', {mode: 'number'}).notNull(),
+    webSearchRequests: integer('web_search_requests').notNull().default(0),
     recordedAt: timestamp('recorded_at', {withTimezone: true}).notNull(),
   },
   (table) => [

--- a/libs/api/usage/src/db/schema/inference-segments.ts
+++ b/libs/api/usage/src/db/schema/inference-segments.ts
@@ -1,3 +1,4 @@
+import {inferenceSegmentDialects} from '@shipfox/api-usage-dto';
 import {sql} from 'drizzle-orm';
 import {bigint, index, integer, text, timestamp, uniqueIndex, uuid} from 'drizzle-orm/pg-core';
 import {pgTable} from './common.js';
@@ -18,9 +19,7 @@ export const usageInferenceSegments = pgTable(
     stepAttemptId: uuid('step_attempt_id').notNull(),
     upstream: text('upstream').notNull(),
     model: text('model').notNull(),
-    dialect: text('dialect', {
-      enum: ['anthropic-messages', 'openai-completions', 'openai-responses'],
-    }).notNull(),
+    dialect: text('dialect', {enum: inferenceSegmentDialects}).notNull(),
     windowStart: timestamp('window_start', {withTimezone: true}).notNull(),
     windowEnd: timestamp('window_end', {withTimezone: true}).notNull(),
     requestCount: bigint('request_count', {mode: 'number'}).notNull(),

--- a/libs/api/usage/src/db/usage.test.ts
+++ b/libs/api/usage/src/db/usage.test.ts
@@ -126,6 +126,7 @@ function inferenceSegment(workspaceId = crypto.randomUUID()) {
     cacheCreationTokens: 0,
     cacheReadTokens: 4,
     reasoningTokens: 6,
+    webSearchRequests: 3,
   };
 }
 
@@ -311,7 +312,10 @@ describe('Usage projections', () => {
     expect(nextPage.nextCursor).toBeNull();
     const firstSegment = page.segments[0];
     if (!firstSegment) throw new Error('Expected a first inference segment');
-    expect(toInferenceSegmentUsage(firstSegment)).toMatchObject({workspaceId});
+    expect(toInferenceSegmentUsage(firstSegment)).toMatchObject({
+      workspaceId,
+      webSearchRequests: 3,
+    });
   });
 
   it('replays terminal job executions by a stable timestamp and id cursor', async () => {

--- a/libs/api/usage/src/db/usage.test.ts
+++ b/libs/api/usage/src/db/usage.test.ts
@@ -327,6 +327,17 @@ describe('Usage projections', () => {
     expect(inferenceSegmentUsageHttpSchema.parse(legacyHttpDto)).toMatchObject({
       web_search_requests: 0,
     });
+
+    const boundaryWorkspaceId = crypto.randomUUID();
+    const boundarySegment = inferenceSegment(boundaryWorkspaceId);
+    boundarySegment.webSearchRequests = 2_147_483_647;
+    await expect(
+      recordInferenceSegments({segments: [boundarySegment], now: recordedAt}),
+    ).resolves.toEqual({recorded: 1, duplicates: 0});
+    const boundaryPage = await listInferenceSegments({workspaceId: boundaryWorkspaceId, limit: 1});
+    const persistedBoundarySegment = boundaryPage.segments[0];
+    if (!persistedBoundarySegment) throw new Error('Expected the boundary inference segment');
+    expect(toInferenceSegmentUsage(persistedBoundarySegment).webSearchRequests).toBe(2_147_483_647);
   });
 
   it('replays terminal job executions by a stable timestamp and id cursor', async () => {

--- a/libs/api/usage/src/db/usage.test.ts
+++ b/libs/api/usage/src/db/usage.test.ts
@@ -1,4 +1,5 @@
 import type {RunnerJobClaimedEvent, RunnerJobLeaseExpiredEvent} from '@shipfox/api-runners-dto';
+import {inferenceSegmentUsageHttpSchema} from '@shipfox/api-usage-dto';
 import type {
   WorkflowsJobExecutionQueuedEventDto,
   WorkflowsJobExecutionTerminatedEventDto,
@@ -319,6 +320,12 @@ describe('Usage projections', () => {
     });
     expect(toInferenceSegmentUsageDto(firstSegment)).toMatchObject({
       web_search_requests: 3,
+    });
+    const {web_search_requests: webSearchRequests, ...legacyHttpDto} =
+      toInferenceSegmentUsageDto(firstSegment);
+    void webSearchRequests;
+    expect(inferenceSegmentUsageHttpSchema.parse(legacyHttpDto)).toMatchObject({
+      web_search_requests: 0,
     });
   });
 

--- a/libs/api/usage/src/db/usage.test.ts
+++ b/libs/api/usage/src/db/usage.test.ts
@@ -4,6 +4,7 @@ import type {
   WorkflowsJobExecutionTerminatedEventDto,
 } from '@shipfox/api-workflows-dto';
 import {eq, sql} from 'drizzle-orm';
+import {toInferenceSegmentUsageDto} from '#presentation/dto.js';
 import {db} from './db.js';
 import {
   listInferenceSegments,
@@ -315,6 +316,9 @@ describe('Usage projections', () => {
     expect(toInferenceSegmentUsage(firstSegment)).toMatchObject({
       workspaceId,
       webSearchRequests: 3,
+    });
+    expect(toInferenceSegmentUsageDto(firstSegment)).toMatchObject({
+      web_search_requests: 3,
     });
   });
 

--- a/libs/api/usage/src/presentation/dto.ts
+++ b/libs/api/usage/src/presentation/dto.ts
@@ -66,6 +66,7 @@ export function toInferenceSegmentUsageDto(
     cache_creation_tokens: row.cacheCreationTokens,
     cache_read_tokens: row.cacheReadTokens,
     reasoning_tokens: row.reasoningTokens,
+    web_search_requests: row.webSearchRequests,
     recorded_at: row.recordedAt.toISOString(),
   };
 }


### PR DESCRIPTION
Adds the upstream Usage contract needed for capture and downstream pricing.

The change persists provider-hosted web-search request counts with a zero database default through segments, recorded events, inter-module responses, and both read routes. It also exports one pure dialect-aware token normalization helper so Anthropic cache counts and OpenAI cached-input subsets produce consistent displayed and priced classes, totals, and cache hit rates.

Raw counts remain available on the DTOs; reasoning stays within output totals and web searches remain a separate count.

Closes ENG-1978

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds web-search request counts to usage segments and centralizes per-dialect token normalization so displayed and priced classes, totals, and cache hit rates are consistent across Anthropic and OpenAI.

**Details**
- Persists `web_search_requests` with a zero default; existing rows and mixed-version payloads backfill to 0.
- Bounds counts to the integer column maximum and carries them through recorded segments, inter-module responses, and both read routes.
- Exports `normaliseTokenClasses` from `@shipfox/api-usage-dto`; Anthropic keeps reported input and cache-write classes, OpenAI subtracts cached input and clamps when the subset exceeds reported input.
- Raw counts remain on DTOs; reasoning tokens stay inside output totals and web searches remain a separate count.
- Roll out Usage consumers before producers, drain the Usage outbox before rollback, and redeploy this version before replaying events after a rollback.

Closes ENG-1978.

<sup>Written for commit 92d978ffff2a5bf427ffd8d0ab95114705135745. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1700?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

