### PR TITLE
[api-workflows] Retire legacy job-execution trigger-event arrays

### DIFF
--- a/.changeset/retire-trigger-arrays.md
+++ b/.changeset/retire-trigger-arrays.md
@@ -2,4 +2,4 @@
 "@shipfox/api-workflows": patch
 ---
 
-Stops new listener executions from duplicating event payloads in legacy arrays while retaining canonical and legacy-compatible reads.
+Stops writing duplicate legacy trigger-event arrays for new listener executions.

--- a/.changeset/retire-trigger-arrays.md
+++ b/.changeset/retire-trigger-arrays.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-workflows": patch
+---
+
+Stops new listener executions from duplicating event payloads in legacy arrays while retaining canonical and legacy-compatible reads.

--- a/libs/api/workflows/README.md
+++ b/libs/api/workflows/README.md
@@ -69,6 +69,11 @@ display label and workflow expression value.
 
 ## Behavior Notes
 
+Listener event rows are canonical for new execution context. The legacy
+execution array remains readable for retained executions and is not backfilled.
+Deploy canonical readers before stopping array writes. If rollback is needed,
+restore the prior dual-write, dual-read release before deploying array-only readers.
+
 Run numbers are sequential within one workflow lineage, start at `1`, and are
 unique for `(definition_id, number)`. `workflow_runs.definition_id` carries the
 workflow lineage id: a stable identity per `(project_id, config_path)` shared by

--- a/libs/api/workflows/README.md
+++ b/libs/api/workflows/README.md
@@ -71,8 +71,11 @@ display label and workflow expression value.
 
 Listener event rows are canonical for new execution context. The legacy
 execution array remains readable for retained executions and is not backfilled.
-Deploy canonical readers before stopping array writes. If rollback is needed,
-restore the prior dual-write, dual-read release before deploying array-only readers.
+Deploy canonical readers and complete one normal compatibility window before
+stopping array writes. An array-only reader cannot recover event context from
+new executions after this release. If rollback is needed, restore a release
+that reads canonical rows before deploying it; do not roll back to an
+array-only reader without a dual-write bridge.
 
 Run numbers are sequential within one workflow lineage, start at `1`, and are
 unique for `(definition_id, number)`. `workflow_runs.definition_id` carries the
@@ -110,6 +113,11 @@ remain in logs and traces.
 | `workflows_next_step_response_overflow` | Instance | `kind` | Count of serialized `/steps/next` responses over the 1,000,000-byte budget; overflow is reported while the response remains served. |
 | `workflows_tool_invocations_queued` | Service | none | Current count of queued tool invocations across the shared database. |
 | `workflows_tool_invocations_in_flight` | Service | none | Current count of tool invocations claimed by an executor. |
+| `workflows_listener_event_rows` | Service | none | Number of retained canonical listener-event rows across the shared database. The value is cached for up to 60 seconds. |
+| `workflows_listener_event_payload_bytes` | Service | none | Stored payload bytes for retained canonical listener-event rows with a payload. The value is cached for up to 60 seconds. |
+| `workflows_listener_event_consumed_oldest_age` | Service | none | Age in milliseconds of the oldest consumed canonical listener-event row still retained. This is a retention-depth signal, not a consumer-liveness signal. The value is cached for up to 60 seconds. |
+| `workflows_listener_event_pending_oldest_age` | Service | none | Age in milliseconds of the oldest pending canonical listener-event row. The value is cached for up to 60 seconds. |
+| `workflows_duplicate_trigger_events_bytes` | Service | none | Serialized bytes retained in legacy job-execution trigger-event arrays. The value is cached for up to 60 seconds. |
 
 ## Development
 

