### PR TITLE
[docs] Keep output limits reference user-facing

### DIFF
--- a/apps/docs/content/docs/reference/limits.mdx
+++ b/apps/docs/content/docs/reference/limits.mdx
@@ -29,14 +29,14 @@ can change the values marked configurable.
 
 | Limit | Default | Configurable | Details |
 | --- | --- | --- | --- |
-| Output bytes per job | 256 KiB total, 64 KiB per value | No | A job fails with an unknown status reason when materialized outputs exceed the cap. See [Job fields](/reference/workflow-schema#job-fields). |
+| Output bytes per job | 256 KiB total, 64 KiB per value | No | A job fails when materialized outputs exceed the cap. See [Job fields](/reference/workflow-schema#job-fields). |
 | Declared outputs per job | 128 entries | No | The `outputs:` map on one job. See [Job fields](/reference/workflow-schema#job-fields). |
 | Structured output nesting | 64 levels | No | Structured values deeper than this fail as non-JSON-safe outputs. |
 
 Persisted typed job outputs use JSON-safe values. CEL integers become JSON
 numbers when they are safe integers and decimal strings otherwise. Timestamps
-become ISO 8601 strings. Unsupported or cyclic values fail the execution with
-an unknown status reason. The total is measured as UTF-8 bytes of the complete
+become ISO 8601 strings. Unsupported or cyclic values fail the execution. The
+total is measured as UTF-8 bytes of the complete
 serialized outputs object, including output keys and JSON syntax.
 
 ## Workflow document


### PR DESCRIPTION
Keep the canonical limits reference focused on constraints readers need when authoring workflows.

The output-cap rows already show the current 256 KiB total and 64 KiB per-value limits. This removes internal status-reason identifiers from the surrounding job-output prose while preserving the UTF-8 serialized-output measurement explanation.

Validation passed with `mise exec -- turbo test --filter=@shipfox/docs...`, covering docs generation, unit checks, prose, links, schema, context, catalog, and production-route checks.

Closes ENG-1553

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes internal status-reason identifiers from the job-output limits prose so the reference stays focused on user-visible behavior. The documented limits and UTF-8 measurement explanation are unchanged. Closes ENG-1553.

<sup>Written for commit a7326cc2a3493762cbee20375b2d17b0724cd8b5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1703?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