--- a/libs/api/workflows/README.md
+++ b/libs/api/workflows/README.md
@@ -42,6 +42,7 @@ const run = await runWorkflow(definitions, {
 | Variable | Default | Purpose |
 | --- | --- | --- |
 | `RUNNER_CATALOG_PATH` | empty | Optional path to a YAML file mapping runner catalog names to complete runner label sets. |
+| `WORKFLOWS_LEGACY_TRIGGER_EVENTS_WRITE_ENABLED` | `true` | Writes legacy trigger-event arrays alongside canonical rows for new listener executions. Keep `true` during mixed deployments. Set `false` after one normal compatibility window with canonical readers, then restart the API. |
 | `WORKFLOWS_TOOL_STEP_EXECUTOR_ENABLED` | `true` | Starts the server-side tool-step executor. Set `false` to stop claiming new tool invocations after an API restart. |
 | `WORKFLOWS_TOOL_STEP_POLL_INTERVAL_MS` | `1000` | Delay between scans for due server-executed tool-step invocations, in milliseconds. The value must be a safe whole number from `1` through `2147483647`. |
 | `WORKFLOWS_TOOL_STEP_EXECUTOR_CONCURRENCY` | `8` | Maximum number of tool-step invocations claimed in one executor pass. The value must be a safe whole number greater than `0`. |
@@ -71,11 +72,16 @@ display label and workflow expression value.
 
 Listener event rows are canonical for new execution context. The legacy
 execution array remains readable for retained executions and is not backfilled.
-Deploy canonical readers and complete one normal compatibility window before
-stopping array writes. An array-only reader cannot recover event context from
-new executions after this release. If rollback is needed, restore a release
-that reads canonical rows before deploying it; do not roll back to an
-array-only reader without a dual-write bridge.
+The writer flag defaults to dual writes for mixed deployments. Set it to `false`
+after canonical readers complete one normal compatibility window. An array-only
+reader cannot recover event context from new executions after the flag changes.
+If rollback is needed, restore a release that reads canonical rows first. An
+array-only rollback requires a dual-write bridge.
+
+The duplicate-array storage gauge is transitional. Its cached refresh still
+scans retained execution history. Remove it after the compatibility window and
+legacy-array retention cleanup. The canonical listener-event gauges remain
+useful for retention operations.
 
 Run numbers are sequential within one workflow lineage, start at `1`, and are
 unique for `(definition_id, number)`. `workflow_runs.definition_id` carries the
@@ -115,8 +121,8 @@ remain in logs and traces.
 | `workflows_tool_invocations_in_flight` | Service | none | Current count of tool invocations claimed by an executor. |
 | `workflows_listener_event_rows` | Service | none | Number of retained canonical listener-event rows across the shared database. The value is cached for up to 60 seconds. |
 | `workflows_listener_event_payload_bytes` | Service | none | Stored payload bytes for retained canonical listener-event rows with a payload. The value is cached for up to 60 seconds. |
-| `workflows_listener_event_consumed_oldest_age` | Service | none | Age in milliseconds of the oldest consumed canonical listener-event row still retained. This is a retention-depth signal, not a consumer-liveness signal. The value is cached for up to 60 seconds. |
-| `workflows_listener_event_pending_oldest_age` | Service | none | Age in milliseconds of the oldest pending canonical listener-event row. The value is cached for up to 60 seconds. |
+| `workflows_listener_event_consumed_oldest_age` | Service | none | Age in milliseconds of the oldest consumed canonical listener-event row still retained. This is a retention-depth signal, not a consumer-liveness signal. The value is `0` when no matching row exists or its timestamp is in the future. The value is cached for up to 60 seconds. |
+| `workflows_listener_event_pending_oldest_age` | Service | none | Age in milliseconds of the oldest pending canonical listener-event row. The value is `0` when no matching row exists or its timestamp is in the future. The value is cached for up to 60 seconds. |
 | `workflows_duplicate_trigger_events_bytes` | Service | none | Serialized bytes retained in legacy job-execution trigger-event arrays. The value is cached for up to 60 seconds. |
 
 ## Development

--- a/libs/api/workflows/drizzle/0009_luxuriant_hex.sql
+++ b/libs/api/workflows/drizzle/0009_luxuriant_hex.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "workflows_job_executions" ALTER COLUMN "trigger_events" DROP DEFAULT;--> statement-breakpoint
+ALTER TABLE "workflows_job_executions" ALTER COLUMN "trigger_events" DROP NOT NULL;

--- a/libs/api/workflows/drizzle/meta/0009_snapshot.json
+++ b/libs/api/workflows/drizzle/meta/0009_snapshot.json
@@ -1,0 +1,2251 @@
+{
+  "id": "9efd11c6-a28d-4a8a-817a-876970e72afc",
+  "prevId": "2fc16196-749b-4ee9-9614-07bc1ac1d555",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.workflows_checkout_renewal_subjects": {
+      "name": "workflows_checkout_renewal_subjects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "step_id": {
+          "name": "step_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow_run_attempt_id": {
+          "name": "workflow_run_attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "workflows_checkout_renewal_subject_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "repository_url": {
+          "name": "repository_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_repository_id": {
+          "name": "external_repository_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permissions_contents": {
+          "name": "permissions_contents",
+          "type": "workflows_checkout_contents",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "promoted_at": {
+          "name": "promoted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workflows_crs_step_id_attempt_uq": {
+          "name": "workflows_crs_step_id_attempt_uq",
+          "columns": [
+            {
+              "expression": "step_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attempt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_crs_workflow_run_attempt_id_idx": {
+          "name": "workflows_crs_workflow_run_attempt_id_idx",
+          "columns": [
+            {
+              "expression": "workflow_run_attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflows_checkout_renewal_subjects_step_id_workflows_steps_id_fk": {
+          "name": "workflows_checkout_renewal_subjects_step_id_workflows_steps_id_fk",
+          "tableFrom": "workflows_checkout_renewal_subjects",
+          "tableTo": "workflows_steps",
+          "columnsFrom": ["step_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflows_checkout_renewal_subjects_workflow_run_attempt_id_workflows_workflow_run_attempts_id_fk": {
+          "name": "workflows_checkout_renewal_subjects_workflow_run_attempt_id_workflows_workflow_run_attempts_id_fk",
+          "tableFrom": "workflows_checkout_renewal_subjects",
+          "tableTo": "workflows_workflow_run_attempts",
+          "columnsFrom": ["workflow_run_attempt_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workflows_crs_attempt_positive_ck": {
+          "name": "workflows_crs_attempt_positive_ck",
+          "value": "\"workflows_checkout_renewal_subjects\".\"attempt\" > 0"
+        },
+        "workflows_crs_promoted_at_ck": {
+          "name": "workflows_crs_promoted_at_ck",
+          "value": "(\"workflows_checkout_renewal_subjects\".\"status\" = 'pending' and \"workflows_checkout_renewal_subjects\".\"promoted_at\" is null) or (\"workflows_checkout_renewal_subjects\".\"status\" = 'promoted' and \"workflows_checkout_renewal_subjects\".\"promoted_at\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workflows_job_executions": {
+      "name": "workflows_job_executions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runner": {
+          "name": "runner",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runner_labels": {
+          "name": "runner_labels",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template_key": {
+          "name": "template_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provisioner_id": {
+          "name": "provisioner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provisioner_scope": {
+          "name": "provisioner_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_kind": {
+          "name": "provider_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "launch_kind": {
+          "name": "launch_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "workflows_job_execution_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "status_reason": {
+          "name": "status_reason",
+          "type": "workflows_job_status_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_reason_message": {
+          "name": "status_reason_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_events": {
+          "name": "trigger_events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outputs": {
+          "name": "outputs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "evaluation_trace": {
+          "name": "evaluation_trace",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "queued_at": {
+          "name": "queued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timed_out_at": {
+          "name": "timed_out_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workflows_job_executions_job_id_idx": {
+          "name": "workflows_job_executions_job_id_idx",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_job_executions_running_idx": {
+          "name": "workflows_job_executions_running_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"workflows_job_executions\".\"status\" = 'running'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_job_executions_job_sequence_uq": {
+          "name": "workflows_job_executions_job_sequence_uq",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflows_job_executions_job_id_workflows_jobs_id_fk": {
+          "name": "workflows_job_executions_job_id_workflows_jobs_id_fk",
+          "tableFrom": "workflows_job_executions",
+          "tableTo": "workflows_jobs",
+          "columnsFrom": ["job_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflows_job_listener_events": {
+      "name": "workflows_job_listener_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disposition": {
+          "name": "disposition",
+          "type": "workflows_job_listener_event_disposition",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "workflows_job_listener_event_outcome",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "outcome_reason": {
+          "name": "outcome_reason",
+          "type": "workflows_job_listener_event_outcome_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_ref": {
+          "name": "event_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delivery_id": {
+          "name": "delivery_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event": {
+          "name": "event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_reference": {
+          "name": "trigger_reference",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stored_payload_bytes": {
+          "name": "stored_payload_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "normalized_event_bytes": {
+          "name": "normalized_event_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_by_execution_id": {
+          "name": "consumed_by_execution_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workflows_job_listener_events_job_event_ref_unique": {
+          "name": "workflows_job_listener_events_job_event_ref_unique",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_job_listener_events_job_received_idx": {
+          "name": "workflows_job_listener_events_job_received_idx",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_job_listener_events_pending_order_idx": {
+          "name": "workflows_job_listener_events_pending_order_idx",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"workflows_job_listener_events\".\"consumed_by_execution_id\" IS NULL AND \"workflows_job_listener_events\".\"outcome\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_job_listener_events_consumed_order_idx": {
+          "name": "workflows_job_listener_events_consumed_order_idx",
+          "columns": [
+            {
+              "expression": "consumed_by_execution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"workflows_job_listener_events\".\"consumed_by_execution_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflows_job_listener_events_job_id_workflows_jobs_id_fk": {
+          "name": "workflows_job_listener_events_job_id_workflows_jobs_id_fk",
+          "tableFrom": "workflows_job_listener_events",
+          "tableTo": "workflows_jobs",
+          "columnsFrom": ["job_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflows_job_listener_events_consumed_by_execution_id_workflows_job_executions_id_fk": {
+          "name": "workflows_job_listener_events_consumed_by_execution_id_workflows_job_executions_id_fk",
+          "tableFrom": "workflows_job_listener_events",
+          "tableTo": "workflows_job_executions",
+          "columnsFrom": ["consumed_by_execution_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workflows_job_listener_events_byte_counts_ck": {
+          "name": "workflows_job_listener_events_byte_counts_ck",
+          "value": "\"workflows_job_listener_events\".\"stored_payload_bytes\" >= 0 AND \"workflows_job_listener_events\".\"normalized_event_bytes\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workflows_jobs": {
+      "name": "workflows_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workflow_run_attempt_id": {
+          "name": "workflow_run_attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "workflows_job_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'one_shot'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "workflows_job_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "status_reason": {
+          "name": "status_reason",
+          "type": "workflows_job_status_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "carried_over": {
+          "name": "carried_over",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "checkout_persist_credentials": {
+          "name": "checkout_persist_credentials",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "checkout_permissions_contents": {
+          "name": "checkout_permissions_contents",
+          "type": "workflows_checkout_contents",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "success": {
+          "name": "success",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "evaluation_trace": {
+          "name": "evaluation_trace",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_timeout_ms": {
+          "name": "execution_timeout_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "listening_timeout_ms": {
+          "name": "listening_timeout_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_executions": {
+          "name": "max_executions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "on_resolve": {
+          "name": "on_resolve",
+          "type": "workflows_job_on_resolve",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "batch_debounce_ms": {
+          "name": "batch_debounce_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "batch_max_size": {
+          "name": "batch_max_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "batch_max_wait_ms": {
+          "name": "batch_max_wait_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "listener_status": {
+          "name": "listener_status",
+          "type": "workflows_listener_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'inactive'"
+        },
+        "resolution_reason": {
+          "name": "resolution_reason",
+          "type": "workflows_resolution_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "listening_on": {
+          "name": "listening_on",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "listening_until": {
+          "name": "listening_until",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outputs": {
+          "name": "outputs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dependencies": {
+          "name": "dependencies",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runner": {
+          "name": "runner",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workflows_jobs_workflow_run_attempt_id_idx": {
+          "name": "workflows_jobs_workflow_run_attempt_id_idx",
+          "columns": [
+            {
+              "expression": "workflow_run_attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_jobs_active_listeners_idx": {
+          "name": "workflows_jobs_active_listeners_idx",
+          "columns": [
+            {
+              "expression": "listener_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"workflows_jobs\".\"listener_status\" = 'listening'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflows_jobs_workflow_run_attempt_id_workflows_workflow_run_attempts_id_fk": {
+          "name": "workflows_jobs_workflow_run_attempt_id_workflows_workflow_run_attempts_id_fk",
+          "tableFrom": "workflows_jobs",
+          "tableTo": "workflows_workflow_run_attempts",
+          "columnsFrom": ["workflow_run_attempt_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflows_outbox": {
+      "name": "workflows_outbox",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ordering_key": {
+          "name": "ordering_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "dispatched_at": {
+          "name": "dispatched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dispatch_attempts": {
+          "name": "dispatch_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_dispatch_at": {
+          "name": "next_dispatch_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_dispatch_error": {
+          "name": "last_dispatch_error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_dispatch_failed_at": {
+          "name": "last_dispatch_failed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dead_lettered_at": {
+          "name": "dead_lettered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workflows_outbox_pending_idx": {
+          "name": "workflows_outbox_pending_idx",
+          "columns": [
+            {
+              "expression": "next_dispatch_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"dispatched_at\" IS NULL AND \"dead_lettered_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_outbox_dispatched_retention_idx": {
+          "name": "workflows_outbox_dispatched_retention_idx",
+          "columns": [
+            {
+              "expression": "dispatched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"dispatched_at\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflows_step_attempts": {
+      "name": "workflows_step_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "step_id": {
+          "name": "step_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_execution_id": {
+          "name": "job_execution_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "execution_order": {
+          "name": "execution_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "workflows_step_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "evaluation_trace": {
+          "name": "evaluation_trace",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output": {
+          "name": "output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exit_code": {
+          "name": "exit_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "log_outcome": {
+          "name": "log_outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gate_result": {
+          "name": "gate_result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "restart_feedback": {
+          "name": "restart_feedback",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invocations": {
+          "name": "invocations",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workflows_step_attempts_step_id_workflows_steps_id_fk": {
+          "name": "workflows_step_attempts_step_id_workflows_steps_id_fk",
+          "tableFrom": "workflows_step_attempts",
+          "tableTo": "workflows_steps",
+          "columnsFrom": ["step_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflows_step_attempts_step_id_job_execution_id_workflows_steps_fk": {
+          "name": "workflows_step_attempts_step_id_job_execution_id_workflows_steps_fk",
+          "tableFrom": "workflows_step_attempts",
+          "tableTo": "workflows_steps",
+          "columnsFrom": ["step_id", "job_execution_id"],
+          "columnsTo": ["id", "job_execution_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workflows_step_attempts_step_id_attempt_uq": {
+          "name": "workflows_step_attempts_step_id_attempt_uq",
+          "nullsNotDistinct": false,
+          "columns": ["step_id", "attempt"]
+        },
+        "workflows_step_attempts_job_execution_id_execution_order_uq": {
+          "name": "workflows_step_attempts_job_execution_id_execution_order_uq",
+          "nullsNotDistinct": false,
+          "columns": ["job_execution_id", "execution_order"]
+        },
+        "workflows_step_attempts_id_step_id_job_execution_id_uq": {
+          "name": "workflows_step_attempts_id_step_id_job_execution_id_uq",
+          "nullsNotDistinct": false,
+          "columns": ["id", "step_id", "job_execution_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "workflows_step_attempts_attempt_positive_ck": {
+          "name": "workflows_step_attempts_attempt_positive_ck",
+          "value": "\"workflows_step_attempts\".\"attempt\" > 0"
+        },
+        "workflows_step_attempts_execution_order_positive_ck": {
+          "name": "workflows_step_attempts_execution_order_positive_ck",
+          "value": "\"workflows_step_attempts\".\"execution_order\" > 0"
+        },
+        "workflows_step_attempts_status_dispatched_ck": {
+          "name": "workflows_step_attempts_status_dispatched_ck",
+          "value": "\"workflows_step_attempts\".\"status\" NOT IN ('pending', 'skipped')"
+        },
+        "workflows_step_attempts_log_outcome_ck": {
+          "name": "workflows_step_attempts_log_outcome_ck",
+          "value": "\"workflows_step_attempts\".\"log_outcome\" IS NULL OR \"workflows_step_attempts\".\"log_outcome\" IN ('drained', 'abandoned')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workflows_steps": {
+      "name": "workflows_steps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "job_execution_id": {
+          "name": "job_execution_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_location": {
+          "name": "source_location",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "workflows_step_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "status_reason": {
+          "name": "status_reason",
+          "type": "workflows_step_status_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "evaluation_trace": {
+          "name": "evaluation_trace",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "condition": {
+          "name": "condition",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config_plan": {
+          "name": "config_plan",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authored_config": {
+          "name": "authored_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "current_attempt": {
+          "name": "current_attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workflows_steps_job_execution_id_idx": {
+          "name": "workflows_steps_job_execution_id_idx",
+          "columns": [
+            {
+              "expression": "job_execution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_steps_id_job_execution_id_uq": {
+          "name": "workflows_steps_id_job_execution_id_uq",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "job_execution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflows_steps_job_execution_id_workflows_job_executions_id_fk": {
+          "name": "workflows_steps_job_execution_id_workflows_job_executions_id_fk",
+          "tableFrom": "workflows_steps",
+          "tableTo": "workflows_job_executions",
+          "columnsFrom": ["job_execution_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workflows_steps_current_attempt_positive_ck": {
+          "name": "workflows_steps_current_attempt_positive_ck",
+          "value": "\"workflows_steps\".\"current_attempt\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workflows_tool_invocations": {
+      "name": "workflows_tool_invocations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "step_id": {
+          "name": "step_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_attempt_id": {
+          "name": "step_attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_execution_id": {
+          "name": "job_execution_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "workflows_tool_invocation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "call_index": {
+          "name": "call_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "due_at": {
+          "name": "due_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimed_by": {
+          "name": "claimed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_expires_at": {
+          "name": "claim_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workflows_tool_invocations_job_execution_id_idx": {
+          "name": "workflows_tool_invocations_job_execution_id_idx",
+          "columns": [
+            {
+              "expression": "job_execution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_tool_invocations_due_at_unsettled_idx": {
+          "name": "workflows_tool_invocations_due_at_unsettled_idx",
+          "columns": [
+            {
+              "expression": "due_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"workflows_tool_invocations\".\"status\" <> 'settled'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflows_tool_invocations_step_id_workflows_steps_id_fk": {
+          "name": "workflows_tool_invocations_step_id_workflows_steps_id_fk",
+          "tableFrom": "workflows_tool_invocations",
+          "tableTo": "workflows_steps",
+          "columnsFrom": ["step_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflows_tool_invocations_step_attempt_id_workflows_step_attempts_id_fk": {
+          "name": "workflows_tool_invocations_step_attempt_id_workflows_step_attempts_id_fk",
+          "tableFrom": "workflows_tool_invocations",
+          "tableTo": "workflows_step_attempts",
+          "columnsFrom": ["step_attempt_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflows_tool_invocations_job_execution_id_workflows_job_executions_id_fk": {
+          "name": "workflows_tool_invocations_job_execution_id_workflows_job_executions_id_fk",
+          "tableFrom": "workflows_tool_invocations",
+          "tableTo": "workflows_job_executions",
+          "columnsFrom": ["job_execution_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflows_tool_invocations_step_id_job_execution_id_workflows_steps_fk": {
+          "name": "workflows_tool_invocations_step_id_job_execution_id_workflows_steps_fk",
+          "tableFrom": "workflows_tool_invocations",
+          "tableTo": "workflows_steps",
+          "columnsFrom": ["step_id", "job_execution_id"],
+          "columnsTo": ["id", "job_execution_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflows_tool_invocations_step_attempt_id_step_id_job_execution_id_workflows_step_attempts_fk": {
+          "name": "workflows_tool_invocations_step_attempt_id_step_id_job_execution_id_workflows_step_attempts_fk",
+          "tableFrom": "workflows_tool_invocations",
+          "tableTo": "workflows_step_attempts",
+          "columnsFrom": ["step_attempt_id", "step_id", "job_execution_id"],
+          "columnsTo": ["id", "step_id", "job_execution_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workflows_tool_invocations_step_attempt_id_uq": {
+          "name": "workflows_tool_invocations_step_attempt_id_uq",
+          "nullsNotDistinct": false,
+          "columns": ["step_attempt_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "workflows_tool_invocations_call_index_nonnegative_ck": {
+          "name": "workflows_tool_invocations_call_index_nonnegative_ck",
+          "value": "\"workflows_tool_invocations\".\"call_index\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workflows_workflow_run_attempts": {
+      "name": "workflows_workflow_run_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workflow_run_id": {
+          "name": "workflow_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "workflows_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "rerun_mode": {
+          "name": "rerun_mode",
+          "type": "workflows_rerun_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rerun_by_user_id": {
+          "name": "rerun_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vars": {
+          "name": "vars",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_tool_materialization": {
+          "name": "agent_tool_materialization",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workflows_wra_workflow_run_attempt_unique": {
+          "name": "workflows_wra_workflow_run_attempt_unique",
+          "columns": [
+            {
+              "expression": "workflow_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attempt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_wra_one_active_attempt_unique": {
+          "name": "workflows_wra_one_active_attempt_unique",
+          "columns": [
+            {
+              "expression": "workflow_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"workflows_workflow_run_attempts\".\"status\" in ('pending', 'running')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflows_workflow_run_attempts_workflow_run_id_workflows_workflow_runs_id_fk": {
+          "name": "workflows_workflow_run_attempts_workflow_run_id_workflows_workflow_runs_id_fk",
+          "tableFrom": "workflows_workflow_run_attempts",
+          "tableTo": "workflows_workflow_runs",
+          "columnsFrom": ["workflow_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workflows_wra_attempt_positive_ck": {
+          "name": "workflows_wra_attempt_positive_ck",
+          "value": "\"workflows_workflow_run_attempts\".\"attempt\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workflows_workflow_run_counters": {
+      "name": "workflows_workflow_run_counters",
+      "schema": "",
+      "columns": {
+        "definition_id": {
+          "name": "definition_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "next_number": {
+          "name": "next_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "workflows_wrrc_definition_id_unique": {
+          "name": "workflows_wrrc_definition_id_unique",
+          "columns": [
+            {
+              "expression": "definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflows_workflow_runs": {
+      "name": "workflows_workflow_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_name": {
+          "name": "workflow_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "workflows_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'synced'"
+        },
+        "dev_source": {
+          "name": "dev_source",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_attempt": {
+          "name": "current_attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "trigger_provider": {
+          "name": "trigger_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_source": {
+          "name": "trigger_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_event": {
+          "name": "trigger_event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_payload": {
+          "name": "trigger_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_reference": {
+          "name": "trigger_reference",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inputs": {
+          "name": "inputs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_snapshot": {
+          "name": "source_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_idempotency_key": {
+          "name": "trigger_idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timeout_ms": {
+          "name": "timeout_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2592000000
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workflows_wr_trigger_idempotency_key_unique": {
+          "name": "workflows_wr_trigger_idempotency_key_unique",
+          "columns": [
+            {
+              "expression": "trigger_idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_wr_definition_number_unique": {
+          "name": "workflows_wr_definition_number_unique",
+          "columns": [
+            {
+              "expression": "definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_wr_project_created_id_idx": {
+          "name": "workflows_wr_project_created_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_wr_project_origin_created_id_idx": {
+          "name": "workflows_wr_project_origin_created_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "origin",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_wr_project_status_created_id_idx": {
+          "name": "workflows_wr_project_status_created_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_wr_project_definition_created_id_idx": {
+          "name": "workflows_wr_project_definition_created_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_wr_project_trigger_created_id_idx": {
+          "name": "workflows_wr_project_trigger_created_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trigger_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_wr_running_idx": {
+          "name": "workflows_wr_running_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"workflows_workflow_runs\".\"status\" = 'running'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workflows_wr_current_attempt_positive_ck": {
+          "name": "workflows_wr_current_attempt_positive_ck",
+          "value": "\"workflows_workflow_runs\".\"current_attempt\" > 0"
+        },
+        "workflows_wr_origin_ck": {
+          "name": "workflows_wr_origin_ck",
+          "value": "\"workflows_workflow_runs\".\"origin\" in ('synced', 'dev')"
+        },
+        "workflows_wr_dev_source_ck": {
+          "name": "workflows_wr_dev_source_ck",
+          "value": "(\n        (\"workflows_workflow_runs\".\"origin\" = 'synced' and \"workflows_workflow_runs\".\"dev_source\" is null)\n        or (\n          \"workflows_workflow_runs\".\"origin\" = 'dev'\n          and \"workflows_workflow_runs\".\"dev_source\" is not null\n          and jsonb_typeof(\"workflows_workflow_runs\".\"dev_source\") = 'object'\n        )\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.workflows_checkout_renewal_subject_status": {
+      "name": "workflows_checkout_renewal_subject_status",
+      "schema": "public",
+      "values": ["pending", "promoted"]
+    },
+    "public.workflows_job_execution_status": {
+      "name": "workflows_job_execution_status",
+      "schema": "public",
+      "values": ["pending", "running", "succeeded", "failed", "cancelled"]
+    },
+    "public.workflows_job_listener_event_disposition": {
+      "name": "workflows_job_listener_event_disposition",
+      "schema": "public",
+      "values": ["fire", "resolve"]
+    },
+    "public.workflows_job_listener_event_outcome": {
+      "name": "workflows_job_listener_event_outcome",
+      "schema": "public",
+      "values": ["pending", "consumed", "honored", "rejected", "abandoned"]
+    },
+    "public.workflows_job_listener_event_outcome_reason": {
+      "name": "workflows_job_listener_event_outcome_reason",
+      "schema": "public",
+      "values": ["payload_too_large", "until", "timeout", "max_executions", "cancelled"]
+    },
+    "public.workflows_checkout_contents": {
+      "name": "workflows_checkout_contents",
+      "schema": "public",
+      "values": ["read", "write"]
+    },
+    "public.workflows_job_mode": {
+      "name": "workflows_job_mode",
+      "schema": "public",
+      "values": ["one_shot", "listening"]
+    },
+    "public.workflows_job_on_resolve": {
+      "name": "workflows_job_on_resolve",
+      "schema": "public",
+      "values": ["finish", "cancel"]
+    },
+    "public.workflows_job_status": {
+      "name": "workflows_job_status",
+      "schema": "public",
+      "values": ["pending", "running", "succeeded", "failed", "cancelled", "skipped"]
+    },
+    "public.workflows_job_status_reason": {
+      "name": "workflows_job_status_reason",
+      "schema": "public",
+      "values": [
+        "dependency_not_completed",
+        "condition_false",
+        "default_gate_rejected",
+        "condition_rejected",
+        "condition_errored",
+        "user_cancelled",
+        "run_cancelled",
+        "timed_out",
+        "runner_lost",
+        "output_too_large",
+        "step_failed",
+        "unknown",
+        "output_invalid"
+      ]
+    },
+    "public.workflows_listener_status": {
+      "name": "workflows_listener_status",
+      "schema": "public",
+      "values": ["inactive", "listening", "resolved"]
+    },
+    "public.workflows_resolution_reason": {
+      "name": "workflows_resolution_reason",
+      "schema": "public",
+      "values": ["until", "timeout", "max_executions", "cancelled"]
+    },
+    "public.workflows_step_status": {
+      "name": "workflows_step_status",
+      "schema": "public",
+      "values": ["pending", "running", "succeeded", "failed", "cancelled", "skipped"]
+    },
+    "public.workflows_step_status_reason": {
+      "name": "workflows_step_status_reason",
+      "schema": "public",
+      "values": ["default_gate_rejected", "condition_rejected", "condition_errored"]
+    },
+    "public.workflows_tool_invocation_status": {
+      "name": "workflows_tool_invocation_status",
+      "schema": "public",
+      "values": ["queued", "in_flight", "settled"]
+    },
+    "public.workflows_rerun_mode": {
+      "name": "workflows_rerun_mode",
+      "schema": "public",
+      "values": ["all", "failed"]
+    },
+    "public.workflows_run_status": {
+      "name": "workflows_run_status",
+      "schema": "public",
+      "values": ["pending", "running", "succeeded", "failed", "cancelled"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/libs/api/workflows/drizzle/meta/_journal.json
+++ b/libs/api/workflows/drizzle/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1788515520229,
       "tag": "0008_job_execution_runner_identity",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1788607058447,
+      "tag": "0009_luxuriant_hex",
+      "breakpoints": true
     }
   ]
 }

--- a/libs/api/workflows/src/config.ts
+++ b/libs/api/workflows/src/config.ts
@@ -8,6 +8,10 @@ export const config = createConfig({
     desc: 'Path to the YAML file that maps runner catalog names to complete label sets. Leave it empty to use every job runner value as a literal label. The file is loaded at startup; restart the API after changing it.',
     default: '',
   }),
+  WORKFLOWS_LEGACY_TRIGGER_EVENTS_WRITE_ENABLED: bool({
+    desc: 'Whether new listener executions also write the legacy trigger-event array. Keep true during mixed deployments. Set false after canonical readers complete one normal compatibility window, then restart the API.',
+    default: true,
+  }),
   WORKFLOWS_TOOL_STEP_EXECUTOR_ENABLED: bool({
     desc: 'Whether the API process runs the server-side workflow tool-step executor. Set false to disable new tool-step calls until the API restarts.',
     default: true,

--- a/libs/api/workflows/src/db/execution-trigger-events.ts
+++ b/libs/api/workflows/src/db/execution-trigger-events.ts
@@ -1,0 +1,49 @@
+import {and, asc, inArray} from 'drizzle-orm';
+import type {WorkflowExecutionEvent} from '#core/entities/job-execution.js';
+import type {db, Tx} from './db.js';
+import {normalizeListenerEvent} from './job-listener-events.js';
+import type {JobExecutionDb} from './schema/job-executions.js';
+import {jobListenerEvents} from './schema/job-listener-events.js';
+
+/**
+ * Hydrates execution rows from the canonical listener-event table.
+ *
+ * The legacy trigger-events array remains the fallback for executions retained
+ * from before canonical event reads were deployed.
+ */
+export async function loadJobExecutionsWithCanonicalTriggerEvents(
+  source: ReturnType<typeof db> | Tx,
+  executions: readonly JobExecutionDb[],
+): Promise<JobExecutionDb[]> {
+  if (executions.length === 0) return [];
+
+  const eventRows = await source
+    .select()
+    .from(jobListenerEvents)
+    .where(
+      and(
+        inArray(
+          jobListenerEvents.consumedByExecutionId,
+          executions.map((execution) => execution.id),
+        ),
+        inArray(jobListenerEvents.jobId, [
+          ...new Set(executions.map((execution) => execution.jobId)),
+        ]),
+      ),
+    )
+    .orderBy(asc(jobListenerEvents.receivedAt), asc(jobListenerEvents.id));
+  const eventsByExecutionId = new Map<string, WorkflowExecutionEvent[]>();
+  for (const eventRow of eventRows) {
+    if (eventRow.consumedByExecutionId === null) continue;
+    const events = eventsByExecutionId.get(eventRow.consumedByExecutionId) ?? [];
+    events.push(normalizeListenerEvent(eventRow));
+    eventsByExecutionId.set(eventRow.consumedByExecutionId, events);
+  }
+
+  return executions.map((execution) => {
+    const canonicalEvents = eventsByExecutionId.get(execution.id);
+    return canonicalEvents === undefined
+      ? execution
+      : {...execution, triggerEvents: canonicalEvents};
+  });
+}

--- a/libs/api/workflows/src/db/execution-trigger-events.ts
+++ b/libs/api/workflows/src/db/execution-trigger-events.ts
@@ -14,8 +14,8 @@ import {jobListenerEvents} from './schema/job-listener-events.js';
 export async function loadJobExecutionsWithCanonicalTriggerEvents(
   source: ReturnType<typeof db> | Tx,
   executions: readonly JobExecutionDb[],
-): Promise<JobExecutionDb[]> {
-  if (executions.length === 0) return [];
+): Promise<ReadonlyMap<string, JobExecutionDb>> {
+  if (executions.length === 0) return new Map();
 
   const eventRows = await source
     .select()
@@ -40,10 +40,13 @@ export async function loadJobExecutionsWithCanonicalTriggerEvents(
     eventsByExecutionId.set(eventRow.consumedByExecutionId, events);
   }
 
-  return executions.map((execution) => {
-    const canonicalEvents = eventsByExecutionId.get(execution.id);
-    return canonicalEvents === undefined
-      ? execution
-      : {...execution, triggerEvents: canonicalEvents};
-  });
+  return new Map(
+    executions.map((execution) => {
+      const canonicalEvents = eventsByExecutionId.get(execution.id);
+      return [
+        execution.id,
+        canonicalEvents === undefined ? execution : {...execution, triggerEvents: canonicalEvents},
+      ] as const;
+    }),
+  );
 }

--- a/libs/api/workflows/src/db/index.ts
+++ b/libs/api/workflows/src/db/index.ts
@@ -30,6 +30,10 @@ export {
   resolveJobListener,
   settleListenerJobExecution,
 } from './job-listeners.js';
+export {
+  getListenerEventStorageStats,
+  type ListenerEventStorageStats,
+} from './listener-storage.js';
 export {workflowsOutbox} from './schema/outbox.js';
 export {workflowRunCounters} from './schema/workflow-run-counters.js';
 export type {

--- a/libs/api/workflows/src/db/job-listeners.test.ts
+++ b/libs/api/workflows/src/db/job-listeners.test.ts
@@ -30,7 +30,12 @@ import {steps} from '#db/schema/steps.js';
 import {workflowRunAttempts} from '#db/schema/workflow-run-attempts.js';
 import {jobExecutionTerminatedEvents} from '#test/helpers/workflow-runs.js';
 import {jobFactory, workflowModel, workflowRunFactory} from '#test/index.js';
-import {getJobsByWorkflowRunId, updateJobExecutionStatus} from './workflow-runs.js';
+import {
+  getFirstJobExecutionByJobId,
+  getJobsByWorkflowRunId,
+  getLatestJobExecutionByJobId,
+  updateJobExecutionStatus,
+} from './workflow-runs.js';
 
 interface ListeningJobOptions {
   status?: JobStatus;
@@ -80,7 +85,7 @@ async function createListeningJobFromModel(model: Parameters<typeof workflowMode
 async function insertExecution(jobId: string, sequence: number, status: JobExecutionStatus) {
   const [row] = await db()
     .insert(jobExecutions)
-    .values({jobId, sequence, name: `firing #${sequence}`, status, triggerEvents: []})
+    .values({jobId, sequence, name: `firing #${sequence}`, status})
     .returning();
   if (!row) throw new Error('insertExecution: no row returned');
   return row;
@@ -115,6 +120,14 @@ function readJob(jobId: string) {
     .where(eq(jobs.id, jobId))
     .limit(1)
     .then((rows) => rows[0]);
+}
+
+function readListenerEvents(jobId: string) {
+  return db()
+    .select()
+    .from(jobListenerEvents)
+    .where(eq(jobListenerEvents.jobId, jobId))
+    .orderBy(asc(jobListenerEvents.receivedAt), asc(jobListenerEvents.id));
 }
 
 async function activatedPayload(jobId: string): Promise<WorkflowsJobActivatedEventDto> {
@@ -568,7 +581,7 @@ describe('resolveJobListener', () => {
 });
 
 describe('drainListenerEventsIntoExecution', () => {
-  it('stores trigger events in received_at order', async () => {
+  it('stores canonical listener events in received_at order without an execution array', async () => {
     const job = await createListeningJob({status: 'running', listenerStatus: 'listening'});
     const middle = new Date('2026-01-01T00:01:00.000Z');
     const first = new Date('2026-01-01T00:00:00.000Z');
@@ -579,15 +592,17 @@ describe('drainListenerEventsIntoExecution', () => {
 
     await drainListenerEventsIntoExecution({jobId: job.id, expectedSequence: 1});
 
+    const events = await readListenerEvents(job.id);
+    expect(
+      events
+        .filter((event) => event.consumedByExecutionId !== null)
+        .map((event) => event.receivedAt.toISOString()),
+    ).toEqual([first.toISOString(), middle.toISOString(), last.toISOString()]);
     const [execution] = await db()
       .select()
       .from(jobExecutions)
       .where(and(eq(jobExecutions.jobId, job.id), eq(jobExecutions.sequence, 1)));
-    expect(execution?.triggerEvents.map((event) => event.received_at)).toEqual([
-      first.toISOString(),
-      middle.toISOString(),
-      last.toISOString(),
-    ]);
+    expect(execution?.triggerEvents).toBeNull();
   });
 
   it('exposes each buffered event reference on its execution event', async () => {
@@ -624,31 +639,21 @@ describe('drainListenerEventsIntoExecution', () => {
 
     await drainListenerEventsIntoExecution({jobId: job.id, expectedSequence: 1});
 
-    const [execution] = await db()
-      .select()
-      .from(jobExecutions)
-      .where(and(eq(jobExecutions.jobId, job.id), eq(jobExecutions.sequence, 1)));
-    // The execution event carries the reference's location fields, not its actor:
-    // `WorkflowExecutionEvent` enumerates its own shape and the trigger actor is not part of
-    // it. Widening that is the listening-jobs contract's call, not this branch's.
-    const {actor: _firstActor, ...firstEventFields} = firstReference;
-    const {actor: _secondActor, ...secondEventFields} = secondReference;
-    expect(execution?.triggerEvents).toEqual([
+    const events = await readListenerEvents(job.id);
+    expect(events.filter((event) => event.consumedByExecutionId !== null)).toMatchObject([
       {
         source: 'github',
         event: 'pull_request',
-        delivery_id: expect.any(String),
-        received_at: '2026-01-01T00:00:00.000Z',
-        ...firstEventFields,
-        data: {action: 'opened'},
+        receivedAt: new Date('2026-01-01T00:00:00.000Z'),
+        triggerReference: firstReference,
+        payload: {action: 'opened'},
       },
       {
         source: 'github',
         event: 'pull_request',
-        delivery_id: expect.any(String),
-        received_at: '2026-01-01T00:01:00.000Z',
-        ...secondEventFields,
-        data: {action: 'opened'},
+        receivedAt: new Date('2026-01-01T00:01:00.000Z'),
+        triggerReference: secondReference,
+        payload: {action: 'opened'},
       },
     ]);
   });
@@ -888,8 +893,11 @@ describe('drainListenerEventsIntoExecution', () => {
     expect(firstDrain).toMatchObject({kind: 'execution', sequence: 1});
     expect(secondDrain).toMatchObject({kind: 'execution', sequence: 2});
     expect(
-      executions.map((execution) => execution.triggerEvents).map((events) => events.length),
-    ).toEqual([2, 2]);
+      unconsumedEvents.filter((event) => event.consumedByExecutionId === executions[0]?.id),
+    ).toHaveLength(2);
+    expect(
+      unconsumedEvents.filter((event) => event.consumedByExecutionId === executions[1]?.id),
+    ).toHaveLength(2);
     expect(unconsumedEvents.filter((event) => event.consumedByExecutionId === null)).toHaveLength(
       1,
     );
@@ -935,15 +943,18 @@ describe('drainListenerEventsIntoExecution', () => {
       .select()
       .from(jobExecutions)
       .where(and(eq(jobExecutions.jobId, job.id), eq(jobExecutions.sequence, 1)));
-    const serializedBytes = Buffer.byteLength(
-      JSON.stringify(execution?.triggerEvents ?? []),
-      'utf8',
-    );
+    const events = await readListenerEvents(job.id);
+    const consumedEvents = events.filter((event) => event.consumedByExecutionId === execution?.id);
 
     expect(result).toMatchObject({kind: 'execution', status: 'pending'});
-    expect(execution?.triggerEvents).toHaveLength(1);
-    expect(serializedBytes).toBeGreaterThan(WORKFLOW_DIAGNOSTIC_TRIGGER_EVENTS_MAX_BYTES);
-    expect(serializedBytes).toBeLessThanOrEqual(MAX_LISTENER_TRIGGER_EVENTS_BYTES);
+    expect(execution?.triggerEvents).toBeNull();
+    expect(consumedEvents).toHaveLength(1);
+    expect(consumedEvents[0]?.normalizedEventBytes).toBeGreaterThan(
+      WORKFLOW_DIAGNOSTIC_TRIGGER_EVENTS_MAX_BYTES,
+    );
+    expect(consumedEvents[0]?.normalizedEventBytes).toBeLessThanOrEqual(
+      MAX_LISTENER_TRIGGER_EVENTS_BYTES,
+    );
   });
 
   it('partitions a byte-limited listener batch without consuming its tail', async () => {
@@ -983,15 +994,20 @@ describe('drainListenerEventsIntoExecution', () => {
 
     expect(firstDrain).toMatchObject({kind: 'execution', sequence: 1});
     expect(secondDrain).toMatchObject({kind: 'execution', sequence: 2});
-    expect(executions.map((execution) => execution.triggerEvents.length)).toEqual([2, 1]);
+    expect(
+      afterSecondDrain.filter((event) => event.consumedByExecutionId === executions[0]?.id),
+    ).toHaveLength(2);
+    expect(
+      afterSecondDrain.filter((event) => event.consumedByExecutionId === executions[1]?.id),
+    ).toHaveLength(1);
     expect(afterFirstDrain.filter((event) => event.consumedByExecutionId === null)).toHaveLength(1);
     expect(afterSecondDrain.filter((event) => event.consumedByExecutionId === null)).toHaveLength(
       0,
     );
     expect(
-      executions.flatMap((execution) =>
-        execution.triggerEvents.map((event) => (event.data as {name: string}).name),
-      ),
+      afterSecondDrain
+        .filter((event) => event.consumedByExecutionId !== null)
+        .map((event) => (event.payload as {name: string}).name),
     ).toEqual(payloads);
   });
 
@@ -1029,11 +1045,17 @@ describe('drainListenerEventsIntoExecution', () => {
 
     expect(firstDrain).toMatchObject({kind: 'execution', sequence: 1});
     expect(secondDrain).toMatchObject({kind: 'execution', sequence: 2});
-    expect(executions.map((execution) => execution.triggerEvents.length)).toEqual([1, 1]);
+    const events = await readListenerEvents(job.id);
     expect(
-      executions.flatMap((execution) =>
-        execution.triggerEvents.map((event) => (event.data as {name: string}).name),
-      ),
+      events.filter((event) => event.consumedByExecutionId === executions[0]?.id),
+    ).toHaveLength(1);
+    expect(
+      events.filter((event) => event.consumedByExecutionId === executions[1]?.id),
+    ).toHaveLength(1);
+    expect(
+      events
+        .filter((event) => event.consumedByExecutionId !== null)
+        .map((event) => (event.payload as {name: string}).name),
     ).toEqual(payloads);
   });
 
@@ -1062,10 +1084,13 @@ describe('drainListenerEventsIntoExecution', () => {
       .where(and(eq(jobExecutions.jobId, job.id), eq(jobExecutions.sequence, 1)));
 
     expect(result).toMatchObject({kind: 'execution', sequence: 1});
-    expect(execution?.triggerEvents).toHaveLength(2);
-    expect(execution?.triggerEvents.map((event) => (event.data as {name: string}).name)).toEqual(
-      payloads,
-    );
+    const events = await readListenerEvents(job.id);
+    expect(events.filter((event) => event.consumedByExecutionId === execution?.id)).toHaveLength(2);
+    expect(
+      events
+        .filter((event) => event.consumedByExecutionId === execution?.id)
+        .map((event) => (event.payload as {name: string}).name),
+    ).toEqual(payloads);
   });
 
   it('leaves a legacy oversized listener head pending after an empty drain', async () => {
@@ -1140,6 +1165,47 @@ describe('drainListenerEventsIntoExecution', () => {
       ['gpu', 'linux'],
       ['arm', 'linux'],
     ]);
+  });
+
+  it('loads prior listener events from canonical rows after array writes stop', async () => {
+    const job = await createListeningJobFromModel({
+      jobs: {
+        review: {
+          runner: ['linux'],
+          runnerTemplates: [template('executions[0].events[0].data.runner')],
+          steps: [{run: 'echo review'}],
+        },
+      },
+    });
+    await bufferEvent(job.id, 'fire', crypto.randomUUID(), new Date('2026-01-01T00:00:00.000Z'));
+    await db()
+      .update(jobListenerEvents)
+      .set({payload: {runner: 'GPU'}})
+      .where(eq(jobListenerEvents.jobId, job.id));
+
+    const first = await drainListenerEventsIntoExecution({jobId: job.id, expectedSequence: 1});
+    const persistedFirst = await getFirstJobExecutionByJobId(job.id);
+    expect(persistedFirst?.triggerEvents).toMatchObject([{data: {runner: 'GPU'}}]);
+
+    await bufferEvent(job.id, 'fire', crypto.randomUUID(), new Date('2026-01-01T00:01:00.000Z'));
+    await db()
+      .update(jobListenerEvents)
+      .set({payload: {runner: 'ARM'}})
+      .where(
+        and(eq(jobListenerEvents.jobId, job.id), isNull(jobListenerEvents.consumedByExecutionId)),
+      );
+    const second = await drainListenerEventsIntoExecution({jobId: job.id, expectedSequence: 2});
+    const persistedSecond = await getLatestJobExecutionByJobId(job.id);
+
+    const executions = await db()
+      .select()
+      .from(jobExecutions)
+      .where(eq(jobExecutions.jobId, job.id))
+      .orderBy(asc(jobExecutions.sequence));
+    expect(first).toMatchObject({kind: 'execution', requiredLabels: ['gpu', 'linux']});
+    expect(second).toMatchObject({kind: 'execution', requiredLabels: ['gpu', 'linux']});
+    expect(persistedSecond?.triggerEvents).toMatchObject([{data: {runner: 'ARM'}}]);
+    expect(executions.map((execution) => execution.triggerEvents)).toEqual([null, null]);
   });
 
   it('persists step conditions for listener firings', async () => {

--- a/libs/api/workflows/src/db/job-listeners.test.ts
+++ b/libs/api/workflows/src/db/job-listeners.test.ts
@@ -6,7 +6,7 @@ import {
 import {createWorkflowExpression} from '@shipfox/expression';
 import {and, asc, eq, isNull} from 'drizzle-orm';
 import type {JobListeningTrigger, JobStatus} from '#core/entities/job.js';
-import type {JobExecutionStatus} from '#core/entities/job-execution.js';
+import type {JobExecutionStatus, WorkflowExecutionEvent} from '#core/entities/job-execution.js';
 import type {WorkflowRunTriggerReference} from '#core/entities/workflow-run.js';
 import {nextStepForJob, recordStepResult} from '#core/job-execution.js';
 import {
@@ -22,6 +22,7 @@ import {
   resolveJobListener,
   settleListenerJobExecution,
 } from '#db/job-listeners.js';
+import {getListenerEventStorageStats} from '#db/listener-storage.js';
 import {jobExecutions} from '#db/schema/job-executions.js';
 import {jobListenerEvents} from '#db/schema/job-listener-events.js';
 import {jobs} from '#db/schema/jobs.js';
@@ -32,6 +33,8 @@ import {jobExecutionTerminatedEvents} from '#test/helpers/workflow-runs.js';
 import {jobFactory, workflowModel, workflowRunFactory} from '#test/index.js';
 import {
   getFirstJobExecutionByJobId,
+  getJobExecutionsByJobId,
+  getJobExecutionsByWorkflowRunAttemptId,
   getJobsByWorkflowRunId,
   getLatestJobExecutionByJobId,
   updateJobExecutionStatus,
@@ -1208,6 +1211,76 @@ describe('drainListenerEventsIntoExecution', () => {
     expect(executions.map((execution) => execution.triggerEvents)).toEqual([null, null]);
   });
 
+  it('orders canonical events and falls back to retained legacy arrays', async () => {
+    const job = await createListeningJob({status: 'running', listenerStatus: 'listening'});
+    await bufferEvent(
+      job.id,
+      'fire',
+      crypto.randomUUID(),
+      new Date('2026-01-01T00:01:00.000Z'),
+      null,
+      {order: 'middle'},
+    );
+    await bufferEvent(
+      job.id,
+      'fire',
+      crypto.randomUUID(),
+      new Date('2026-01-01T00:02:00.000Z'),
+      null,
+      {order: 'last'},
+    );
+    await bufferEvent(
+      job.id,
+      'fire',
+      crypto.randomUUID(),
+      new Date('2026-01-01T00:00:00.000Z'),
+      null,
+      {order: 'first'},
+    );
+    const firstDrain = await drainListenerEventsIntoExecution({
+      jobId: job.id,
+      expectedSequence: 1,
+      maxSize: 3,
+    });
+    const legacyEvent: WorkflowExecutionEvent = {
+      source: 'github',
+      event: 'push',
+      delivery_id: 'legacy-fallback',
+      received_at: '2026-01-01T00:03:00.000Z',
+      project: null,
+      repository: null,
+      ref: null,
+      commit: null,
+      data: {order: 'legacy'},
+    };
+    const legacyExecution = await insertExecution(job.id, 2, 'succeeded');
+    await db()
+      .update(jobExecutions)
+      .set({triggerEvents: [legacyEvent]})
+      .where(eq(jobExecutions.id, legacyExecution.id));
+
+    const first = await getFirstJobExecutionByJobId(job.id);
+    const latest = await getLatestJobExecutionByJobId(job.id);
+    const byJob = await getJobExecutionsByJobId(job.id);
+    const byAttempt = await getJobExecutionsByWorkflowRunAttemptId(job.workflowRunAttemptId);
+
+    expect(firstDrain).toMatchObject({kind: 'execution'});
+    expect(first?.triggerEvents.map((event) => (event.data as {order: string}).order)).toEqual([
+      'first',
+      'middle',
+      'last',
+    ]);
+    expect(latest?.triggerEvents).toEqual([legacyEvent]);
+    expect(byJob.map((execution) => execution.triggerEvents)).toEqual([
+      first?.triggerEvents,
+      [legacyEvent],
+    ]);
+    expect(byAttempt.map((execution) => execution.triggerEvents)).toEqual([
+      first?.triggerEvents,
+      [legacyEvent],
+    ]);
+  });
+
   it('persists step conditions for listener firings', async () => {
     const condition = conditionExpression('false');
     const job = await createListeningJobFromModel({
@@ -1446,5 +1519,82 @@ describe('drainListenerEventsIntoExecution', () => {
       .where(and(eq(jobExecutions.jobId, job.id), eq(jobExecutions.sequence, 1)));
     expect(result).toMatchObject({kind: 'execution', status: 'failed'});
     expect(execution?.status).toBe('failed');
+  });
+});
+
+describe('getListenerEventStorageStats', () => {
+  it('counts retained payloads, ages, and legacy bytes with database queries', async () => {
+    const job = await createListeningJob({status: 'running', listenerStatus: 'listening'});
+    const before = await getListenerEventStorageStats();
+    const execution = await insertExecution(job.id, 1, 'pending');
+    const legacyEvent: WorkflowExecutionEvent = {
+      source: 'github',
+      event: 'push',
+      delivery_id: 'legacy-storage-metric',
+      received_at: '2026-01-01T00:00:00.000Z',
+      project: null,
+      repository: null,
+      ref: null,
+      commit: null,
+      data: {legacy: true},
+    };
+    await db()
+      .update(jobExecutions)
+      .set({triggerEvents: [legacyEvent]})
+      .where(eq(jobExecutions.id, execution.id));
+
+    await db()
+      .insert(jobListenerEvents)
+      .values([
+        {
+          jobId: job.id,
+          disposition: 'fire',
+          outcome: 'consumed',
+          eventRef: 'storage-metric-consumed',
+          deliveryId: 'storage-metric-consumed',
+          source: 'github',
+          event: 'push',
+          payload: {state: 'consumed'},
+          storedPayloadBytes: 11,
+          normalizedEventBytes: 12,
+          receivedAt: new Date('2026-01-01T00:00:00.000Z'),
+          consumedByExecutionId: execution.id,
+        },
+        {
+          jobId: job.id,
+          disposition: 'fire',
+          outcome: 'pending',
+          eventRef: 'storage-metric-pending',
+          deliveryId: 'storage-metric-pending',
+          source: 'github',
+          event: 'push',
+          payload: {state: 'pending'},
+          storedPayloadBytes: 13,
+          normalizedEventBytes: 14,
+          receivedAt: new Date('2026-01-02T00:00:00.000Z'),
+        },
+        {
+          jobId: job.id,
+          disposition: 'fire',
+          outcome: 'rejected',
+          outcomeReason: 'payload_too_large',
+          eventRef: 'storage-metric-rejected',
+          deliveryId: 'storage-metric-rejected',
+          source: 'github',
+          event: 'push',
+          payload: null,
+          storedPayloadBytes: 97,
+          normalizedEventBytes: 98,
+          receivedAt: new Date('2026-01-03T00:00:00.000Z'),
+        },
+      ]);
+
+    const after = await getListenerEventStorageStats();
+
+    expect(after.listenerEventRows - before.listenerEventRows).toBe(3);
+    expect(after.listenerEventPayloadBytes - before.listenerEventPayloadBytes).toBe(24);
+    expect(after.consumedListenerEventOldestAgeMilliseconds).toBeGreaterThan(0);
+    expect(after.pendingListenerEventOldestAgeMilliseconds).toBeGreaterThan(0);
+    expect(after.duplicateTriggerEventsBytes).toBeGreaterThan(before.duplicateTriggerEventsBytes);
   });
 });

--- a/libs/api/workflows/src/db/job-listeners.test.ts
+++ b/libs/api/workflows/src/db/job-listeners.test.ts
@@ -4,7 +4,7 @@ import {
   type WorkflowsJobActivatedEventDto,
 } from '@shipfox/api-workflows-dto';
 import {createWorkflowExpression} from '@shipfox/expression';
-import {and, asc, eq, isNull} from 'drizzle-orm';
+import {and, asc, eq, isNull, sql} from 'drizzle-orm';
 import type {JobListeningTrigger, JobStatus} from '#core/entities/job.js';
 import type {JobExecutionStatus, WorkflowExecutionEvent} from '#core/entities/job-execution.js';
 import type {WorkflowRunTriggerReference} from '#core/entities/workflow-run.js';
@@ -32,7 +32,9 @@ import {workflowRunAttempts} from '#db/schema/workflow-run-attempts.js';
 import {jobExecutionTerminatedEvents} from '#test/helpers/workflow-runs.js';
 import {jobFactory, workflowModel, workflowRunFactory} from '#test/index.js';
 import {
+  getDirectDependencyJobContexts,
   getFirstJobExecutionByJobId,
+  getJobExecutionById,
   getJobExecutionsByJobId,
   getJobExecutionsByWorkflowRunAttemptId,
   getJobsByWorkflowRunId,
@@ -1261,6 +1263,7 @@ describe('drainListenerEventsIntoExecution', () => {
 
     const first = await getFirstJobExecutionByJobId(job.id);
     const latest = await getLatestJobExecutionByJobId(job.id);
+    const byId = await getJobExecutionById(legacyExecution.id);
     const byJob = await getJobExecutionsByJobId(job.id);
     const byAttempt = await getJobExecutionsByWorkflowRunAttemptId(job.workflowRunAttemptId);
 
@@ -1271,6 +1274,7 @@ describe('drainListenerEventsIntoExecution', () => {
       'last',
     ]);
     expect(latest?.triggerEvents).toEqual([legacyEvent]);
+    expect(byId?.triggerEvents).toEqual([legacyEvent]);
     expect(byJob.map((execution) => execution.triggerEvents)).toEqual([
       first?.triggerEvents,
       [legacyEvent],
@@ -1278,6 +1282,32 @@ describe('drainListenerEventsIntoExecution', () => {
     expect(byAttempt.map((execution) => execution.triggerEvents)).toEqual([
       first?.triggerEvents,
       [legacyEvent],
+    ]);
+
+    const dependencyListener = await createListenerWithDependencies({
+      on: [{source: 'github', event: 'pull_request'}],
+    });
+    const [dependencyJob] = await db()
+      .select()
+      .from(jobs)
+      .where(
+        and(
+          eq(jobs.workflowRunAttemptId, dependencyListener.workflowRunAttemptId),
+          eq(jobs.key, 'build'),
+        ),
+      )
+      .limit(1);
+    if (!dependencyJob) throw new Error('Expected dependency job');
+    await db().delete(jobExecutions).where(eq(jobExecutions.jobId, dependencyJob.id));
+    const dependencyExecution = await insertExecution(dependencyJob.id, 1, 'succeeded');
+    await db()
+      .update(jobExecutions)
+      .set({triggerEvents: [legacyEvent]})
+      .where(eq(jobExecutions.id, dependencyExecution.id));
+
+    const dependencyContexts = await getDirectDependencyJobContexts(dependencyListener.id);
+    expect(dependencyContexts.find((context) => context.job.key === 'build')?.executions).toEqual([
+      expect.objectContaining({triggerEvents: [legacyEvent]}),
     ]);
   });
 
@@ -1587,14 +1617,37 @@ describe('getListenerEventStorageStats', () => {
           normalizedEventBytes: 98,
           receivedAt: new Date('2026-01-03T00:00:00.000Z'),
         },
+        {
+          jobId: job.id,
+          disposition: 'resolve',
+          outcome: 'abandoned',
+          outcomeReason: 'until',
+          eventRef: 'storage-metric-abandoned',
+          deliveryId: 'storage-metric-abandoned',
+          source: 'github',
+          event: 'push',
+          payload: {state: 'abandoned'},
+          storedPayloadBytes: 17,
+          normalizedEventBytes: 18,
+          receivedAt: new Date('2026-01-04T00:00:00.000Z'),
+        },
       ]);
 
+    const afterArray = await getListenerEventStorageStats();
+    const nonArrayExecution = await insertExecution(job.id, 2, 'pending');
+    await db()
+      .update(jobExecutions)
+      .set({triggerEvents: sql`'{"legacy":"object"}'::jsonb`})
+      .where(eq(jobExecutions.id, nonArrayExecution.id));
     const after = await getListenerEventStorageStats();
 
-    expect(after.listenerEventRows - before.listenerEventRows).toBe(3);
-    expect(after.listenerEventPayloadBytes - before.listenerEventPayloadBytes).toBe(24);
+    expect(after.listenerEventRows - before.listenerEventRows).toBe(4);
+    expect(after.listenerEventPayloadBytes - before.listenerEventPayloadBytes).toBe(41);
     expect(after.consumedListenerEventOldestAgeMilliseconds).toBeGreaterThan(0);
     expect(after.pendingListenerEventOldestAgeMilliseconds).toBeGreaterThan(0);
-    expect(after.duplicateTriggerEventsBytes).toBeGreaterThan(before.duplicateTriggerEventsBytes);
+    expect(afterArray.duplicateTriggerEventsBytes).toBeGreaterThan(
+      before.duplicateTriggerEventsBytes,
+    );
+    expect(after.duplicateTriggerEventsBytes).toBe(afterArray.duplicateTriggerEventsBytes);
   });
 });

--- a/libs/api/workflows/src/db/job-listeners.test.ts
+++ b/libs/api/workflows/src/db/job-listeners.test.ts
@@ -1587,7 +1587,7 @@ describe('getListenerEventStorageStats', () => {
           payload: {state: 'consumed'},
           storedPayloadBytes: 11,
           normalizedEventBytes: 12,
-          receivedAt: new Date('2026-01-01T00:00:00.000Z'),
+          receivedAt: new Date('1970-01-01T00:00:00.000Z'),
           consumedByExecutionId: execution.id,
         },
         {
@@ -1601,7 +1601,7 @@ describe('getListenerEventStorageStats', () => {
           payload: {state: 'pending'},
           storedPayloadBytes: 13,
           normalizedEventBytes: 14,
-          receivedAt: new Date('2026-01-02T00:00:00.000Z'),
+          receivedAt: new Date('1970-01-01T00:01:00.000Z'),
         },
         {
           jobId: job.id,
@@ -1643,8 +1643,14 @@ describe('getListenerEventStorageStats', () => {
 
     expect(after.listenerEventRows - before.listenerEventRows).toBe(4);
     expect(after.listenerEventPayloadBytes - before.listenerEventPayloadBytes).toBe(41);
-    expect(after.consumedListenerEventOldestAgeMilliseconds).toBeGreaterThan(0);
-    expect(after.pendingListenerEventOldestAgeMilliseconds).toBeGreaterThan(0);
+    expect(
+      after.consumedListenerEventOldestAgeMilliseconds -
+        before.consumedListenerEventOldestAgeMilliseconds,
+    ).toBeGreaterThan(0);
+    expect(
+      after.pendingListenerEventOldestAgeMilliseconds -
+        before.pendingListenerEventOldestAgeMilliseconds,
+    ).toBeGreaterThan(0);
     expect(afterArray.duplicateTriggerEventsBytes).toBeGreaterThan(
       before.duplicateTriggerEventsBytes,
     );

--- a/libs/api/workflows/src/db/job-listeners.test.ts
+++ b/libs/api/workflows/src/db/job-listeners.test.ts
@@ -1266,6 +1266,10 @@ describe('drainListenerEventsIntoExecution', () => {
     const byId = await getJobExecutionById(legacyExecution.id);
     const byJob = await getJobExecutionsByJobId(job.id);
     const byAttempt = await getJobExecutionsByWorkflowRunAttemptId(job.workflowRunAttemptId);
+    const byAttemptWithoutTriggerEvents = await getJobExecutionsByWorkflowRunAttemptId(
+      job.workflowRunAttemptId,
+      {includeTriggerEvents: false},
+    );
 
     expect(firstDrain).toMatchObject({kind: 'execution'});
     expect(first?.triggerEvents.map((event) => (event.data as {order: string}).order)).toEqual([
@@ -1282,6 +1286,10 @@ describe('drainListenerEventsIntoExecution', () => {
     expect(byAttempt.map((execution) => execution.triggerEvents)).toEqual([
       first?.triggerEvents,
       [legacyEvent],
+    ]);
+    expect(byAttemptWithoutTriggerEvents.map((execution) => execution.triggerEvents)).toEqual([
+      [],
+      [],
     ]);
 
     const dependencyListener = await createListenerWithDependencies({
@@ -1646,11 +1654,11 @@ describe('getListenerEventStorageStats', () => {
     expect(
       after.consumedListenerEventOldestAgeMilliseconds -
         before.consumedListenerEventOldestAgeMilliseconds,
-    ).toBeGreaterThan(0);
+    ).toBeGreaterThan(24 * 60 * 60 * 1000);
     expect(
       after.pendingListenerEventOldestAgeMilliseconds -
         before.pendingListenerEventOldestAgeMilliseconds,
-    ).toBeGreaterThan(0);
+    ).toBeGreaterThan(24 * 60 * 60 * 1000);
     expect(afterArray.duplicateTriggerEventsBytes).toBeGreaterThan(
       before.duplicateTriggerEventsBytes,
     );

--- a/libs/api/workflows/src/db/job-listeners.test.ts
+++ b/libs/api/workflows/src/db/job-listeners.test.ts
@@ -18,6 +18,7 @@ import {deliverEventToListener} from '#db/job-listener-events.js';
 import {
   activateJobListener,
   drainListenerEventsIntoExecution,
+  legacyTriggerEventsInsertValues,
   peekListenerBuffer,
   resolveJobListener,
   settleListenerJobExecution,
@@ -117,6 +118,26 @@ function bufferEvent(
     receivedAt,
   });
 }
+
+describe('legacyTriggerEventsInsertValues', () => {
+  it('retains legacy arrays when the mixed-deployment gate is enabled', () => {
+    const event: WorkflowExecutionEvent = {
+      source: 'github',
+      event: 'push',
+      delivery_id: 'legacy-writer-gate',
+      received_at: '2026-01-01T00:00:00.000Z',
+      project: null,
+      repository: null,
+      ref: null,
+      commit: null,
+      data: {action: 'opened'},
+    };
+
+    expect(legacyTriggerEventsInsertValues([event], true)).toEqual({triggerEvents: [event]});
+    expect(legacyTriggerEventsInsertValues([event], false)).toEqual({});
+    expect(legacyTriggerEventsInsertValues([event])).toEqual({});
+  });
+});
 
 function readJob(jobId: string) {
   return db()

--- a/libs/api/workflows/src/db/job-listeners.ts
+++ b/libs/api/workflows/src/db/job-listeners.ts
@@ -63,8 +63,8 @@ import {
 import {writeWorkflowsOutboxEvent} from './outbox-writes.js';
 import {
   type JobExecutionDb,
-  type JobExecutionDbWithoutTriggerEvents,
   jobExecutions,
+  jobExecutionWithoutTriggerEventsSelection,
   toJobExecution,
 } from './schema/job-executions.js';
 import {type JobListenerEventDb, jobListenerEvents} from './schema/job-listener-events.js';
@@ -110,32 +110,6 @@ function recordFinalizedListenerEventMetrics(
     recordWorkflowListenerEventOutcome('abandoned', reason, counts.abandoned);
   }
 }
-
-const listenerPriorExecutionSelection = {
-  id: jobExecutions.id,
-  jobId: jobExecutions.jobId,
-  sequence: jobExecutions.sequence,
-  name: jobExecutions.name,
-  runner: jobExecutions.runner,
-  runnerLabels: jobExecutions.runnerLabels,
-  templateKey: jobExecutions.templateKey,
-  provisionerId: jobExecutions.provisionerId,
-  provisionerScope: jobExecutions.provisionerScope,
-  providerKind: jobExecutions.providerKind,
-  launchKind: jobExecutions.launchKind,
-  status: jobExecutions.status,
-  statusReason: jobExecutions.statusReason,
-  statusReasonMessage: jobExecutions.statusReasonMessage,
-  outputs: jobExecutions.outputs,
-  evaluationTrace: jobExecutions.evaluationTrace,
-  version: jobExecutions.version,
-  createdAt: jobExecutions.createdAt,
-  updatedAt: jobExecutions.updatedAt,
-  queuedAt: jobExecutions.queuedAt,
-  startedAt: jobExecutions.startedAt,
-  finishedAt: jobExecutions.finishedAt,
-  timedOutAt: jobExecutions.timedOutAt,
-} satisfies Record<keyof JobExecutionDbWithoutTriggerEvents, unknown>;
 
 export interface ActivateJobListenerParams {
   jobId: string;
@@ -1086,7 +1060,7 @@ async function loadListenerPriorExecutions(
 ): Promise<JobExecution[]> {
   if (!includeTriggerEvents) {
     const priorExecutions = await source
-      .select(listenerPriorExecutionSelection)
+      .select(jobExecutionWithoutTriggerEventsSelection)
       .from(jobExecutions)
       .where(eq(jobExecutions.jobId, jobId))
       .orderBy(asc(jobExecutions.sequence), asc(jobExecutions.id));

--- a/libs/api/workflows/src/db/job-listeners.ts
+++ b/libs/api/workflows/src/db/job-listeners.ts
@@ -1102,5 +1102,7 @@ async function loadListenerPriorExecutions(
     source,
     priorExecutions,
   );
-  return hydratedExecutions.map((execution) => toJobExecution(execution, fallbackName));
+  return priorExecutions.map((execution) =>
+    toJobExecution(hydratedExecutions.get(execution.id) ?? execution, fallbackName),
+  );
 }

--- a/libs/api/workflows/src/db/job-listeners.ts
+++ b/libs/api/workflows/src/db/job-listeners.ts
@@ -54,6 +54,7 @@ import {
   recordWorkflowListenerResolved,
 } from '#metrics/instance.js';
 import {db, type Tx} from './db.js';
+import {loadJobExecutionsWithCanonicalTriggerEvents} from './execution-trigger-events.js';
 import {
   type FinalizedListenerEventCounts,
   finalizePendingListenerEvents,
@@ -567,21 +568,19 @@ async function deriveJobListenerResolutionDecision(
   });
 
   const [executionRows, dependencyJobs] = await Promise.all([
-    (includePriorExecutionTriggerEvents
-      ? db().select().from(jobExecutions)
-      : db().select(listenerPriorExecutionSelection).from(jobExecutions)
-    )
-      .where(eq(jobExecutions.jobId, jobId))
-      .orderBy(asc(jobExecutions.sequence), asc(jobExecutions.id)),
+    loadListenerPriorExecutions(
+      jobId,
+      jobRow.name ?? jobRow.key,
+      db(),
+      includePriorExecutionTriggerEvents,
+    ),
     getDirectDependencyJobContexts(jobId),
   ]);
   return {
     expectedVersion: jobRow.version,
     ...deriveJobSuccess({
       success: jobRow.success,
-      executions: executionRows.map((execution) =>
-        toJobExecution(execution, jobRow.name ?? jobRow.key),
-      ),
+      executions: executionRows,
       jobs: dependencyJobs,
       vars: target.attempt.vars ?? undefined,
     }),
@@ -913,7 +912,6 @@ async function persistMaterializedListenerExecution(
       runner: params.materialized.runner.length === 0 ? null : [...params.materialized.runner],
       status: params.materialized.status,
       statusReason: params.materialized.statusReason,
-      triggerEvents: [...params.materialized.triggerEvents],
       evaluationTrace: params.materialized.evaluationTrace,
       ...(params.materialized.status === 'failed' ? {finishedAt: sql`now()`} : {}),
     })
@@ -985,7 +983,6 @@ async function persistRejectedMaterializedListenerExecution(
       status: 'failed',
       statusReason: 'output_too_large',
       statusReasonMessage: boundedListenerDiagnosticMessage(error.message),
-      triggerEvents: [],
       evaluationTrace: null,
       finishedAt: sql`now()`,
     })
@@ -1084,14 +1081,26 @@ async function loadListenerMaterializationTarget(jobId: string, tx?: Tx) {
 async function loadListenerPriorExecutions(
   jobId: string,
   fallbackName: string,
-  tx: Tx,
+  source: ReturnType<typeof db> | Tx,
   includeTriggerEvents: boolean,
 ): Promise<JobExecution[]> {
-  const priorExecutions = await (includeTriggerEvents
-    ? tx.select().from(jobExecutions)
-    : tx.select(listenerPriorExecutionSelection).from(jobExecutions)
-  )
+  if (!includeTriggerEvents) {
+    const priorExecutions = await source
+      .select(listenerPriorExecutionSelection)
+      .from(jobExecutions)
+      .where(eq(jobExecutions.jobId, jobId))
+      .orderBy(asc(jobExecutions.sequence), asc(jobExecutions.id));
+    return priorExecutions.map((execution) => toJobExecution(execution, fallbackName));
+  }
+
+  const priorExecutions = await source
+    .select()
+    .from(jobExecutions)
     .where(eq(jobExecutions.jobId, jobId))
     .orderBy(asc(jobExecutions.sequence), asc(jobExecutions.id));
-  return priorExecutions.map((execution) => toJobExecution(execution, fallbackName));
+  const hydratedExecutions = await loadJobExecutionsWithCanonicalTriggerEvents(
+    source,
+    priorExecutions,
+  );
+  return hydratedExecutions.map((execution) => toJobExecution(execution, fallbackName));
 }

--- a/libs/api/workflows/src/db/job-listeners.ts
+++ b/libs/api/workflows/src/db/job-listeners.ts
@@ -93,6 +93,13 @@ const LISTENER_EVENT_SQL_BYTE_LIMIT =
 // a batch count. The application packer remains the byte authority.
 const LISTENER_EVENT_SQL_CANDIDATE_COUNT_LIMIT = 100;
 
+export function legacyTriggerEventsInsertValues(
+  triggerEvents: readonly WorkflowExecutionEvent[],
+  enabled = config.WORKFLOWS_LEGACY_TRIGGER_EVENTS_WRITE_ENABLED,
+): Partial<Record<'triggerEvents', WorkflowExecutionEvent[]>> {
+  return enabled ? {triggerEvents: [...triggerEvents]} : {};
+}
+
 function pendingListenerEventCondition() {
   return and(
     eq(jobListenerEvents.outcome, 'pending'),
@@ -887,9 +894,7 @@ async function persistMaterializedListenerExecution(
       runner: params.materialized.runner.length === 0 ? null : [...params.materialized.runner],
       status: params.materialized.status,
       statusReason: params.materialized.statusReason,
-      ...(config.WORKFLOWS_LEGACY_TRIGGER_EVENTS_WRITE_ENABLED
-        ? {triggerEvents: [...params.materialized.triggerEvents]}
-        : {}),
+      ...legacyTriggerEventsInsertValues(params.materialized.triggerEvents),
       evaluationTrace: params.materialized.evaluationTrace,
       ...(params.materialized.status === 'failed' ? {finishedAt: sql`now()`} : {}),
     })

--- a/libs/api/workflows/src/db/job-listeners.ts
+++ b/libs/api/workflows/src/db/job-listeners.ts
@@ -9,6 +9,7 @@ import {
 } from '@shipfox/api-workflows-dto';
 import {logger} from '@shipfox/node-opentelemetry';
 import {and, asc, count, eq, inArray, isNull, notInArray, sql} from 'drizzle-orm';
+import {config} from '#config.js';
 import {type AgentDefaultsResolver, createAgentDefaultsResolver} from '#core/agent-defaults.js';
 import {
   type AgentToolMaterializationContext,
@@ -886,6 +887,9 @@ async function persistMaterializedListenerExecution(
       runner: params.materialized.runner.length === 0 ? null : [...params.materialized.runner],
       status: params.materialized.status,
       statusReason: params.materialized.statusReason,
+      ...(config.WORKFLOWS_LEGACY_TRIGGER_EVENTS_WRITE_ENABLED
+        ? {triggerEvents: [...params.materialized.triggerEvents]}
+        : {}),
       evaluationTrace: params.materialized.evaluationTrace,
       ...(params.materialized.status === 'failed' ? {finishedAt: sql`now()`} : {}),
     })

--- a/libs/api/workflows/src/db/listener-storage.ts
+++ b/libs/api/workflows/src/db/listener-storage.ts
@@ -16,7 +16,9 @@ export async function getListenerEventStorageStats(): Promise<ListenerEventStora
     db()
       .select({
         listenerEventRows: count(),
-        listenerEventPayloadBytes: sql<number>`coalesce(sum(${jobListenerEvents.storedPayloadBytes}), 0)`,
+        listenerEventPayloadBytes: sql<number>`coalesce(sum(
+          ${jobListenerEvents.storedPayloadBytes}
+        ) filter (where ${jobListenerEvents.payload} is not null), 0)`,
         consumedListenerEventOldestAgeMilliseconds: listenerEventOldestAge(
           sql`${jobListenerEvents.consumedByExecutionId} is not null`,
         ),

--- a/libs/api/workflows/src/db/listener-storage.ts
+++ b/libs/api/workflows/src/db/listener-storage.ts
@@ -1,0 +1,63 @@
+import {count, sql} from 'drizzle-orm';
+import {db} from './db.js';
+import {jobExecutions} from './schema/job-executions.js';
+import {jobListenerEvents} from './schema/job-listener-events.js';
+
+export interface ListenerEventStorageStats {
+  listenerEventRows: number;
+  listenerEventPayloadBytes: number;
+  consumedListenerEventOldestAgeMilliseconds: number;
+  pendingListenerEventOldestAgeMilliseconds: number;
+  duplicateTriggerEventsBytes: number;
+}
+
+export async function getListenerEventStorageStats(): Promise<ListenerEventStorageStats> {
+  const [eventStats, executionStats] = await Promise.all([
+    db()
+      .select({
+        listenerEventRows: count(),
+        listenerEventPayloadBytes: sql<number>`coalesce(sum(${jobListenerEvents.storedPayloadBytes}), 0)`,
+        consumedListenerEventOldestAgeMilliseconds: listenerEventOldestAge(
+          sql`${jobListenerEvents.consumedByExecutionId} is not null`,
+        ),
+        pendingListenerEventOldestAgeMilliseconds: listenerEventOldestAge(
+          sql`${jobListenerEvents.consumedByExecutionId} is null and ${jobListenerEvents.outcome} = 'pending'`,
+        ),
+      })
+      .from(jobListenerEvents)
+      .then(([row]) => row),
+    db()
+      .select({
+        duplicateTriggerEventsBytes: sql<number>`coalesce(sum(
+          case
+            when jsonb_typeof(${jobExecutions.triggerEvents}) = 'array'
+            then octet_length(${jobExecutions.triggerEvents}::text)
+            else 0
+          end
+        ), 0)`,
+      })
+      .from(jobExecutions)
+      .then(([row]) => row),
+  ]);
+
+  return {
+    listenerEventRows: Number(eventStats?.listenerEventRows ?? 0),
+    listenerEventPayloadBytes: Number(eventStats?.listenerEventPayloadBytes ?? 0),
+    consumedListenerEventOldestAgeMilliseconds: Number(
+      eventStats?.consumedListenerEventOldestAgeMilliseconds ?? 0,
+    ),
+    pendingListenerEventOldestAgeMilliseconds: Number(
+      eventStats?.pendingListenerEventOldestAgeMilliseconds ?? 0,
+    ),
+    duplicateTriggerEventsBytes: Number(executionStats?.duplicateTriggerEventsBytes ?? 0),
+  };
+}
+
+function listenerEventOldestAge(condition: ReturnType<typeof sql>) {
+  return sql<number>`coalesce(
+    extract(epoch from (
+      statement_timestamp() - min(${jobListenerEvents.receivedAt}) filter (where ${condition})
+    )) * 1000,
+    0
+  )`;
+}

--- a/libs/api/workflows/src/db/listener-storage.ts
+++ b/libs/api/workflows/src/db/listener-storage.ts
@@ -56,10 +56,13 @@ export async function getListenerEventStorageStats(): Promise<ListenerEventStora
 }
 
 function listenerEventOldestAge(condition: ReturnType<typeof sql>) {
-  return sql<number>`coalesce(
-    extract(epoch from (
-      statement_timestamp() - min(${jobListenerEvents.receivedAt}) filter (where ${condition})
-    )) * 1000,
+  return sql<number>`greatest(
+    coalesce(
+      extract(epoch from (
+        statement_timestamp() - min(${jobListenerEvents.receivedAt}) filter (where ${condition})
+      )) * 1000,
+      0
+    ),
     0
   )`;
 }

--- a/libs/api/workflows/src/db/schema/job-executions.ts
+++ b/libs/api/workflows/src/db/schema/job-executions.ts
@@ -53,7 +53,9 @@ export const jobExecutions = pgTable(
     status: jobExecutionStatusEnum('status').notNull().default('pending'),
     statusReason: jobStatusReasonEnum('status_reason'),
     statusReasonMessage: text('status_reason_message'),
-    triggerEvents: jsonb('trigger_events').notNull().default([]).$type<WorkflowExecutionEvent[]>(),
+    // Retained for mixed-deployment reads. New listener executions keep their
+    // canonical events in workflows_job_listener_events instead.
+    triggerEvents: jsonb('trigger_events').$type<WorkflowExecutionEvent[] | null>(),
     outputs: jsonb('outputs').$type<Record<string, unknown> | null>(),
     evaluationTrace: jsonb('evaluation_trace').$type<readonly PersistedEvaluationTraceEntry[]>(),
     version: integer('version').notNull().default(1),

--- a/libs/api/workflows/src/db/schema/job-executions.ts
+++ b/libs/api/workflows/src/db/schema/job-executions.ts
@@ -82,6 +82,32 @@ export type JobExecutionDb = typeof jobExecutions.$inferSelect;
 export type JobExecutionDbWithoutTriggerEvents = Omit<JobExecutionDb, 'triggerEvents'>;
 export type JobExecutionCreateDb = typeof jobExecutions.$inferInsert;
 
+export const jobExecutionWithoutTriggerEventsSelection = {
+  id: jobExecutions.id,
+  jobId: jobExecutions.jobId,
+  sequence: jobExecutions.sequence,
+  name: jobExecutions.name,
+  runner: jobExecutions.runner,
+  runnerLabels: jobExecutions.runnerLabels,
+  templateKey: jobExecutions.templateKey,
+  provisionerId: jobExecutions.provisionerId,
+  provisionerScope: jobExecutions.provisionerScope,
+  providerKind: jobExecutions.providerKind,
+  launchKind: jobExecutions.launchKind,
+  status: jobExecutions.status,
+  statusReason: jobExecutions.statusReason,
+  statusReasonMessage: jobExecutions.statusReasonMessage,
+  outputs: jobExecutions.outputs,
+  evaluationTrace: jobExecutions.evaluationTrace,
+  version: jobExecutions.version,
+  createdAt: jobExecutions.createdAt,
+  updatedAt: jobExecutions.updatedAt,
+  queuedAt: jobExecutions.queuedAt,
+  startedAt: jobExecutions.startedAt,
+  finishedAt: jobExecutions.finishedAt,
+  timedOutAt: jobExecutions.timedOutAt,
+} satisfies Record<keyof JobExecutionDbWithoutTriggerEvents, unknown>;
+
 export function toJobExecution(
   row: JobExecutionDb | JobExecutionDbWithoutTriggerEvents,
   fallbackName: string,

--- a/libs/api/workflows/src/db/workflow-runs/job-executions.test.ts
+++ b/libs/api/workflows/src/db/workflow-runs/job-executions.test.ts
@@ -22,6 +22,8 @@ import {
   workflowRunAttemptId,
 } from '#test/helpers/workflow-runs.js';
 import {db} from '../db.js';
+import {jobExecutions} from '../schema/job-executions.js';
+import {jobListenerEvents} from '../schema/job-listener-events.js';
 import {workflowsOutbox} from '../schema/outbox.js';
 import {
   applyStepResult,
@@ -513,6 +515,60 @@ describe('workflow run job executions', () => {
     expect(Array.isArray(resolved.outputs?.findings)).toBe(true);
     const persisted = await getFirstJobExecutionByJobId(job.id);
     expect(persisted?.outputs).toEqual({findings: [{severity: 'high'}]});
+  });
+
+  test('resolves canonical execution events when materializing job outputs', async () => {
+    const run = await createWorkflowRun({
+      workspaceId,
+      projectId,
+      definitionId,
+      model: buildModel({
+        jobs: {
+          build: {
+            steps: [{run: 'echo build'}],
+            outputs: {action: template('executions[0].events[0].data.action')},
+          },
+        },
+      }),
+      triggerPayload: {
+        source: 'manual',
+        event: 'fire',
+        subscriptionId: crypto.randomUUID(),
+        userId: crypto.randomUUID(),
+      },
+    });
+    const [job] = await getJobsByWorkflowRunId(run.id);
+    if (!job) throw new Error('Expected workflow job');
+    const execution = await getFirstJobExecutionByJobId(job.id);
+    if (!execution) throw new Error('Expected job execution');
+    await db()
+      .update(jobExecutions)
+      .set({triggerEvents: null})
+      .where(eq(jobExecutions.id, execution.id));
+    await db()
+      .insert(jobListenerEvents)
+      .values({
+        jobId: job.id,
+        disposition: 'fire',
+        outcome: 'consumed',
+        eventRef: 'output-canonical-event',
+        deliveryId: 'output-canonical-delivery',
+        source: 'github',
+        event: 'pull_request',
+        payload: {action: 'opened'},
+        storedPayloadBytes: 19,
+        normalizedEventBytes: 128,
+        receivedAt: new Date('2026-01-01T00:00:00.000Z'),
+        consumedByExecutionId: execution.id,
+      });
+
+    const resolved = await updateJobExecutionStatus({
+      jobExecutionId: execution.id,
+      status: 'succeeded',
+      expectedVersion: execution.version,
+    });
+
+    expect(resolved.outputs).toEqual({action: 'opened'});
   });
 
   test.each([

--- a/libs/api/workflows/src/db/workflow-runs/job-executions.ts
+++ b/libs/api/workflows/src/db/workflow-runs/job-executions.ts
@@ -24,7 +24,12 @@ import {
 } from '#metrics/instance.js';
 import {db, type Tx} from '../db.js';
 import {loadJobExecutionsWithCanonicalTriggerEvents} from '../execution-trigger-events.js';
-import {type JobExecutionDb, jobExecutions, toJobExecution} from '../schema/job-executions.js';
+import {
+  type JobExecutionDb,
+  jobExecutions,
+  jobExecutionWithoutTriggerEventsSelection,
+  toJobExecution,
+} from '../schema/job-executions.js';
 import {jobs, toJob} from '../schema/jobs.js';
 import {stepAttempts, toStepAttempt} from '../schema/step-attempts.js';
 import {steps, toStep} from '../schema/steps.js';
@@ -72,15 +77,22 @@ export async function getJobExecutionsByWorkflowRunAttemptId(
   workflowRunAttemptId: string,
   options: {includeTriggerEvents?: boolean} = {},
 ): Promise<JobExecution[]> {
+  if (options.includeTriggerEvents === false) {
+    const rows = await db()
+      .select({jobExecution: jobExecutionWithoutTriggerEventsSelection, job: jobs})
+      .from(jobExecutions)
+      .innerJoin(jobs, eq(jobExecutions.jobId, jobs.id))
+      .where(eq(jobs.workflowRunAttemptId, workflowRunAttemptId))
+      .orderBy(asc(jobExecutions.sequence), asc(jobExecutions.id));
+    return rows.map((row) => toJobExecution(row.jobExecution, row.job.name ?? row.job.key));
+  }
+
   const rows = await db()
     .select({jobExecution: jobExecutions, job: jobs})
     .from(jobExecutions)
     .innerJoin(jobs, eq(jobExecutions.jobId, jobs.id))
     .where(eq(jobs.workflowRunAttemptId, workflowRunAttemptId))
     .orderBy(asc(jobExecutions.sequence), asc(jobExecutions.id));
-  if (options.includeTriggerEvents === false) {
-    return rows.map((row) => toJobExecution(row.jobExecution, row.job.name ?? row.job.key));
-  }
   const executions = await loadJobExecutionsWithCanonicalTriggerEvents(
     db(),
     rows.map((row) => row.jobExecution),

--- a/libs/api/workflows/src/db/workflow-runs/job-executions.ts
+++ b/libs/api/workflows/src/db/workflow-runs/job-executions.ts
@@ -52,8 +52,8 @@ async function toHydratedJobExecution(
   row: JobExecutionDb,
   fallbackName: string,
 ): Promise<JobExecution> {
-  const [hydrated] = await loadJobExecutionsWithCanonicalTriggerEvents(source, [row]);
-  return toJobExecution(hydrated ?? row, fallbackName);
+  const hydrated = await loadJobExecutionsWithCanonicalTriggerEvents(source, [row]);
+  return toJobExecution(hydrated.get(row.id) ?? row, fallbackName);
 }
 
 export async function getJobExecutionById(id: string, tx?: Tx): Promise<JobExecution | undefined> {
@@ -70,6 +70,7 @@ export async function getJobExecutionById(id: string, tx?: Tx): Promise<JobExecu
 
 export async function getJobExecutionsByWorkflowRunAttemptId(
   workflowRunAttemptId: string,
+  options: {includeTriggerEvents?: boolean} = {},
 ): Promise<JobExecution[]> {
   const rows = await db()
     .select({jobExecution: jobExecutions, job: jobs})
@@ -77,14 +78,16 @@ export async function getJobExecutionsByWorkflowRunAttemptId(
     .innerJoin(jobs, eq(jobExecutions.jobId, jobs.id))
     .where(eq(jobs.workflowRunAttemptId, workflowRunAttemptId))
     .orderBy(asc(jobExecutions.sequence), asc(jobExecutions.id));
+  if (options.includeTriggerEvents === false) {
+    return rows.map((row) => toJobExecution(row.jobExecution, row.job.name ?? row.job.key));
+  }
   const executions = await loadJobExecutionsWithCanonicalTriggerEvents(
     db(),
     rows.map((row) => row.jobExecution),
   );
-  const executionsById = new Map(executions.map((execution) => [execution.id, execution]));
   return rows.map((row) =>
     toJobExecution(
-      executionsById.get(row.jobExecution.id) ?? row.jobExecution,
+      executions.get(row.jobExecution.id) ?? row.jobExecution,
       row.job.name ?? row.job.key,
     ),
   );
@@ -101,10 +104,9 @@ export async function getJobExecutionsByJobId(jobId: string): Promise<JobExecuti
     db(),
     rows.map((row) => row.jobExecution),
   );
-  const executionsById = new Map(executions.map((execution) => [execution.id, execution]));
   return rows.map((row) =>
     toJobExecution(
-      executionsById.get(row.jobExecution.id) ?? row.jobExecution,
+      executions.get(row.jobExecution.id) ?? row.jobExecution,
       row.job.name ?? row.job.key,
     ),
   );
@@ -221,14 +223,15 @@ async function resolveJobExecutionOutputs(
     executionRows,
   );
   const fallbackName = target.job.name ?? target.job.key;
-  const executions = hydratedExecutionRows.map((row) =>
-    row.id === target.execution.id
+  const executions = executionRows.map((row) => {
+    const hydrated = hydratedExecutionRows.get(row.id) ?? row;
+    return row.id === target.execution.id
       ? toJobExecution(
-          {...row, status: params.status, statusReason: params.statusReason},
+          {...hydrated, status: params.status, statusReason: params.statusReason},
           fallbackName,
         )
-      : toJobExecution(row, fallbackName),
-  );
+      : toJobExecution(hydrated, fallbackName);
+  });
   const jobExecution = executions.find((execution) => execution.id === target.execution.id);
   if (!jobExecution) throw new JobNotFoundError(params.jobExecutionId);
 
@@ -437,7 +440,7 @@ export async function queueJobExecution(params: {jobExecutionId: string}): Promi
     });
 
     return {
-      execution: await toHydratedJobExecution(tx, queued, row.job.name ?? row.job.key),
+      execution: {...existing, queuedAt: queued.queuedAt, updatedAt: queued.updatedAt},
       changed: true,
     };
   });

--- a/libs/api/workflows/src/db/workflow-runs/job-executions.ts
+++ b/libs/api/workflows/src/db/workflow-runs/job-executions.ts
@@ -23,7 +23,8 @@ import {
   recordWorkflowJobExecutionTimedOut,
 } from '#metrics/instance.js';
 import {db, type Tx} from '../db.js';
-import {jobExecutions, toJobExecution} from '../schema/job-executions.js';
+import {loadJobExecutionsWithCanonicalTriggerEvents} from '../execution-trigger-events.js';
+import {type JobExecutionDb, jobExecutions, toJobExecution} from '../schema/job-executions.js';
 import {jobs, toJob} from '../schema/jobs.js';
 import {stepAttempts, toStepAttempt} from '../schema/step-attempts.js';
 import {steps, toStep} from '../schema/steps.js';
@@ -46,6 +47,15 @@ async function getJobExecutionFallbackName(tx: Tx, jobExecutionId: string): Prom
   return row.job.name ?? row.job.key;
 }
 
+async function toHydratedJobExecution(
+  source: ReturnType<typeof db> | Tx,
+  row: JobExecutionDb,
+  fallbackName: string,
+): Promise<JobExecution> {
+  const [hydrated] = await loadJobExecutionsWithCanonicalTriggerEvents(source, [row]);
+  return toJobExecution(hydrated ?? row, fallbackName);
+}
+
 export async function getJobExecutionById(id: string, tx?: Tx): Promise<JobExecution | undefined> {
   const rows = await (tx ?? db())
     .select({jobExecution: jobExecutions, job: jobs})
@@ -54,7 +64,8 @@ export async function getJobExecutionById(id: string, tx?: Tx): Promise<JobExecu
     .where(eq(jobExecutions.id, id))
     .limit(1);
   const row = rows[0];
-  return row ? toJobExecution(row.jobExecution, row.job.name ?? row.job.key) : undefined;
+  if (!row) return undefined;
+  return toHydratedJobExecution(tx ?? db(), row.jobExecution, row.job.name ?? row.job.key);
 }
 
 export async function getJobExecutionsByWorkflowRunAttemptId(
@@ -66,7 +77,17 @@ export async function getJobExecutionsByWorkflowRunAttemptId(
     .innerJoin(jobs, eq(jobExecutions.jobId, jobs.id))
     .where(eq(jobs.workflowRunAttemptId, workflowRunAttemptId))
     .orderBy(asc(jobExecutions.sequence), asc(jobExecutions.id));
-  return rows.map((row) => toJobExecution(row.jobExecution, row.job.name ?? row.job.key));
+  const executions = await loadJobExecutionsWithCanonicalTriggerEvents(
+    db(),
+    rows.map((row) => row.jobExecution),
+  );
+  const executionsById = new Map(executions.map((execution) => [execution.id, execution]));
+  return rows.map((row) =>
+    toJobExecution(
+      executionsById.get(row.jobExecution.id) ?? row.jobExecution,
+      row.job.name ?? row.job.key,
+    ),
+  );
 }
 
 export async function getJobExecutionsByJobId(jobId: string): Promise<JobExecution[]> {
@@ -76,7 +97,17 @@ export async function getJobExecutionsByJobId(jobId: string): Promise<JobExecuti
     .innerJoin(jobs, eq(jobExecutions.jobId, jobs.id))
     .where(eq(jobExecutions.jobId, jobId))
     .orderBy(asc(jobExecutions.sequence), asc(jobExecutions.id));
-  return rows.map((row) => toJobExecution(row.jobExecution, row.job.name ?? row.job.key));
+  const executions = await loadJobExecutionsWithCanonicalTriggerEvents(
+    db(),
+    rows.map((row) => row.jobExecution),
+  );
+  const executionsById = new Map(executions.map((execution) => [execution.id, execution]));
+  return rows.map((row) =>
+    toJobExecution(
+      executionsById.get(row.jobExecution.id) ?? row.jobExecution,
+      row.job.name ?? row.job.key,
+    ),
+  );
 }
 
 export async function getFirstJobExecutionByJobId(
@@ -91,7 +122,8 @@ export async function getFirstJobExecutionByJobId(
     .orderBy(asc(jobExecutions.sequence), asc(jobExecutions.id))
     .limit(1);
   const row = rows[0];
-  return row ? toJobExecution(row.jobExecution, row.job.name ?? row.job.key) : undefined;
+  if (!row) return undefined;
+  return toHydratedJobExecution(tx ?? db(), row.jobExecution, row.job.name ?? row.job.key);
 }
 
 export async function getLatestJobExecutionByJobId(
@@ -106,7 +138,8 @@ export async function getLatestJobExecutionByJobId(
     .orderBy(desc(jobExecutions.sequence), desc(jobExecutions.id))
     .limit(1);
   const row = rows[0];
-  return row ? toJobExecution(row.jobExecution, row.job.name ?? row.job.key) : undefined;
+  if (!row) return undefined;
+  return toHydratedJobExecution(tx ?? db(), row.jobExecution, row.job.name ?? row.job.key);
 }
 
 export interface UpdateJobExecutionStatusAtVersionParams {
@@ -183,8 +216,12 @@ async function resolveJobExecutionOutputs(
     .from(jobExecutions)
     .where(eq(jobExecutions.jobId, target.job.id))
     .orderBy(asc(jobExecutions.sequence), asc(jobExecutions.id));
+  const hydratedExecutionRows = await loadJobExecutionsWithCanonicalTriggerEvents(
+    tx,
+    executionRows,
+  );
   const fallbackName = target.job.name ?? target.job.key;
-  const executions = executionRows.map((row) =>
+  const executions = hydratedExecutionRows.map((row) =>
     row.id === target.execution.id
       ? toJobExecution(
           {...row, status: params.status, statusReason: params.statusReason},
@@ -299,8 +336,13 @@ async function updateJobExecutionStatusAtVersion(
       launchKind: row.launchKind,
     });
   }
+  const execution = await toHydratedJobExecution(
+    tx,
+    row,
+    await getJobExecutionFallbackName(tx, row.id),
+  );
   return {
-    execution: toJobExecution(row, await getJobExecutionFallbackName(tx, row.id)),
+    execution,
     changed: true,
   };
 }
@@ -337,7 +379,9 @@ export async function updateJobExecutionStatus(
             .where(eq(jobExecutions.id, params.jobExecutionId))
             .limit(1)
         )[0];
-        return row ? toJobExecution(row, await getJobExecutionFallbackName(tx, row.id)) : undefined;
+        return row
+          ? toHydratedJobExecution(tx, row, await getJobExecutionFallbackName(tx, row.id))
+          : undefined;
       },
       matchFn: (execution) =>
         (execution.status === params.status && execution.statusReason === statusReason) ||
@@ -364,7 +408,11 @@ export async function queueJobExecution(params: {jobExecutionId: string}): Promi
       .for('update');
     if (!row) throw new JobNotFoundError(params.jobExecutionId);
 
-    const existing = toJobExecution(row.jobExecution, row.job.name ?? row.job.key);
+    const existing = await toHydratedJobExecution(
+      tx,
+      row.jobExecution,
+      row.job.name ?? row.job.key,
+    );
     if (existing.queuedAt !== null || TERMINAL_EXECUTION_STATUSES.includes(existing.status)) {
       return {execution: existing, changed: false};
     }
@@ -389,7 +437,7 @@ export async function queueJobExecution(params: {jobExecutionId: string}): Promi
     });
 
     return {
-      execution: toJobExecution(queued, row.job.name ?? row.job.key),
+      execution: await toHydratedJobExecution(tx, queued, row.job.name ?? row.job.key),
       changed: true,
     };
   });
@@ -448,7 +496,9 @@ export async function failJobExecutionAsTimedOut(params: {
             .where(eq(jobExecutions.id, params.jobExecutionId))
             .limit(1)
         )[0];
-        return row ? toJobExecution(row, await getJobExecutionFallbackName(tx, row.id)) : undefined;
+        return row
+          ? toHydratedJobExecution(tx, row, await getJobExecutionFallbackName(tx, row.id))
+          : undefined;
       },
       matchFn: (execution) => (execution.timedOutAt !== null ? {execution, changed: false} : null),
       failureMessage: `Optimistic lock failure: job execution ${params.jobExecutionId} version ${params.expectedVersion}`,

--- a/libs/api/workflows/src/db/workflow-runs/job-status.test.ts
+++ b/libs/api/workflows/src/db/workflow-runs/job-status.test.ts
@@ -3,6 +3,7 @@ import {MAX_JOB_OUTPUTS_TOTAL_BYTES} from '#core/step-config/job-output-limits.j
 import {buildModel, createTestRun, jobTerminatedEvents} from '#test/helpers/workflow-runs.js';
 import {db} from '../db.js';
 import {jobExecutions} from '../schema/job-executions.js';
+import {jobListenerEvents} from '../schema/job-listener-events.js';
 import {jobs} from '../schema/jobs.js';
 import {
   createWorkflowRun,
@@ -196,6 +197,57 @@ describe('workflow run queries', () => {
       const resolved = await resolveJobStatusFromJobExecutions({jobId: job.id});
 
       expect(resolved.status).toBe('succeeded');
+    });
+
+    test('resolves job status expressions from canonical execution events', async () => {
+      const run = await createWorkflowRun({
+        workspaceId,
+        projectId,
+        definitionId,
+        model: buildModel({
+          jobs: {
+            build: {
+              success: 'executions[0].events[0].data.action == "opened"',
+              steps: [{run: 'npm test'}],
+            },
+          },
+        }),
+        triggerPayload: {
+          source: 'manual',
+          event: 'fire',
+          subscriptionId: crypto.randomUUID(),
+          userId: crypto.randomUUID(),
+        },
+      });
+      const [job] = await getJobsByWorkflowRunId(run.id);
+      if (!job) throw new Error('Expected workflow job');
+      const execution = await getFirstJobExecutionByJobId(job.id);
+      if (!execution) throw new Error('Expected workflow job execution');
+      await db()
+        .update(jobExecutions)
+        .set({status: 'succeeded', triggerEvents: null})
+        .where(eq(jobExecutions.id, execution.id));
+      await db()
+        .insert(jobListenerEvents)
+        .values({
+          jobId: job.id,
+          disposition: 'fire',
+          outcome: 'consumed',
+          eventRef: 'status-canonical-event',
+          deliveryId: 'status-canonical-delivery',
+          source: 'github',
+          event: 'pull_request',
+          payload: {action: 'opened'},
+          storedPayloadBytes: 19,
+          normalizedEventBytes: 128,
+          receivedAt: new Date('2026-01-01T00:00:00.000Z'),
+          consumedByExecutionId: execution.id,
+        });
+
+      const resolved = await resolveJobStatusFromJobExecutions({jobId: job.id});
+
+      expect(resolved.status).toBe('succeeded');
+      expect((await getJobsByWorkflowRunId(run.id))[0]).toMatchObject({status: 'succeeded'});
     });
 
     test('resolves custom job success expressions over direct dependency outputs', async () => {

--- a/libs/api/workflows/src/db/workflow-runs/jobs.ts
+++ b/libs/api/workflows/src/db/workflow-runs/jobs.ts
@@ -22,8 +22,9 @@ import {MAX_JOB_OUTPUTS_TOTAL_BYTES} from '#core/step-config/job-output-limits.j
 import type {RuntimeCompletionStatus} from '#core/workflow-scheduling/runtime-dag.js';
 import {recordWorkflowJobStatusChanged} from '#metrics/instance.js';
 import {db, type Tx} from '../db.js';
+import {loadJobExecutionsWithCanonicalTriggerEvents} from '../execution-trigger-events.js';
 import {writeWorkflowsOutboxEvent} from '../outbox-writes.js';
-import {jobExecutions, toJobExecution} from '../schema/job-executions.js';
+import {type JobExecutionDb, jobExecutions, toJobExecution} from '../schema/job-executions.js';
 import {jobs, toJob} from '../schema/jobs.js';
 import {workflowRunAttempts} from '../schema/workflow-run-attempts.js';
 import {toWorkflowRun, toWorkflowRunOriginState, workflowRuns} from '../schema/workflow-runs.js';
@@ -38,6 +39,13 @@ function outputTypesByJobKey(
       job.outputTypes === undefined ? [] : [[job.key, job.outputTypes] as const],
     ),
   );
+}
+
+function canonicalExecutionRow(
+  row: JobExecutionDb,
+  executionsById: ReadonlyMap<string, JobExecutionDb>,
+): JobExecutionDb {
+  return executionsById.get(row.id) ?? row;
 }
 
 export async function getJobsByWorkflowRunAttemptId(workflowRunAttemptId: string): Promise<Job[]> {
@@ -134,6 +142,11 @@ export async function getDirectDependencyJobContexts(
       ),
     )
     .orderBy(asc(jobs.position), asc(jobs.id), asc(jobExecutions.sequence), asc(jobExecutions.id));
+  const hydratedExecutions = await loadJobExecutionsWithCanonicalTriggerEvents(
+    tx ?? db(),
+    rows.flatMap((row) => (row.execution === null ? [] : [row.execution])),
+  );
+  const executionsById = new Map(hydratedExecutions.map((execution) => [execution.id, execution]));
 
   const contextsByJobId = new Map<string, JobContextInput & {executions: JobExecution[]}>();
   for (const row of rows) {
@@ -147,8 +160,14 @@ export async function getDirectDependencyJobContexts(
       };
       contextsByJobId.set(row.job.id, context);
     }
-    if (row.execution)
-      context.executions.push(toJobExecution(row.execution, row.job.name ?? row.job.key));
+    if (row.execution) {
+      context.executions.push(
+        toJobExecution(
+          canonicalExecutionRow(row.execution, executionsById),
+          row.job.name ?? row.job.key,
+        ),
+      );
+    }
   }
 
   return [...contextsByJobId.values()];
@@ -315,6 +334,11 @@ async function directDependencyContextsByJobKey(
     .leftJoin(jobExecutions, eq(jobExecutions.jobId, jobs.id))
     .where(and(eq(jobs.workflowRunAttemptId, runAttemptId), inArray(jobs.key, [...dependencyKeys])))
     .orderBy(asc(jobs.position), asc(jobs.id), asc(jobExecutions.sequence), asc(jobExecutions.id));
+  const hydratedExecutions = await loadJobExecutionsWithCanonicalTriggerEvents(
+    tx,
+    rows.flatMap((row) => (row.execution === null ? [] : [row.execution])),
+  );
+  const executionsById = new Map(hydratedExecutions.map((execution) => [execution.id, execution]));
 
   const contextsByJobKey = new Map<string, JobContextInput & {executions: JobExecution[]}>();
   for (const row of rows) {
@@ -328,8 +352,14 @@ async function directDependencyContextsByJobKey(
       };
       contextsByJobKey.set(row.job.key, context);
     }
-    if (row.execution)
-      context.executions.push(toJobExecution(row.execution, row.job.name ?? row.job.key));
+    if (row.execution) {
+      context.executions.push(
+        toJobExecution(
+          canonicalExecutionRow(row.execution, executionsById),
+          row.job.name ?? row.job.key,
+        ),
+      );
+    }
   }
 
   return contextsByJobKey;
@@ -507,10 +537,14 @@ export async function resolveJobStatusFromJobExecutions(params: {
     if (jobExecutionRows.length === 0) {
       throw new Error(`Cannot resolve job ${params.jobId}: no job executions found`);
     }
+    const hydratedExecutionRows = await loadJobExecutionsWithCanonicalTriggerEvents(
+      tx,
+      jobExecutionRows,
+    );
 
     const {status, statusReason, trace} = evaluateJobSuccess({
       success: jobRow.success,
-      executions: jobExecutionRows.map((execution) =>
+      executions: hydratedExecutionRows.map((execution) =>
         toJobExecution(execution, jobRow.name ?? jobRow.key),
       ),
       jobs: await getDirectDependencyJobContexts(params.jobId, tx),

--- a/libs/api/workflows/src/db/workflow-runs/jobs.ts
+++ b/libs/api/workflows/src/db/workflow-runs/jobs.ts
@@ -25,7 +25,7 @@ import {db, type Tx} from '../db.js';
 import {loadJobExecutionsWithCanonicalTriggerEvents} from '../execution-trigger-events.js';
 import {writeWorkflowsOutboxEvent} from '../outbox-writes.js';
 import {type JobExecutionDb, jobExecutions, toJobExecution} from '../schema/job-executions.js';
-import {jobs, toJob} from '../schema/jobs.js';
+import {type JobDb, jobs, toJob} from '../schema/jobs.js';
 import {workflowRunAttempts} from '../schema/workflow-run-attempts.js';
 import {toWorkflowRun, toWorkflowRunOriginState, workflowRuns} from '../schema/workflow-runs.js';
 import {getWorkflowRunById} from './queries.js';
@@ -41,11 +41,15 @@ function outputTypesByJobKey(
   );
 }
 
-function canonicalExecutionRow(
-  row: JobExecutionDb,
-  executionsById: ReadonlyMap<string, JobExecutionDb>,
-): JobExecutionDb {
-  return executionsById.get(row.id) ?? row;
+function toDependencyExecution(
+  row: {job: JobDb; execution: JobExecutionDb | null},
+  hydratedExecutions: ReadonlyMap<string, JobExecutionDb>,
+): JobExecution | undefined {
+  if (!row.execution) return undefined;
+  return toJobExecution(
+    hydratedExecutions.get(row.execution.id) ?? row.execution,
+    row.job.name ?? row.job.key,
+  );
 }
 
 export async function getJobsByWorkflowRunAttemptId(workflowRunAttemptId: string): Promise<Job[]> {
@@ -146,7 +150,6 @@ export async function getDirectDependencyJobContexts(
     tx ?? db(),
     rows.flatMap((row) => (row.execution === null ? [] : [row.execution])),
   );
-  const executionsById = new Map(hydratedExecutions.map((execution) => [execution.id, execution]));
 
   const contextsByJobId = new Map<string, JobContextInput & {executions: JobExecution[]}>();
   for (const row of rows) {
@@ -160,14 +163,8 @@ export async function getDirectDependencyJobContexts(
       };
       contextsByJobId.set(row.job.id, context);
     }
-    if (row.execution) {
-      context.executions.push(
-        toJobExecution(
-          canonicalExecutionRow(row.execution, executionsById),
-          row.job.name ?? row.job.key,
-        ),
-      );
-    }
+    const execution = toDependencyExecution(row, hydratedExecutions);
+    if (execution) context.executions.push(execution);
   }
 
   return [...contextsByJobId.values()];
@@ -338,7 +335,6 @@ async function directDependencyContextsByJobKey(
     tx,
     rows.flatMap((row) => (row.execution === null ? [] : [row.execution])),
   );
-  const executionsById = new Map(hydratedExecutions.map((execution) => [execution.id, execution]));
 
   const contextsByJobKey = new Map<string, JobContextInput & {executions: JobExecution[]}>();
   for (const row of rows) {
@@ -352,14 +348,8 @@ async function directDependencyContextsByJobKey(
       };
       contextsByJobKey.set(row.job.key, context);
     }
-    if (row.execution) {
-      context.executions.push(
-        toJobExecution(
-          canonicalExecutionRow(row.execution, executionsById),
-          row.job.name ?? row.job.key,
-        ),
-      );
-    }
+    const execution = toDependencyExecution(row, hydratedExecutions);
+    if (execution) context.executions.push(execution);
   }
 
   return contextsByJobKey;
@@ -544,8 +534,11 @@ export async function resolveJobStatusFromJobExecutions(params: {
 
     const {status, statusReason, trace} = evaluateJobSuccess({
       success: jobRow.success,
-      executions: hydratedExecutionRows.map((execution) =>
-        toJobExecution(execution, jobRow.name ?? jobRow.key),
+      executions: jobExecutionRows.map((execution) =>
+        toJobExecution(
+          hydratedExecutionRows.get(execution.id) ?? execution,
+          jobRow.name ?? jobRow.key,
+        ),
       ),
       jobs: await getDirectDependencyJobContexts(params.jobId, tx),
       vars: workflowContext.vars ?? undefined,

--- a/libs/api/workflows/src/metrics/service.test.ts
+++ b/libs/api/workflows/src/metrics/service.test.ts
@@ -66,6 +66,8 @@ describe('registerWorkflowsServiceMetrics', () => {
     const observer = {observe: vi.fn()};
 
     await callback?.(observer);
+    await callback?.(observer);
+    expect(mocks.getListenerEventStorageStats).toHaveBeenCalledTimes(1);
 
     expect(observer.observe).toHaveBeenCalledWith(mocks.gauges.get('workflows_running_runs'), 2);
     expect(observer.observe).toHaveBeenCalledWith(
@@ -104,5 +106,50 @@ describe('registerWorkflowsServiceMetrics', () => {
       mocks.gauges.get('workflows_duplicate_trigger_events_bytes'),
       11,
     );
+    expect(mocks.addBatchObservableCallback.mock.calls[0]?.[1]).toEqual(
+      expect.arrayContaining([
+        mocks.gauges.get('workflows_listener_event_rows'),
+        mocks.gauges.get('workflows_listener_event_payload_bytes'),
+        mocks.gauges.get('workflows_listener_event_consumed_oldest_age'),
+        mocks.gauges.get('workflows_listener_event_pending_oldest_age'),
+        mocks.gauges.get('workflows_duplicate_trigger_events_bytes'),
+      ]),
+    );
+  });
+
+  test('keeps existing gauges observable when storage stats fail', async () => {
+    mocks.getWorkflowJobExecutionDepth.mockResolvedValue({runningRuns: 2, runningJobExecutions: 3});
+    mocks.countActiveListeners.mockResolvedValue(4);
+    mocks.getToolInvocationDepth.mockResolvedValue({queued: 5, inFlight: 6});
+    mocks.getListenerEventStorageStats.mockRejectedValue(new Error('storage unavailable'));
+
+    registerWorkflowsServiceMetrics();
+    const callback = mocks.addBatchObservableCallback.mock.calls[0]?.[0];
+    const observer = {observe: vi.fn()};
+
+    await callback?.(observer);
+
+    expect(observer.observe).toHaveBeenCalledWith(mocks.gauges.get('workflows_running_runs'), 2);
+    expect(observer.observe).toHaveBeenCalledWith(
+      mocks.gauges.get('workflows_running_job_executions'),
+      3,
+    );
+    expect(observer.observe).toHaveBeenCalledWith(
+      mocks.gauges.get('workflows_active_listeners'),
+      4,
+    );
+    expect(observer.observe).toHaveBeenCalledWith(
+      mocks.gauges.get('workflows_tool_invocations_queued'),
+      5,
+    );
+    expect(observer.observe).toHaveBeenCalledWith(
+      mocks.gauges.get('workflows_tool_invocations_in_flight'),
+      6,
+    );
+    expect(
+      observer.observe.mock.calls.some(
+        ([gauge]) => gauge === mocks.gauges.get('workflows_listener_event_rows'),
+      ),
+    ).toBe(false);
   });
 });

--- a/libs/api/workflows/src/metrics/service.test.ts
+++ b/libs/api/workflows/src/metrics/service.test.ts
@@ -152,4 +152,50 @@ describe('registerWorkflowsServiceMetrics', () => {
       ),
     ).toBe(false);
   });
+
+  test('omits expired storage gauges when a refresh fails', async () => {
+    vi.useFakeTimers();
+    try {
+      const storageStats = {
+        listenerEventRows: 7,
+        listenerEventPayloadBytes: 8,
+        consumedListenerEventOldestAgeMilliseconds: 9,
+        pendingListenerEventOldestAgeMilliseconds: 10,
+        duplicateTriggerEventsBytes: 11,
+      };
+      mocks.getWorkflowJobExecutionDepth.mockResolvedValue({
+        runningRuns: 2,
+        runningJobExecutions: 3,
+      });
+      mocks.countActiveListeners.mockResolvedValue(4);
+      mocks.getToolInvocationDepth.mockResolvedValue({queued: 5, inFlight: 6});
+      mocks.getListenerEventStorageStats
+        .mockResolvedValueOnce(storageStats)
+        .mockRejectedValueOnce(new Error('storage unavailable'));
+
+      registerWorkflowsServiceMetrics();
+      const callback = mocks.addBatchObservableCallback.mock.calls[0]?.[0];
+      const observer = {observe: vi.fn()};
+
+      await callback?.(observer);
+      expect(observer.observe).toHaveBeenCalledWith(
+        mocks.gauges.get('workflows_duplicate_trigger_events_bytes'),
+        11,
+      );
+
+      vi.advanceTimersByTime(60_001);
+      observer.observe.mockClear();
+      await callback?.(observer);
+
+      expect(observer.observe).toHaveBeenCalledWith(mocks.gauges.get('workflows_running_runs'), 2);
+      expect(
+        observer.observe.mock.calls.some(
+          ([gauge]) => gauge === mocks.gauges.get('workflows_listener_event_rows'),
+        ),
+      ).toBe(false);
+      expect(mocks.getListenerEventStorageStats).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/libs/api/workflows/src/metrics/service.test.ts
+++ b/libs/api/workflows/src/metrics/service.test.ts
@@ -3,6 +3,7 @@ const mocks = vi.hoisted(() => {
   return {
     addBatchObservableCallback: vi.fn(),
     countActiveListeners: vi.fn(),
+    getListenerEventStorageStats: vi.fn(),
     getToolInvocationDepth: vi.fn(),
     getWorkflowJobExecutionDepth: vi.fn(),
     createObservableGauge: vi.fn((name: string) => {
@@ -17,6 +18,9 @@ const mocks = vi.hoisted(() => {
 });
 
 vi.mock('#db/job-listeners.js', () => ({countActiveListeners: mocks.countActiveListeners}));
+vi.mock('#db/listener-storage.js', () => ({
+  getListenerEventStorageStats: mocks.getListenerEventStorageStats,
+}));
 vi.mock('#db/workflow-runs.js', () => ({
   getToolInvocationDepth: mocks.getToolInvocationDepth,
   getWorkflowJobExecutionDepth: mocks.getWorkflowJobExecutionDepth,
@@ -31,6 +35,7 @@ describe('registerWorkflowsServiceMetrics', () => {
   beforeEach(() => {
     mocks.addBatchObservableCallback.mockReset();
     mocks.countActiveListeners.mockReset();
+    mocks.getListenerEventStorageStats.mockReset();
     mocks.getToolInvocationDepth.mockReset();
     mocks.getWorkflowJobExecutionDepth.mockReset();
     mocks.createObservableGauge.mockClear();
@@ -48,6 +53,13 @@ describe('registerWorkflowsServiceMetrics', () => {
     mocks.getWorkflowJobExecutionDepth.mockResolvedValue({runningRuns: 2, runningJobExecutions: 3});
     mocks.countActiveListeners.mockResolvedValue(4);
     mocks.getToolInvocationDepth.mockResolvedValue({queued: 5, inFlight: 6});
+    mocks.getListenerEventStorageStats.mockResolvedValue({
+      listenerEventRows: 7,
+      listenerEventPayloadBytes: 8,
+      consumedListenerEventOldestAgeMilliseconds: 9,
+      pendingListenerEventOldestAgeMilliseconds: 10,
+      duplicateTriggerEventsBytes: 11,
+    });
 
     registerWorkflowsServiceMetrics();
     const callback = mocks.addBatchObservableCallback.mock.calls[0]?.[0];
@@ -71,6 +83,26 @@ describe('registerWorkflowsServiceMetrics', () => {
     expect(observer.observe).toHaveBeenCalledWith(
       mocks.gauges.get('workflows_tool_invocations_in_flight'),
       6,
+    );
+    expect(observer.observe).toHaveBeenCalledWith(
+      mocks.gauges.get('workflows_listener_event_rows'),
+      7,
+    );
+    expect(observer.observe).toHaveBeenCalledWith(
+      mocks.gauges.get('workflows_listener_event_payload_bytes'),
+      8,
+    );
+    expect(observer.observe).toHaveBeenCalledWith(
+      mocks.gauges.get('workflows_listener_event_consumed_oldest_age'),
+      9,
+    );
+    expect(observer.observe).toHaveBeenCalledWith(
+      mocks.gauges.get('workflows_listener_event_pending_oldest_age'),
+      10,
+    );
+    expect(observer.observe).toHaveBeenCalledWith(
+      mocks.gauges.get('workflows_duplicate_trigger_events_bytes'),
+      11,
     );
   });
 });

--- a/libs/api/workflows/src/metrics/service.test.ts
+++ b/libs/api/workflows/src/metrics/service.test.ts
@@ -6,6 +6,7 @@ const mocks = vi.hoisted(() => {
     getListenerEventStorageStats: vi.fn(),
     getToolInvocationDepth: vi.fn(),
     getWorkflowJobExecutionDepth: vi.fn(),
+    loggerWarn: vi.fn(),
     createObservableGauge: vi.fn((name: string) => {
       const gauge = {};
       gauges.set(name, gauge);
@@ -27,6 +28,7 @@ vi.mock('#db/workflow-runs.js', () => ({
 }));
 vi.mock('@shipfox/node-opentelemetry', () => ({
   getServiceMetricsProvider: mocks.getServiceMetricsProvider,
+  logger: () => ({warn: mocks.loggerWarn}),
 }));
 
 import {registerWorkflowsServiceMetrics} from './service.js';
@@ -38,6 +40,7 @@ describe('registerWorkflowsServiceMetrics', () => {
     mocks.getListenerEventStorageStats.mockReset();
     mocks.getToolInvocationDepth.mockReset();
     mocks.getWorkflowJobExecutionDepth.mockReset();
+    mocks.loggerWarn.mockReset();
     mocks.createObservableGauge.mockClear();
     mocks.gauges.clear();
     mocks.getMeter.mockReset();
@@ -151,6 +154,10 @@ describe('registerWorkflowsServiceMetrics', () => {
         ([gauge]) => gauge === mocks.gauges.get('workflows_listener_event_rows'),
       ),
     ).toBe(false);
+    expect(mocks.loggerWarn).toHaveBeenCalledWith(
+      {err: expect.any(Error)},
+      'Failed to collect workflow listener event storage metrics',
+    );
   });
 
   test('omits expired storage gauges when a refresh fails', async () => {

--- a/libs/api/workflows/src/metrics/service.test.ts
+++ b/libs/api/workflows/src/metrics/service.test.ts
@@ -160,6 +160,43 @@ describe('registerWorkflowsServiceMetrics', () => {
     );
   });
 
+  test('keeps independent gauges observable when a core query fails', async () => {
+    mocks.getWorkflowJobExecutionDepth.mockRejectedValue(new Error('depth unavailable'));
+    mocks.countActiveListeners.mockResolvedValue(4);
+    mocks.getToolInvocationDepth.mockResolvedValue({queued: 5, inFlight: 6});
+    mocks.getListenerEventStorageStats.mockResolvedValue({
+      listenerEventRows: 7,
+      listenerEventPayloadBytes: 8,
+      consumedListenerEventOldestAgeMilliseconds: 9,
+      pendingListenerEventOldestAgeMilliseconds: 10,
+      duplicateTriggerEventsBytes: 11,
+    });
+
+    registerWorkflowsServiceMetrics();
+    const callback = mocks.addBatchObservableCallback.mock.calls[0]?.[0];
+    const observer = {observe: vi.fn()};
+
+    await callback?.(observer);
+
+    expect(
+      observer.observe.mock.calls.some(
+        ([gauge]) => gauge === mocks.gauges.get('workflows_running_runs'),
+      ),
+    ).toBe(false);
+    expect(observer.observe).toHaveBeenCalledWith(
+      mocks.gauges.get('workflows_active_listeners'),
+      4,
+    );
+    expect(observer.observe).toHaveBeenCalledWith(
+      mocks.gauges.get('workflows_tool_invocations_queued'),
+      5,
+    );
+    expect(mocks.loggerWarn).toHaveBeenCalledWith(
+      {err: expect.any(Error)},
+      'Failed to collect workflow execution depth metrics',
+    );
+  });
+
   test('omits expired storage gauges when a refresh fails', async () => {
     vi.useFakeTimers();
     try {

--- a/libs/api/workflows/src/metrics/service.ts
+++ b/libs/api/workflows/src/metrics/service.ts
@@ -23,12 +23,7 @@ function createListenerEventStorageStatsCache(): () => Promise<ListenerEventStor
         refresh = undefined;
       });
 
-    try {
-      return await refresh;
-    } catch (error) {
-      if (cached) return cached.value;
-      throw error;
-    }
+    return await refresh;
   };
 }
 

--- a/libs/api/workflows/src/metrics/service.ts
+++ b/libs/api/workflows/src/metrics/service.ts
@@ -1,10 +1,40 @@
 import {getServiceMetricsProvider} from '@shipfox/node-opentelemetry';
 import {countActiveListeners} from '#db/job-listeners.js';
-import {getListenerEventStorageStats} from '#db/listener-storage.js';
+import {
+  getListenerEventStorageStats,
+  type ListenerEventStorageStats,
+} from '#db/listener-storage.js';
 import {getToolInvocationDepth, getWorkflowJobExecutionDepth} from '#db/workflow-runs.js';
+
+const LISTENER_EVENT_STORAGE_STATS_CACHE_TTL_MS = 60_000;
+
+function createListenerEventStorageStatsCache(): () => Promise<ListenerEventStorageStats> {
+  let cached: {value: ListenerEventStorageStats; expiresAt: number} | undefined;
+  let refresh: Promise<ListenerEventStorageStats> | undefined;
+
+  return async () => {
+    if (cached && cached.expiresAt > Date.now()) return cached.value;
+    refresh ??= getListenerEventStorageStats()
+      .then((value) => {
+        cached = {value, expiresAt: Date.now() + LISTENER_EVENT_STORAGE_STATS_CACHE_TTL_MS};
+        return value;
+      })
+      .finally(() => {
+        refresh = undefined;
+      });
+
+    try {
+      return await refresh;
+    } catch (error) {
+      if (cached) return cached.value;
+      throw error;
+    }
+  };
+}
 
 export function registerWorkflowsServiceMetrics(): void {
   const meter = getServiceMetricsProvider().getMeter('workflows');
+  const getCachedListenerEventStorageStats = createListenerEventStorageStatsCache();
 
   const runningRuns = meter.createObservableGauge('workflows_running_runs', {
     description: 'Workflow runs currently marked running',
@@ -58,28 +88,35 @@ export function registerWorkflowsServiceMetrics(): void {
 
   meter.addBatchObservableCallback(
     async (observer) => {
-      const [depth, listenerCount, toolInvocationDepth, storage] = await Promise.all([
+      const [depth, listenerCount, toolInvocationDepth, storage] = await Promise.allSettled([
         getWorkflowJobExecutionDepth(),
         countActiveListeners(),
         getToolInvocationDepth(),
-        getListenerEventStorageStats(),
+        getCachedListenerEventStorageStats(),
       ]);
-      observer.observe(runningRuns, depth.runningRuns);
-      observer.observe(runningJobExecutions, depth.runningJobExecutions);
-      observer.observe(activeListeners, listenerCount);
-      observer.observe(queuedToolInvocations, toolInvocationDepth.queued);
-      observer.observe(inFlightToolInvocations, toolInvocationDepth.inFlight);
-      observer.observe(listenerEventRows, storage.listenerEventRows);
-      observer.observe(listenerEventPayloadBytes, storage.listenerEventPayloadBytes);
-      observer.observe(
-        listenerEventConsumedOldestAge,
-        storage.consumedListenerEventOldestAgeMilliseconds,
-      );
-      observer.observe(
-        listenerEventPendingOldestAge,
-        storage.pendingListenerEventOldestAgeMilliseconds,
-      );
-      observer.observe(duplicateTriggerEventsBytes, storage.duplicateTriggerEventsBytes);
+      if (depth.status === 'fulfilled') {
+        observer.observe(runningRuns, depth.value.runningRuns);
+        observer.observe(runningJobExecutions, depth.value.runningJobExecutions);
+      }
+      if (listenerCount.status === 'fulfilled')
+        observer.observe(activeListeners, listenerCount.value);
+      if (toolInvocationDepth.status === 'fulfilled') {
+        observer.observe(queuedToolInvocations, toolInvocationDepth.value.queued);
+        observer.observe(inFlightToolInvocations, toolInvocationDepth.value.inFlight);
+      }
+      if (storage.status === 'fulfilled') {
+        observer.observe(listenerEventRows, storage.value.listenerEventRows);
+        observer.observe(listenerEventPayloadBytes, storage.value.listenerEventPayloadBytes);
+        observer.observe(
+          listenerEventConsumedOldestAge,
+          storage.value.consumedListenerEventOldestAgeMilliseconds,
+        );
+        observer.observe(
+          listenerEventPendingOldestAge,
+          storage.value.pendingListenerEventOldestAgeMilliseconds,
+        );
+        observer.observe(duplicateTriggerEventsBytes, storage.value.duplicateTriggerEventsBytes);
+      }
     },
     [
       runningRuns,

--- a/libs/api/workflows/src/metrics/service.ts
+++ b/libs/api/workflows/src/metrics/service.ts
@@ -1,5 +1,6 @@
 import {getServiceMetricsProvider} from '@shipfox/node-opentelemetry';
 import {countActiveListeners} from '#db/job-listeners.js';
+import {getListenerEventStorageStats} from '#db/listener-storage.js';
 import {getToolInvocationDepth, getWorkflowJobExecutionDepth} from '#db/workflow-runs.js';
 
 export function registerWorkflowsServiceMetrics(): void {
@@ -23,19 +24,62 @@ export function registerWorkflowsServiceMetrics(): void {
       description: 'Server-executed workflow tool invocations currently in flight',
     },
   );
+  const listenerEventRows = meter.createObservableGauge('workflows_listener_event_rows', {
+    description: 'Canonical listener-event rows currently retained',
+  });
+  const listenerEventPayloadBytes = meter.createObservableGauge(
+    'workflows_listener_event_payload_bytes',
+    {
+      description: 'Stored payload bytes in canonical listener-event rows',
+      unit: 'By',
+    },
+  );
+  const listenerEventConsumedOldestAge = meter.createObservableGauge(
+    'workflows_listener_event_consumed_oldest_age',
+    {
+      description: 'Age in milliseconds of the oldest consumed canonical listener event',
+      unit: 'ms',
+    },
+  );
+  const listenerEventPendingOldestAge = meter.createObservableGauge(
+    'workflows_listener_event_pending_oldest_age',
+    {
+      description: 'Age in milliseconds of the oldest pending canonical listener event',
+      unit: 'ms',
+    },
+  );
+  const duplicateTriggerEventsBytes = meter.createObservableGauge(
+    'workflows_duplicate_trigger_events_bytes',
+    {
+      description: 'Bytes retained in legacy job-execution trigger-event arrays',
+      unit: 'By',
+    },
+  );
 
   meter.addBatchObservableCallback(
     async (observer) => {
-      const [depth, listenerCount, toolInvocationDepth] = await Promise.all([
+      const [depth, listenerCount, toolInvocationDepth, storage] = await Promise.all([
         getWorkflowJobExecutionDepth(),
         countActiveListeners(),
         getToolInvocationDepth(),
+        getListenerEventStorageStats(),
       ]);
       observer.observe(runningRuns, depth.runningRuns);
       observer.observe(runningJobExecutions, depth.runningJobExecutions);
       observer.observe(activeListeners, listenerCount);
       observer.observe(queuedToolInvocations, toolInvocationDepth.queued);
       observer.observe(inFlightToolInvocations, toolInvocationDepth.inFlight);
+      observer.observe(listenerEventRows, storage.listenerEventRows);
+      observer.observe(listenerEventPayloadBytes, storage.listenerEventPayloadBytes);
+      observer.observe(
+        listenerEventConsumedOldestAge,
+        storage.consumedListenerEventOldestAgeMilliseconds,
+      );
+      observer.observe(
+        listenerEventPendingOldestAge,
+        storage.pendingListenerEventOldestAgeMilliseconds,
+      );
+      observer.observe(duplicateTriggerEventsBytes, storage.duplicateTriggerEventsBytes);
     },
     [
       runningRuns,
@@ -43,6 +87,11 @@ export function registerWorkflowsServiceMetrics(): void {
       activeListeners,
       queuedToolInvocations,
       inFlightToolInvocations,
+      listenerEventRows,
+      listenerEventPayloadBytes,
+      listenerEventConsumedOldestAge,
+      listenerEventPendingOldestAge,
+      duplicateTriggerEventsBytes,
     ],
   );
 }

--- a/libs/api/workflows/src/metrics/service.ts
+++ b/libs/api/workflows/src/metrics/service.ts
@@ -1,4 +1,4 @@
-import {getServiceMetricsProvider} from '@shipfox/node-opentelemetry';
+import {getServiceMetricsProvider, logger} from '@shipfox/node-opentelemetry';
 import {countActiveListeners} from '#db/job-listeners.js';
 import {
   getListenerEventStorageStats,
@@ -83,34 +83,34 @@ export function registerWorkflowsServiceMetrics(): void {
 
   meter.addBatchObservableCallback(
     async (observer) => {
-      const [depth, listenerCount, toolInvocationDepth, storage] = await Promise.allSettled([
+      const [depth, listenerCount, toolInvocationDepth] = await Promise.all([
         getWorkflowJobExecutionDepth(),
         countActiveListeners(),
         getToolInvocationDepth(),
-        getCachedListenerEventStorageStats(),
       ]);
-      if (depth.status === 'fulfilled') {
-        observer.observe(runningRuns, depth.value.runningRuns);
-        observer.observe(runningJobExecutions, depth.value.runningJobExecutions);
+      let storage: ListenerEventStorageStats | undefined;
+      try {
+        storage = await getCachedListenerEventStorageStats();
+      } catch (error) {
+        logger().warn({err: error}, 'Failed to collect workflow listener event storage metrics');
       }
-      if (listenerCount.status === 'fulfilled')
-        observer.observe(activeListeners, listenerCount.value);
-      if (toolInvocationDepth.status === 'fulfilled') {
-        observer.observe(queuedToolInvocations, toolInvocationDepth.value.queued);
-        observer.observe(inFlightToolInvocations, toolInvocationDepth.value.inFlight);
-      }
-      if (storage.status === 'fulfilled') {
-        observer.observe(listenerEventRows, storage.value.listenerEventRows);
-        observer.observe(listenerEventPayloadBytes, storage.value.listenerEventPayloadBytes);
+      observer.observe(runningRuns, depth.runningRuns);
+      observer.observe(runningJobExecutions, depth.runningJobExecutions);
+      observer.observe(activeListeners, listenerCount);
+      observer.observe(queuedToolInvocations, toolInvocationDepth.queued);
+      observer.observe(inFlightToolInvocations, toolInvocationDepth.inFlight);
+      if (storage) {
+        observer.observe(listenerEventRows, storage.listenerEventRows);
+        observer.observe(listenerEventPayloadBytes, storage.listenerEventPayloadBytes);
         observer.observe(
           listenerEventConsumedOldestAge,
-          storage.value.consumedListenerEventOldestAgeMilliseconds,
+          storage.consumedListenerEventOldestAgeMilliseconds,
         );
         observer.observe(
           listenerEventPendingOldestAge,
-          storage.value.pendingListenerEventOldestAgeMilliseconds,
+          storage.pendingListenerEventOldestAgeMilliseconds,
         );
-        observer.observe(duplicateTriggerEventsBytes, storage.value.duplicateTriggerEventsBytes);
+        observer.observe(duplicateTriggerEventsBytes, storage.duplicateTriggerEventsBytes);
       }
     },
     [

--- a/libs/api/workflows/src/metrics/service.ts
+++ b/libs/api/workflows/src/metrics/service.ts
@@ -83,7 +83,7 @@ export function registerWorkflowsServiceMetrics(): void {
 
   meter.addBatchObservableCallback(
     async (observer) => {
-      const [depth, listenerCount, toolInvocationDepth] = await Promise.all([
+      const [depth, listenerCount, toolInvocationDepth] = await Promise.allSettled([
         getWorkflowJobExecutionDepth(),
         countActiveListeners(),
         getToolInvocationDepth(),
@@ -94,11 +94,26 @@ export function registerWorkflowsServiceMetrics(): void {
       } catch (error) {
         logger().warn({err: error}, 'Failed to collect workflow listener event storage metrics');
       }
-      observer.observe(runningRuns, depth.runningRuns);
-      observer.observe(runningJobExecutions, depth.runningJobExecutions);
-      observer.observe(activeListeners, listenerCount);
-      observer.observe(queuedToolInvocations, toolInvocationDepth.queued);
-      observer.observe(inFlightToolInvocations, toolInvocationDepth.inFlight);
+      if (depth.status === 'fulfilled') {
+        observer.observe(runningRuns, depth.value.runningRuns);
+        observer.observe(runningJobExecutions, depth.value.runningJobExecutions);
+      } else {
+        logger().warn({err: depth.reason}, 'Failed to collect workflow execution depth metrics');
+      }
+      if (listenerCount.status === 'fulfilled') {
+        observer.observe(activeListeners, listenerCount.value);
+      } else {
+        logger().warn({err: listenerCount.reason}, 'Failed to collect active listener metrics');
+      }
+      if (toolInvocationDepth.status === 'fulfilled') {
+        observer.observe(queuedToolInvocations, toolInvocationDepth.value.queued);
+        observer.observe(inFlightToolInvocations, toolInvocationDepth.value.inFlight);
+      } else {
+        logger().warn(
+          {err: toolInvocationDepth.reason},
+          'Failed to collect workflow tool invocation metrics',
+        );
+      }
       if (storage) {
         observer.observe(listenerEventRows, storage.listenerEventRows);
         observer.observe(listenerEventPayloadBytes, storage.listenerEventPayloadBytes);

--- a/libs/api/workflows/src/temporal/activities/orchestration-activities.ts
+++ b/libs/api/workflows/src/temporal/activities/orchestration-activities.ts
@@ -73,7 +73,9 @@ export async function loadRunAttemptDag(runAttemptId: string): Promise<RunDag> {
   if (!attempt) throw new Error(`Run attempt not found: ${runAttemptId}`);
 
   const jobs = await getJobsByWorkflowRunAttemptId(runAttemptId);
-  const jobExecutions = await getJobExecutionsByWorkflowRunAttemptId(runAttemptId);
+  const jobExecutions = await getJobExecutionsByWorkflowRunAttemptId(runAttemptId, {
+    includeTriggerEvents: false,
+  });
   const firstJobExecutions = new Map<string, (typeof jobExecutions)[number]>();
   for (const jobExecution of jobExecutions) {
     if (!firstJobExecutions.has(jobExecution.jobId)) {

--- a/libs/api/workflows/test/env.ts
+++ b/libs/api/workflows/test/env.ts
@@ -4,6 +4,7 @@ process.env.POSTGRES_USERNAME ??= 'shipfox';
 process.env.POSTGRES_PASSWORD ??= 'password';
 process.env.POSTGRES_DATABASE = 'api_test';
 process.env.POSTGRES_MAX_CONNECTIONS ??= '5';
+process.env.WORKFLOWS_LEGACY_TRIGGER_EVENTS_WRITE_ENABLED = 'false';
 process.env.AUTH_ROOT_KEY = 'MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=';
 process.env.SECRETS_ENCRYPTION_KEK = 'ZmVkY2JhOTg3NjU0MzIxMGZlZGNiYTk4NzY1NDMyMTA=';
 process.env.TZ = 'UTC';


### PR DESCRIPTION
## Summary

New listener executions use canonical listener-event rows for execution context. They continue dual-writing legacy trigger-event arrays while `WORKFLOWS_LEGACY_TRIGGER_EVENTS_WRITE_ENABLED=true`, which is the safe default for mixed deployments. Set the flag to `false` after the compatibility window; retained arrays remain readable and are not backfilled.

The review follow-up also:

- adds DB coverage for canonical event hydration in job status and output resolution;
- covers the no-trigger-events projection, legacy fallback, and both writer-gate branches;
- bounds storage-stat refreshes with a single-flight 60-second cache;
- excludes null-payload rows from payload-byte totals and clamps age gauges at zero;
- isolates storage-stat failures and logs core-query failures without suppressing unrelated gauges;
- documents the transitional duplicate-array gauge and its retirement condition.

## Compatibility gate

Public canonical event read contracts are in `main` through [#1674](https://github.com/ShipfoxHQ/shipfox/pull/1674), [#1680](https://github.com/ShipfoxHQ/shipfox/pull/1680), and [#1698](https://github.com/ShipfoxHQ/shipfox/pull/1698). This PR adds runtime entity hydration and the configurable writer rollout gate. Deploy this release with legacy writes enabled, complete one normal compatibility window with canonical readers, then set `WORKFLOWS_LEGACY_TRIGGER_EVENTS_WRITE_ENABLED=false` and restart the API. This PR does not claim production deployment or compatibility-window proof. Restore canonical readers before rollback; an array-only rollback requires a dual-write bridge for executions created after the flag changes.

## Validation

- `mise exec -- turbo test --filter=@shipfox/api-workflows...` — 85 files / 1,226 tests
- `mise exec -- turbo type --filter=@shipfox/api-workflows...`
- `mise exec -- turbo check --filter=@shipfox/api-workflows...`
- `mise exec -- turbo verify --filter=@shipfox/api-workflows...`
- `mise exec -- pnpm check:api-database-boundaries`
- `mise exec -- pnpm --filter=@shipfox/api-workflows exec drizzle-kit check`
- `mise exec -- turbo depcruise --filter=@shipfox/api-workflows...`
- `mise exec -- git diff --check`

The package check retains one unrelated existing `@shipfox/node-outbox` `__proto__` deprecation warning. Hosted CI, deployment, and operational rollout proof remain external gates.

Closes ENG-1968