### PR TITLE
Bound listener filter snapshots with independent payload limits

### DIFF
--- a/.changeset/bound-listener-filter-snapshots.md
+++ b/.changeset/bound-listener-filter-snapshots.md
@@ -1,0 +1,7 @@
+---
+"@shipfox/api-workflows": patch
+"@shipfox/api-workflows-dto": patch
+"@shipfox/expression": patch
+---
+
+Bound listener filter snapshots to referenced context paths and an independent execution payload limit.

--- a/.changeset/bound-listener-filter-snapshots.md
+++ b/.changeset/bound-listener-filter-snapshots.md
@@ -1,6 +1,7 @@
 ---
 "@shipfox/api-workflows": patch
 "@shipfox/api-workflows-dto": patch
+"@shipfox/client-workflows": patch
 "@shipfox/expression": patch
 ---
 

--- a/.changeset/bound-listener-filter-snapshots.md
+++ b/.changeset/bound-listener-filter-snapshots.md
@@ -1,5 +1,5 @@
 ---
-"@shipfox/api-workflows": patch
+"@shipfox/api-workflows": minor
 "@shipfox/api-agent-access-dto": minor
 "@shipfox/api-workflows-dto": minor
 "@shipfox/client-workflows": minor

--- a/.changeset/bound-listener-filter-snapshots.md
+++ b/.changeset/bound-listener-filter-snapshots.md
@@ -1,8 +1,9 @@
 ---
 "@shipfox/api-workflows": patch
-"@shipfox/api-workflows-dto": patch
-"@shipfox/client-workflows": patch
-"@shipfox/expression": patch
+"@shipfox/api-agent-access-dto": minor
+"@shipfox/api-workflows-dto": minor
+"@shipfox/client-workflows": minor
+"@shipfox/expression": minor
 ---
 
-Bound listener filter snapshots to referenced context paths and an independent execution payload limit.
+Bounds listener filter snapshots to referenced context paths and a separate 512 KiB `filter_snapshot` execution payload limit.

--- a/libs/api/agent-access-dto/src/schemas/workflow-diagnostics.test.ts
+++ b/libs/api/agent-access-dto/src/schemas/workflow-diagnostics.test.ts
@@ -33,6 +33,21 @@ describe('workflow diagnostic Agent Access schemas', () => {
     );
   });
 
+  test('accepts filter snapshot oversized-field diagnostics', () => {
+    expect(
+      getWorkflowExecutionContextResultSchema.safeParse({
+        ...contextResult(),
+        oversized_fields: [
+          {field: 'filter_snapshot', stored_bytes: 524_289, reason: 'value_exceeds_inline_limit'},
+        ],
+      }).success,
+    ).toBe(true);
+    expect(
+      getWorkflowExecutionContextResultJsonSchema.properties.oversized_fields.items.properties
+        .field,
+    ).toMatchObject({enum: expect.arrayContaining(['filter_snapshot'])});
+  });
+
   test('keeps source availability branches distinct in the JSON schema mirror', () => {
     const branches = getWorkflowRunSourceResultJsonSchema.oneOf;
     expect(branches).toHaveLength(2);

--- a/libs/api/agent-access-dto/src/schemas/workflow-diagnostics.ts
+++ b/libs/api/agent-access-dto/src/schemas/workflow-diagnostics.ts
@@ -31,6 +31,7 @@ const diagnosticFields = [
   'execution_evaluation_trace',
   'condition',
   'trigger_events',
+  'filter_snapshot',
 ] as const;
 
 export const agentAccessWorkflowDiagnosticFieldSchema = z.enum(diagnosticFields);

--- a/libs/api/workflows-dto/src/index.ts
+++ b/libs/api/workflows-dto/src/index.ts
@@ -53,6 +53,7 @@ export {
   listenerStatusSchema,
   listeningTriggerSchema,
   logOutcomeSchema,
+  MAX_LISTENER_FILTER_SNAPSHOT_BYTES,
   MAX_LISTENER_FIRE_EVENT_BYTES,
   MAX_LISTENER_TRIGGER_EVENTS_BYTES,
   MAX_RESOLVED_STEP_CONFIG_BYTES,

--- a/libs/api/workflows-dto/src/schemas/index.ts
+++ b/libs/api/workflows-dto/src/schemas/index.ts
@@ -105,6 +105,7 @@ export {
   workflowExecutionTriggerEventsResponseSchema,
 } from './workflow-execution-events.js';
 export {
+  MAX_LISTENER_FILTER_SNAPSHOT_BYTES,
   MAX_LISTENER_FIRE_EVENT_BYTES,
   MAX_LISTENER_TRIGGER_EVENTS_BYTES,
   MAX_RESOLVED_STEP_CONFIG_BYTES,

--- a/libs/api/workflows-dto/src/schemas/workflow-execution-payload.ts
+++ b/libs/api/workflows-dto/src/schemas/workflow-execution-payload.ts
@@ -10,6 +10,8 @@ export const RUNNER_NEXT_STEP_ENVELOPE_ALLOWANCE_BYTES = 128 * 1024;
 export const MAX_RESOLVED_STEP_CONFIG_BYTES =
   RUNNER_NEXT_STEP_RESPONSE_BUDGET_BYTES - RUNNER_NEXT_STEP_ENVELOPE_ALLOWANCE_BYTES;
 export const MAX_LISTENER_TRIGGER_EVENTS_BYTES = 1_000_000;
+/** Listener snapshots are bounded separately from product job-output totals. */
+export const MAX_LISTENER_FILTER_SNAPSHOT_BYTES = 512 * 1024;
 export const MAX_LISTENER_FIRE_EVENT_BYTES = 768 * 1024;
 
 export const workflowExecutionPayloadFieldSchema = z.enum([
@@ -18,6 +20,7 @@ export const workflowExecutionPayloadFieldSchema = z.enum([
   'config_plan',
   'condition',
   'listener_batch',
+  'filter_snapshot',
 ]);
 
 export type WorkflowExecutionPayloadFieldDto = z.infer<typeof workflowExecutionPayloadFieldSchema>;

--- a/libs/api/workflows-dto/src/schemas/workflow-run-diagnostics.ts
+++ b/libs/api/workflows-dto/src/schemas/workflow-run-diagnostics.ts
@@ -45,6 +45,7 @@ const CONTEXT_DIAGNOSTIC_FIELDS = [
   'execution_evaluation_trace',
   'condition',
   'trigger_events',
+  'filter_snapshot',
 ] as const;
 
 export const stepDiagnosticFieldSchema = z.enum(STEP_DIAGNOSTIC_FIELDS);

--- a/libs/api/workflows/src/core/diagnostics.test.ts
+++ b/libs/api/workflows/src/core/diagnostics.test.ts
@@ -1,4 +1,5 @@
 import {
+  MAX_LISTENER_FILTER_SNAPSHOT_BYTES,
   MAX_RESOLVED_STEP_CONFIG_BYTES,
   STEP_RESPONSE_MAX_LENGTH,
   WORKFLOW_DIAGNOSTIC_CONFIG_MAX_BYTES,
@@ -62,6 +63,18 @@ describe('workflow payload policies', () => {
       expect.objectContaining({
         field: 'resolved_config',
         limitBytes: MAX_RESOLVED_STEP_CONFIG_BYTES,
+      }),
+    );
+  });
+
+  test('bounds listener filter snapshots with their own execution budget', () => {
+    const value = {payload: 'x'.repeat(MAX_LISTENER_FILTER_SNAPSHOT_BYTES)};
+
+    expect(() => assertWorkflowExecutionPayloadSize('filter_snapshot', value)).toThrow(
+      expect.objectContaining({
+        field: 'filter_snapshot',
+        limitBytes: MAX_LISTENER_FILTER_SNAPSHOT_BYTES,
+        measuredBytes: expect.any(Number),
       }),
     );
   });

--- a/libs/api/workflows/src/core/diagnostics.test.ts
+++ b/libs/api/workflows/src/core/diagnostics.test.ts
@@ -79,6 +79,17 @@ describe('workflow payload policies', () => {
     );
   });
 
+  test('accepts a listener filter snapshot exactly at its execution budget', () => {
+    const value = {
+      payload: 'x'.repeat(
+        MAX_LISTENER_FILTER_SNAPSHOT_BYTES - JSON.stringify({payload: ''}).length,
+      ),
+    };
+
+    expect(executionPayloadValueByteLength(value)).toBe(MAX_LISTENER_FILTER_SNAPSHOT_BYTES);
+    expect(() => assertWorkflowExecutionPayloadSize('filter_snapshot', value)).not.toThrow();
+  });
+
   test('observes oversized diagnostics without rejecting the owning write', () => {
     expect(() =>
       observeWorkflowDiagnosticSize('config', {

--- a/libs/api/workflows/src/core/diagnostics.ts
+++ b/libs/api/workflows/src/core/diagnostics.ts
@@ -1,5 +1,6 @@
 import {MAX_WORKFLOW_FILE_BYTES} from '@shipfox/api-definitions-dto';
 import {
+  MAX_LISTENER_FILTER_SNAPSHOT_BYTES,
   MAX_LISTENER_TRIGGER_EVENTS_BYTES,
   MAX_RESOLVED_STEP_CONFIG_BYTES,
   STEP_RESPONSE_MAX_LENGTH,
@@ -178,6 +179,8 @@ export function diagnosticByteLimit(field: WorkflowDiagnosticFieldDto): number {
       return WORKFLOW_DIAGNOSTIC_CONDITION_MAX_BYTES;
     case 'trigger_events':
       return WORKFLOW_DIAGNOSTIC_TRIGGER_EVENTS_MAX_BYTES;
+    case 'filter_snapshot':
+      return MAX_LISTENER_FILTER_SNAPSHOT_BYTES;
   }
 }
 
@@ -191,6 +194,8 @@ function executionPayloadByteLimit(field: WorkflowExecutionPayloadFieldDto): num
       return MAX_WORKFLOW_FILE_BYTES;
     case 'listener_batch':
       return MAX_LISTENER_TRIGGER_EVENTS_BYTES;
+    case 'filter_snapshot':
+      return MAX_LISTENER_FILTER_SNAPSHOT_BYTES;
   }
 }
 
@@ -202,6 +207,8 @@ function diagnosticFieldForExecutionPayload(
       return 'condition';
     case 'listener_batch':
       return 'trigger_events';
+    case 'filter_snapshot':
+      return 'filter_snapshot';
     case 'resolved_config':
     case 'config_plan':
       return 'config';

--- a/libs/api/workflows/src/core/step-config/assemble-run-context.test.ts
+++ b/libs/api/workflows/src/core/step-config/assemble-run-context.test.ts
@@ -875,13 +875,16 @@ describe('listener filter snapshots', () => {
     });
   });
 
-  it('keeps cardinality-only filtered comprehensions narrow', () => {
+  it.each([
+    'size(jobs.build.executions.filter(e, e.status == "failed")) > 0',
+    'jobs.build.executions.filter(e, e.status == "failed").size() > 0',
+  ])('keeps cardinality-only filtered comprehensions narrow: %s', (filter) => {
     const plan = planListenerFilterSnapshots({
       on: [
         {
           source: 'github',
           event: 'pull_request',
-          filter: 'size(jobs.build.executions.filter(e, e.status == "failed")) > 0',
+          filter,
         },
       ],
       until: null,
@@ -1756,6 +1759,82 @@ describe('listener filter snapshots', () => {
           element: {kind: 'object', fields: {count: 'int', createdAt: 'timestamp'}},
         },
       },
+    });
+  });
+
+  it('preserves output types for whole indexed executions', () => {
+    const plan = planListenerFilterSnapshots({
+      on: [
+        {
+          source: 'github',
+          event: 'pull_request',
+          filter: 'jobs.build.executions[0] == jobs.review.executions[0]',
+        },
+      ],
+      until: null,
+    });
+    expect(plan.on[0]?.jobsAreBroad).toBe(false);
+    const dependencyJobs = [
+      {
+        job: {key: 'build', status: 'succeeded' as const, outputs: {pr_number: 42}},
+        outputTypes: {pr_number: 'int' as const, unrelated: 'string' as const},
+        executions: [jobExecution({outputs: {pr_number: 42}})],
+      },
+      {
+        job: {key: 'review', status: 'succeeded' as const, outputs: {pr_number: 42}},
+        outputTypes: {pr_number: 'int' as const, unrelated: 'string' as const},
+        executions: [jobExecution({outputs: {pr_number: 42}})],
+      },
+    ];
+    const context = assembleListenerSnapshotContext({
+      job: {key: 'await'},
+      run,
+      triggerPayload,
+      plan,
+      dependencyJobs,
+    });
+
+    const [matcher] = applyListenerFilterSnapshots(
+      plan.on,
+      context,
+      listenerFilterOutputTypesForJobs(dependencyJobs),
+    );
+
+    expect(matcher?.filter_output_types).toEqual({
+      build: {pr_number: 'int', unrelated: 'string'},
+      review: {pr_number: 'int', unrelated: 'string'},
+    });
+  });
+
+  it('preserves output types for a bare job reference', () => {
+    const plan = planListenerFilterSnapshots({
+      on: [{source: 'github', event: 'pull_request', filter: 'jobs.build'}],
+      until: null,
+    });
+    expect(plan.on[0]?.jobsAreBroad).toBe(false);
+    const dependencyJobs = [
+      {
+        job: {key: 'build', status: 'succeeded' as const, outputs: {pr_number: 42}},
+        outputTypes: {pr_number: 'int' as const, unrelated: 'string' as const},
+        executions: [],
+      },
+    ];
+    const context = assembleListenerSnapshotContext({
+      job: {key: 'await'},
+      run,
+      triggerPayload,
+      plan,
+      dependencyJobs,
+    });
+
+    const [matcher] = applyListenerFilterSnapshots(
+      plan.on,
+      context,
+      listenerFilterOutputTypesForJobs(dependencyJobs),
+    );
+
+    expect(matcher?.filter_output_types).toEqual({
+      build: {pr_number: 'int', unrelated: 'string'},
     });
   });
 

--- a/libs/api/workflows/src/core/step-config/assemble-run-context.test.ts
+++ b/libs/api/workflows/src/core/step-config/assemble-run-context.test.ts
@@ -791,6 +791,47 @@ describe('listener filter snapshots', () => {
     });
   });
 
+  it('preserves higher indexed executions when a later projection is shorter', () => {
+    const plan = planListenerFilterSnapshots({
+      on: [
+        {
+          source: 'github',
+          event: 'pull_request',
+          filter:
+            'jobs.build.executions[1].outputs.pr_number == 43 && jobs.build.executions[0].name == "Build #0"',
+        },
+      ],
+      until: null,
+    });
+    const context = assembleListenerSnapshotContext({
+      job: {key: 'await'},
+      run,
+      triggerPayload,
+      plan,
+      dependencyJobs: [
+        {
+          job: {key: 'build', status: 'succeeded', outputs: {}},
+          executions: [
+            jobExecution({name: 'Build #0', outputs: {unrelated: 'large'}}),
+            jobExecution({name: 'Build #1', outputs: {pr_number: 43, unrelated: 'large'}}),
+          ],
+        },
+      ],
+    });
+
+    const [matcher] = applyListenerFilterSnapshots(plan.on, context);
+
+    expect(matcher?.filter_snapshot).toEqual({
+      jobs: {
+        build: {
+          key: 'build',
+          status: 'succeeded',
+          executions: [{name: 'Build #0'}, {outputs: {pr_number: 43}}],
+        },
+      },
+    });
+  });
+
   it('propagates paths through chained comprehensions', () => {
     const plan = planListenerFilterSnapshots({
       on: [

--- a/libs/api/workflows/src/core/step-config/assemble-run-context.test.ts
+++ b/libs/api/workflows/src/core/step-config/assemble-run-context.test.ts
@@ -1069,6 +1069,64 @@ describe('listener filter snapshots', () => {
         },
       },
     });
+    expect(matcher?.filter_snapshot).toEqual({
+      jobs: {
+        build: {
+          key: 'build',
+          status: 'succeeded',
+          outputs: {details: {count: 42, createdAt: '2026-06-30T12:00:00.000Z'}},
+        },
+      },
+    });
+  });
+
+  it('projects list and map output types', () => {
+    const plan = planListenerFilterSnapshots({
+      on: [
+        {
+          source: 'github',
+          event: 'pull_request',
+          filter:
+            'jobs.build.outputs.items[0] + 1 == 43 && jobs.build.outputs.metadata["key"] == "value"',
+        },
+      ],
+      until: null,
+    });
+    const dependencyJobs = [
+      {
+        job: {
+          key: 'build',
+          status: 'succeeded' as const,
+          outputs: {items: [42], metadata: {key: 'value'}, unrelated: 'large'},
+        },
+        outputTypes: {
+          items: {kind: 'list' as const, element: 'int' as const},
+          metadata: {kind: 'map' as const},
+          unrelated: 'string' as const,
+        },
+        executions: [],
+      },
+    ];
+    const context = assembleListenerSnapshotContext({
+      job: {key: 'await'},
+      run,
+      triggerPayload,
+      plan,
+      dependencyJobs,
+    });
+
+    const [matcher] = applyListenerFilterSnapshots(
+      plan.on,
+      context,
+      listenerFilterOutputTypesForJobs(dependencyJobs),
+    );
+
+    expect(matcher?.filter_output_types).toEqual({
+      build: {
+        items: {kind: 'list', element: 'int'},
+        metadata: {kind: 'map'},
+      },
+    });
   });
 
   it('omits dynamic listener output metadata for rolling-deploy compatibility', () => {
@@ -1246,6 +1304,64 @@ describe('listener filter snapshots', () => {
           status: 'succeeded',
           executions: [{status: 'succeeded'}],
         },
+      },
+    });
+  });
+
+  it('snapshots full jobs when a comprehension uses a whole element alias', () => {
+    const plan = planListenerFilterSnapshots({
+      on: [
+        {
+          source: 'github',
+          event: 'pull_request',
+          filter:
+            'jobs.build.executions.exists(e, e.name == "Build #0" || e in jobs.review.executions)',
+        },
+      ],
+      until: null,
+    });
+    expect(plan.on[0]?.jobsAreBroad).toBe(true);
+
+    const context = assembleListenerSnapshotContext({
+      job: {key: 'await'},
+      run,
+      triggerPayload,
+      plan,
+      dependencyJobs: [
+        {
+          job: {key: 'build', status: 'succeeded', outputs: {pr_number: 42, unrelated: 'large'}},
+          executions: [
+            jobExecution({name: 'Build #0', status: 'succeeded', outputs: {pr_number: 42}}),
+          ],
+        },
+        {
+          job: {key: 'review', status: 'failed', outputs: {reason: 'unrelated'}},
+          executions: [jobExecution({name: 'Review #0', status: 'failed'})],
+        },
+      ],
+    });
+
+    const [matcher] = applyListenerFilterSnapshots(plan.on, context);
+
+    expect(matcher?.filter_snapshot).toEqual({
+      jobs: {
+        build: expect.objectContaining({
+          key: 'build',
+          status: 'succeeded',
+          outputs: {pr_number: 42, unrelated: 'large'},
+          executions: [
+            expect.objectContaining({
+              name: 'Build #0',
+              status: 'succeeded',
+              outputs: {pr_number: 42},
+            }),
+          ],
+        }),
+        review: expect.objectContaining({
+          key: 'review',
+          status: 'failed',
+          outputs: {reason: 'unrelated'},
+        }),
       },
     });
   });

--- a/libs/api/workflows/src/core/step-config/assemble-run-context.test.ts
+++ b/libs/api/workflows/src/core/step-config/assemble-run-context.test.ts
@@ -875,6 +875,52 @@ describe('listener filter snapshots', () => {
     });
   });
 
+  it('keeps cardinality-only filtered comprehensions narrow', () => {
+    const plan = planListenerFilterSnapshots({
+      on: [
+        {
+          source: 'github',
+          event: 'pull_request',
+          filter: 'size(jobs.build.executions.filter(e, e.status == "failed")) > 0',
+        },
+      ],
+      until: null,
+    });
+    expect(plan.on[0]?.jobsAreBroad).toBe(false);
+
+    const context = assembleListenerSnapshotContext({
+      job: {key: 'await'},
+      run,
+      triggerPayload,
+      plan,
+      dependencyJobs: [
+        {
+          job: {key: 'build', status: 'succeeded', outputs: {unrelated: 'large'}},
+          executions: [
+            jobExecution({status: 'failed', outputs: {unrelated: 'large'}}),
+            jobExecution({status: 'succeeded', outputs: {unrelated: 'large'}}),
+          ],
+        },
+        {
+          job: {key: 'deploy', status: 'succeeded', outputs: {unrelated: 'large'}},
+          executions: [jobExecution({status: 'succeeded', outputs: {unrelated: 'large'}})],
+        },
+      ],
+    });
+
+    const [matcher] = applyListenerFilterSnapshots(plan.on, context);
+
+    expect(matcher?.filter_snapshot).toEqual({
+      jobs: {
+        build: {
+          key: 'build',
+          status: 'succeeded',
+          executions: [{status: 'failed'}, {status: 'succeeded'}],
+        },
+      },
+    });
+  });
+
   it('plans each matcher independently when matchers reference different job paths', () => {
     const plan = planListenerFilterSnapshots({
       on: [
@@ -1548,7 +1594,14 @@ describe('listener filter snapshots', () => {
       },
       {
         job: {key: 'review', status: 'failed', outputs: {reason: 'unrelated'}},
-        executions: [jobExecution({name: 'Review #0', status: 'failed'})],
+        outputTypes: {reason: 'string' as const, unrelated: 'string' as const},
+        executions: [
+          jobExecution({
+            name: 'Review #0',
+            status: 'failed',
+            outputs: {reason: 'review-execution-output'},
+          }),
+        ],
       },
       {
         job: {key: 'deploy', status: 'succeeded', outputs: {image: 'unrelated'}},
@@ -1592,6 +1645,7 @@ describe('listener filter snapshots', () => {
     expect(matcher?.filter_snapshot?.jobs).not.toHaveProperty('deploy');
     expect(matcher?.filter_output_types).toEqual({
       build: {pr_number: 'int', unrelated: 'string'},
+      review: {reason: 'string', unrelated: 'string'},
     });
   });
 
@@ -1609,42 +1663,67 @@ describe('listener filter snapshots', () => {
     });
     expect(plan.on[0]?.jobsAreBroad).toBe(false);
 
+    const dependencyJobs = [
+      {
+        job: {
+          key: 'build',
+          status: 'succeeded',
+          outputs: {
+            items: [{count: 1, createdAt: '2026-06-30T12:00:00.000Z', extra: 'build'}],
+            unrelated: 'large',
+          },
+        },
+        outputTypes: {
+          items: {
+            kind: 'list' as const,
+            element: {
+              kind: 'object' as const,
+              fields: {count: 'int' as const, createdAt: 'timestamp' as const},
+            },
+          },
+          unrelated: 'string' as const,
+        },
+        executions: [],
+      },
+      {
+        job: {
+          key: 'review',
+          status: 'succeeded',
+          outputs: {
+            items: [{count: 2, createdAt: '2026-06-30T12:01:00.000Z', extra: 'review'}],
+            unrelated: 'large',
+          },
+        },
+        outputTypes: {
+          items: {
+            kind: 'list' as const,
+            element: {
+              kind: 'object' as const,
+              fields: {count: 'int' as const, createdAt: 'timestamp' as const},
+            },
+          },
+          unrelated: 'string' as const,
+        },
+        executions: [],
+      },
+      {
+        job: {key: 'deploy', status: 'succeeded', outputs: {unrelated: 'large'}},
+        executions: [],
+      },
+    ] as const;
     const context = assembleListenerSnapshotContext({
       job: {key: 'await'},
       run,
       triggerPayload,
       plan,
-      dependencyJobs: [
-        {
-          job: {
-            key: 'build',
-            status: 'succeeded',
-            outputs: {
-              items: [{count: 1, createdAt: '2026-06-30T12:00:00.000Z', extra: 'build'}],
-              unrelated: 'large',
-            },
-          },
-          executions: [],
-        },
-        {
-          job: {
-            key: 'review',
-            status: 'succeeded',
-            outputs: {
-              items: [{count: 2, createdAt: '2026-06-30T12:01:00.000Z', extra: 'review'}],
-              unrelated: 'large',
-            },
-          },
-          executions: [],
-        },
-        {
-          job: {key: 'deploy', status: 'succeeded', outputs: {unrelated: 'large'}},
-          executions: [],
-        },
-      ],
+      dependencyJobs,
     });
 
-    const [matcher] = applyListenerFilterSnapshots(plan.on, context);
+    const [matcher] = applyListenerFilterSnapshots(
+      plan.on,
+      context,
+      listenerFilterOutputTypesForJobs(dependencyJobs),
+    );
 
     expect(matcher?.filter_snapshot).toEqual({
       jobs: {
@@ -1661,6 +1740,20 @@ describe('listener filter snapshots', () => {
           outputs: {
             items: [{count: 2, createdAt: '2026-06-30T12:01:00.000Z', extra: 'review'}],
           },
+        },
+      },
+    });
+    expect(matcher?.filter_output_types).toEqual({
+      build: {
+        items: {
+          kind: 'list',
+          element: {kind: 'object', fields: {count: 'int', createdAt: 'timestamp'}},
+        },
+      },
+      review: {
+        items: {
+          kind: 'list',
+          element: {kind: 'object', fields: {count: 'int', createdAt: 'timestamp'}},
         },
       },
     });

--- a/libs/api/workflows/src/core/step-config/assemble-run-context.test.ts
+++ b/libs/api/workflows/src/core/step-config/assemble-run-context.test.ts
@@ -667,8 +667,57 @@ describe('listener filter snapshots', () => {
         {
           source: 'github',
           event: 'pull_request',
-          filter:
-            'jobs.build.outputs.size() > 0 && jobs.build.outputs.all(output, output == "ready")',
+          filter: 'jobs.build.outputs.all(output, output == "ready")',
+        },
+      ],
+      until: null,
+    });
+    const dependencyJobs = [
+      {
+        job: {
+          key: 'build',
+          status: 'succeeded' as const,
+          outputs: {status: 'ready', createdAt: '2026-06-30T12:00:00.000Z'},
+        },
+        outputTypes: {status: 'string' as const, createdAt: 'timestamp' as const},
+        executions: [],
+      },
+    ];
+    const context = assembleListenerSnapshotContext({
+      job: {key: 'await'},
+      run,
+      triggerPayload,
+      plan,
+      dependencyJobs,
+    });
+
+    const [matcher] = applyListenerFilterSnapshots(
+      plan.on,
+      context,
+      listenerFilterOutputTypesForJobs(dependencyJobs),
+    );
+
+    expect(matcher?.filter_snapshot).toEqual({
+      jobs: {
+        build: {
+          key: 'build',
+          status: 'succeeded',
+          outputs: {status: 'ready', createdAt: '2026-06-30T12:00:00.000Z'},
+        },
+      },
+    });
+    expect(matcher?.filter_output_types).toEqual({
+      build: {status: 'string', createdAt: 'timestamp'},
+    });
+  });
+
+  it('retains available sibling paths when another referenced field is absent', () => {
+    const plan = planListenerFilterSnapshots({
+      on: [
+        {
+          source: 'github',
+          event: 'pull_request',
+          filter: 'jobs.build.outputs.pr_number == 42 || jobs.build.outputs.fork_number == 42',
         },
       ],
       until: null,
@@ -680,11 +729,7 @@ describe('listener filter snapshots', () => {
       plan,
       dependencyJobs: [
         {
-          job: {
-            key: 'build',
-            status: 'succeeded',
-            outputs: {status: 'ready', unrelated: 'also-needed-for-map-iteration'},
-          },
+          job: {key: 'build', status: 'succeeded', outputs: {pr_number: 42}},
           executions: [],
         },
       ],
@@ -697,7 +742,93 @@ describe('listener filter snapshots', () => {
         build: {
           key: 'build',
           status: 'succeeded',
-          outputs: {status: 'ready', unrelated: 'also-needed-for-map-iteration'},
+          outputs: {pr_number: 42},
+        },
+      },
+    });
+  });
+
+  it('merges projections for multiple fields in one indexed execution', () => {
+    const plan = planListenerFilterSnapshots({
+      on: [
+        {
+          source: 'github',
+          event: 'pull_request',
+          filter:
+            'jobs.build.executions[0].outputs.pr_number == 42 && jobs.build.executions[0].name == "Build #1"',
+        },
+      ],
+      until: null,
+    });
+    const context = assembleListenerSnapshotContext({
+      job: {key: 'await'},
+      run,
+      triggerPayload,
+      plan,
+      dependencyJobs: [
+        {
+          job: {key: 'build', status: 'succeeded', outputs: {}},
+          executions: [
+            jobExecution({
+              name: 'Build #1',
+              outputs: {pr_number: 42, unrelated: 'large'},
+            }),
+          ],
+        },
+      ],
+    });
+
+    const [matcher] = applyListenerFilterSnapshots(plan.on, context);
+
+    expect(matcher?.filter_snapshot).toEqual({
+      jobs: {
+        build: {
+          key: 'build',
+          status: 'succeeded',
+          executions: [{name: 'Build #1', outputs: {pr_number: 42}}],
+        },
+      },
+    });
+  });
+
+  it('propagates paths through chained comprehensions', () => {
+    const plan = planListenerFilterSnapshots({
+      on: [
+        {
+          source: 'github',
+          event: 'pull_request',
+          filter:
+            'jobs.build.executions.filter(e, e.status == "failed").exists(x, x.outputs.pr_number == 42)',
+        },
+      ],
+      until: null,
+    });
+    const context = assembleListenerSnapshotContext({
+      job: {key: 'await'},
+      run,
+      triggerPayload,
+      plan,
+      dependencyJobs: [
+        {
+          job: {key: 'build', status: 'succeeded', outputs: {}},
+          executions: [
+            jobExecution({
+              status: 'failed',
+              outputs: {pr_number: 42, unrelated: 'large'},
+            }),
+          ],
+        },
+      ],
+    });
+
+    const [matcher] = applyListenerFilterSnapshots(plan.on, context);
+
+    expect(matcher?.filter_snapshot).toEqual({
+      jobs: {
+        build: {
+          key: 'build',
+          status: 'succeeded',
+          executions: [{status: 'failed', outputs: {pr_number: 42}}],
         },
       },
     });
@@ -841,6 +972,60 @@ describe('listener filter snapshots', () => {
       },
       filter_output_types: {
         build: {details: {kind: 'object', fields: {count: 'int'}}},
+      },
+    });
+  });
+
+  it('merges output types for multiple fields in one nested output', () => {
+    const plan = planListenerFilterSnapshots({
+      on: [
+        {
+          source: 'github',
+          event: 'pull_request',
+          filter:
+            'jobs.build.outputs.details.count == 42 && jobs.build.outputs.details.createdAt == timestamp("2026-06-30T12:00:00.000Z")',
+        },
+      ],
+      until: null,
+    });
+    const dependencyJobs = [
+      {
+        job: {
+          key: 'build',
+          status: 'succeeded' as const,
+          outputs: {
+            details: {count: 42, createdAt: '2026-06-30T12:00:00.000Z'},
+          },
+        },
+        outputTypes: {
+          details: {
+            kind: 'object' as const,
+            fields: {count: 'int' as const, createdAt: 'timestamp' as const},
+          },
+        },
+        executions: [],
+      },
+    ];
+    const context = assembleListenerSnapshotContext({
+      job: {key: 'await'},
+      run,
+      triggerPayload,
+      plan,
+      dependencyJobs,
+    });
+
+    const [matcher] = applyListenerFilterSnapshots(
+      plan.on,
+      context,
+      listenerFilterOutputTypesForJobs(dependencyJobs),
+    );
+
+    expect(matcher?.filter_output_types).toEqual({
+      build: {
+        details: {
+          kind: 'object',
+          fields: {count: 'int', createdAt: 'timestamp'},
+        },
       },
     });
   });

--- a/libs/api/workflows/src/core/step-config/assemble-run-context.test.ts
+++ b/libs/api/workflows/src/core/step-config/assemble-run-context.test.ts
@@ -1538,30 +1538,36 @@ describe('listener filter snapshots', () => {
     });
     expect(plan.on[0]?.jobsAreBroad).toBe(false);
 
+    const dependencyJobs = [
+      {
+        job: {key: 'build', status: 'succeeded', outputs: {pr_number: 42, unrelated: 'large'}},
+        outputTypes: {pr_number: 'int' as const, unrelated: 'string' as const},
+        executions: [
+          jobExecution({name: 'Build #0', status: 'succeeded', outputs: {pr_number: 42}}),
+        ],
+      },
+      {
+        job: {key: 'review', status: 'failed', outputs: {reason: 'unrelated'}},
+        executions: [jobExecution({name: 'Review #0', status: 'failed'})],
+      },
+      {
+        job: {key: 'deploy', status: 'succeeded', outputs: {image: 'unrelated'}},
+        executions: [jobExecution({name: 'Deploy #0', status: 'succeeded'})],
+      },
+    ] as const;
     const context = assembleListenerSnapshotContext({
       job: {key: 'await'},
       run,
       triggerPayload,
       plan,
-      dependencyJobs: [
-        {
-          job: {key: 'build', status: 'succeeded', outputs: {pr_number: 42, unrelated: 'large'}},
-          executions: [
-            jobExecution({name: 'Build #0', status: 'succeeded', outputs: {pr_number: 42}}),
-          ],
-        },
-        {
-          job: {key: 'review', status: 'failed', outputs: {reason: 'unrelated'}},
-          executions: [jobExecution({name: 'Review #0', status: 'failed'})],
-        },
-        {
-          job: {key: 'deploy', status: 'succeeded', outputs: {image: 'unrelated'}},
-          executions: [jobExecution({name: 'Deploy #0', status: 'succeeded'})],
-        },
-      ],
+      dependencyJobs,
     });
 
-    const [matcher] = applyListenerFilterSnapshots(plan.on, context);
+    const [matcher] = applyListenerFilterSnapshots(
+      plan.on,
+      context,
+      listenerFilterOutputTypesForJobs(dependencyJobs),
+    );
 
     expect(matcher?.filter_snapshot).toEqual({
       jobs: {
@@ -1584,6 +1590,9 @@ describe('listener filter snapshots', () => {
       },
     });
     expect(matcher?.filter_snapshot?.jobs).not.toHaveProperty('deploy');
+    expect(matcher?.filter_output_types).toEqual({
+      build: {pr_number: 'int', unrelated: 'string'},
+    });
   });
 
   it('preserves whole-element projections for list outputs', () => {

--- a/libs/api/workflows/src/core/step-config/assemble-run-context.test.ts
+++ b/libs/api/workflows/src/core/step-config/assemble-run-context.test.ts
@@ -1080,6 +1080,55 @@ describe('listener filter snapshots', () => {
     });
   });
 
+  it('preserves prototype-named output values and types', () => {
+    const outputs = Object.fromEntries([
+      ['__proto__', 42],
+      ['unrelated', 'large'],
+    ]);
+    const outputTypes = Object.fromEntries([['__proto__', 'int' as const]]);
+    const plan = planListenerFilterSnapshots({
+      on: [
+        {
+          source: 'github',
+          event: 'pull_request',
+          filter: 'jobs.build.outputs["__proto__"] == 42',
+        },
+      ],
+      until: null,
+    });
+    const dependencyJobs = [
+      {
+        job: {key: 'build', status: 'succeeded' as const, outputs},
+        outputTypes,
+        executions: [],
+      },
+    ];
+    const context = assembleListenerSnapshotContext({
+      job: {key: 'await'},
+      run,
+      triggerPayload,
+      plan,
+      dependencyJobs,
+    });
+
+    const [matcher] = applyListenerFilterSnapshots(
+      plan.on,
+      context,
+      listenerFilterOutputTypesForJobs(dependencyJobs),
+    );
+    const snapshotOutputs = matcher?.filter_snapshot?.jobs as
+      | Record<string, {outputs: Record<string, unknown>}>
+      | undefined;
+    const snapshotTypes = matcher?.filter_output_types?.build;
+
+    expect(Object.hasOwn(snapshotOutputs?.build?.outputs ?? {}, '__proto__')).toBe(true);
+    expect(
+      Object.getOwnPropertyDescriptor(snapshotOutputs?.build?.outputs ?? {}, '__proto__')?.value,
+    ).toBe(42);
+    expect(Object.hasOwn(snapshotTypes ?? {}, '__proto__')).toBe(true);
+    expect(Object.getOwnPropertyDescriptor(snapshotTypes ?? {}, '__proto__')?.value).toBe('int');
+  });
+
   it('projects list and map output types', () => {
     const plan = planListenerFilterSnapshots({
       on: [
@@ -1087,7 +1136,7 @@ describe('listener filter snapshots', () => {
           source: 'github',
           event: 'pull_request',
           filter:
-            'jobs.build.outputs.items[0] + 1 == 43 && jobs.build.outputs.metadata["key"] == "value"',
+            'jobs.build.outputs.items[0].count == 1 && jobs.build.outputs.metadata["key"] == "value"',
         },
       ],
       until: null,
@@ -1097,10 +1146,20 @@ describe('listener filter snapshots', () => {
         job: {
           key: 'build',
           status: 'succeeded' as const,
-          outputs: {items: [42], metadata: {key: 'value'}, unrelated: 'large'},
+          outputs: {
+            items: [{count: 1, createdAt: '2026-06-30T12:00:00.000Z'}],
+            metadata: {key: 'value'},
+            unrelated: 'large',
+          },
         },
         outputTypes: {
-          items: {kind: 'list' as const, element: 'int' as const},
+          items: {
+            kind: 'list' as const,
+            element: {
+              kind: 'object' as const,
+              fields: {count: 'int' as const, createdAt: 'timestamp' as const},
+            },
+          },
           metadata: {kind: 'map' as const},
           unrelated: 'string' as const,
         },
@@ -1123,7 +1182,7 @@ describe('listener filter snapshots', () => {
 
     expect(matcher?.filter_output_types).toEqual({
       build: {
-        items: {kind: 'list', element: 'int'},
+        items: {kind: 'list', element: {kind: 'object', fields: {count: 'int'}}},
         metadata: {kind: 'map'},
       },
     });
@@ -1308,6 +1367,43 @@ describe('listener filter snapshots', () => {
     });
   });
 
+  it('does not pad indexed execution projections beyond the available array', () => {
+    const plan = planListenerFilterSnapshots({
+      on: [
+        {
+          source: 'github',
+          event: 'pull_request',
+          filter: 'jobs.build.executions[5].status != "failed"',
+        },
+      ],
+      until: null,
+    });
+    const context = assembleListenerSnapshotContext({
+      job: {key: 'await'},
+      run,
+      triggerPayload,
+      plan,
+      dependencyJobs: [
+        {
+          job: {key: 'build', status: 'succeeded', outputs: {}},
+          executions: [jobExecution({status: 'succeeded'})],
+        },
+      ],
+    });
+
+    const [matcher] = applyListenerFilterSnapshots(plan.on, context);
+
+    expect(matcher?.filter_snapshot).toEqual({
+      jobs: {
+        build: {
+          key: 'build',
+          status: 'succeeded',
+          executions: [{}],
+        },
+      },
+    });
+  });
+
   it('snapshots all jobs for access after a filtered comprehension', () => {
     const plan = planListenerFilterSnapshots({
       on: [
@@ -1356,7 +1452,79 @@ describe('listener filter snapshots', () => {
     });
   });
 
-  it('snapshots full jobs when a comprehension uses a whole element alias', () => {
+  it('snapshots all jobs when a comprehension result is compared as a value', () => {
+    const plan = planListenerFilterSnapshots({
+      on: [
+        {
+          source: 'github',
+          event: 'pull_request',
+          filter: 'jobs.build.executions.filter(e, e.status == "failed") == jobs.review.executions',
+        },
+      ],
+      until: null,
+    });
+    expect(plan.on[0]?.jobsAreBroad).toBe(true);
+
+    const context = assembleListenerSnapshotContext({
+      job: {key: 'await'},
+      run,
+      triggerPayload,
+      plan,
+      dependencyJobs: [
+        {
+          job: {
+            key: 'build',
+            status: 'succeeded',
+            outputs: {unrelated: 'build-output'},
+          },
+          executions: [
+            jobExecution({
+              status: 'failed',
+              outputs: {pr_number: 42, unrelated: 'build-execution-output'},
+            }),
+          ],
+        },
+        {
+          job: {key: 'review', status: 'failed', outputs: {reason: 'review-output'}},
+          executions: [
+            jobExecution({
+              name: 'Review #0',
+              status: 'failed',
+              outputs: {reason: 'review-execution-output'},
+            }),
+          ],
+        },
+      ],
+    });
+
+    const [matcher] = applyListenerFilterSnapshots(plan.on, context);
+
+    expect(matcher?.filter_snapshot).toEqual({
+      jobs: {
+        build: expect.objectContaining({
+          outputs: {unrelated: 'build-output'},
+          executions: [
+            expect.objectContaining({
+              status: 'failed',
+              outputs: {pr_number: 42, unrelated: 'build-execution-output'},
+            }),
+          ],
+        }),
+        review: expect.objectContaining({
+          outputs: {reason: 'review-output'},
+          executions: [
+            expect.objectContaining({
+              name: 'Review #0',
+              status: 'failed',
+              outputs: {reason: 'review-execution-output'},
+            }),
+          ],
+        }),
+      },
+    });
+  });
+
+  it('preserves whole-element projections without broadening unrelated jobs', () => {
     const plan = planListenerFilterSnapshots({
       on: [
         {
@@ -1368,7 +1536,7 @@ describe('listener filter snapshots', () => {
       ],
       until: null,
     });
-    expect(plan.on[0]?.jobsAreBroad).toBe(true);
+    expect(plan.on[0]?.jobsAreBroad).toBe(false);
 
     const context = assembleListenerSnapshotContext({
       job: {key: 'await'},
@@ -1386,6 +1554,10 @@ describe('listener filter snapshots', () => {
           job: {key: 'review', status: 'failed', outputs: {reason: 'unrelated'}},
           executions: [jobExecution({name: 'Review #0', status: 'failed'})],
         },
+        {
+          job: {key: 'deploy', status: 'succeeded', outputs: {image: 'unrelated'}},
+          executions: [jobExecution({name: 'Deploy #0', status: 'succeeded'})],
+        },
       ],
     });
 
@@ -1396,7 +1568,6 @@ describe('listener filter snapshots', () => {
         build: expect.objectContaining({
           key: 'build',
           status: 'succeeded',
-          outputs: {pr_number: 42, unrelated: 'large'},
           executions: [
             expect.objectContaining({
               name: 'Build #0',
@@ -1408,8 +1579,80 @@ describe('listener filter snapshots', () => {
         review: expect.objectContaining({
           key: 'review',
           status: 'failed',
-          outputs: {reason: 'unrelated'},
+          executions: [expect.objectContaining({name: 'Review #0', status: 'failed'})],
         }),
+      },
+    });
+    expect(matcher?.filter_snapshot?.jobs).not.toHaveProperty('deploy');
+  });
+
+  it('preserves whole-element projections for list outputs', () => {
+    const plan = planListenerFilterSnapshots({
+      on: [
+        {
+          source: 'github',
+          event: 'pull_request',
+          filter:
+            'jobs.build.outputs.items.exists(i, i.count == 1 || i in jobs.review.outputs.items)',
+        },
+      ],
+      until: null,
+    });
+    expect(plan.on[0]?.jobsAreBroad).toBe(false);
+
+    const context = assembleListenerSnapshotContext({
+      job: {key: 'await'},
+      run,
+      triggerPayload,
+      plan,
+      dependencyJobs: [
+        {
+          job: {
+            key: 'build',
+            status: 'succeeded',
+            outputs: {
+              items: [{count: 1, createdAt: '2026-06-30T12:00:00.000Z', extra: 'build'}],
+              unrelated: 'large',
+            },
+          },
+          executions: [],
+        },
+        {
+          job: {
+            key: 'review',
+            status: 'succeeded',
+            outputs: {
+              items: [{count: 2, createdAt: '2026-06-30T12:01:00.000Z', extra: 'review'}],
+              unrelated: 'large',
+            },
+          },
+          executions: [],
+        },
+        {
+          job: {key: 'deploy', status: 'succeeded', outputs: {unrelated: 'large'}},
+          executions: [],
+        },
+      ],
+    });
+
+    const [matcher] = applyListenerFilterSnapshots(plan.on, context);
+
+    expect(matcher?.filter_snapshot).toEqual({
+      jobs: {
+        build: {
+          key: 'build',
+          status: 'succeeded',
+          outputs: {
+            items: [{count: 1, createdAt: '2026-06-30T12:00:00.000Z', extra: 'build'}],
+          },
+        },
+        review: {
+          key: 'review',
+          status: 'succeeded',
+          outputs: {
+            items: [{count: 2, createdAt: '2026-06-30T12:01:00.000Z', extra: 'review'}],
+          },
+        },
       },
     });
   });

--- a/libs/api/workflows/src/core/step-config/assemble-run-context.test.ts
+++ b/libs/api/workflows/src/core/step-config/assemble-run-context.test.ts
@@ -1308,6 +1308,54 @@ describe('listener filter snapshots', () => {
     });
   });
 
+  it('snapshots all jobs for access after a filtered comprehension', () => {
+    const plan = planListenerFilterSnapshots({
+      on: [
+        {
+          source: 'github',
+          event: 'pull_request',
+          filter:
+            'jobs.build.executions.filter(e, e.status == "failed")[0].outputs.pr_number == 42',
+        },
+      ],
+      until: null,
+    });
+    expect(plan.on[0]?.jobsAreBroad).toBe(true);
+
+    const context = assembleListenerSnapshotContext({
+      job: {key: 'await'},
+      run,
+      triggerPayload,
+      plan,
+      dependencyJobs: [
+        {
+          job: {key: 'build', status: 'succeeded', outputs: {pr_number: 42, unrelated: 'large'}},
+          executions: [
+            jobExecution({status: 'failed', outputs: {pr_number: 42, unrelated: 'large'}}),
+          ],
+        },
+      ],
+    });
+
+    const [matcher] = applyListenerFilterSnapshots(plan.on, context);
+
+    expect(matcher?.filter_snapshot).toEqual({
+      jobs: {
+        build: expect.objectContaining({
+          key: 'build',
+          status: 'succeeded',
+          outputs: {pr_number: 42, unrelated: 'large'},
+          executions: [
+            expect.objectContaining({
+              status: 'failed',
+              outputs: {pr_number: 42, unrelated: 'large'},
+            }),
+          ],
+        }),
+      },
+    });
+  });
+
   it('snapshots full jobs when a comprehension uses a whole element alias', () => {
     const plan = planListenerFilterSnapshots({
       on: [

--- a/libs/api/workflows/src/core/step-config/assemble-run-context.test.ts
+++ b/libs/api/workflows/src/core/step-config/assemble-run-context.test.ts
@@ -580,7 +580,6 @@ describe('listener filter snapshots', () => {
           key: 'build',
           status: 'succeeded',
           outputs: {pr_number: 42},
-          executions: expect.any(Array),
         }),
       },
     });
@@ -590,7 +589,181 @@ describe('listener filter snapshots', () => {
         .sort(),
     );
     expect(matcher?.filter_snapshot).not.toHaveProperty('event');
-    expect(matcher?.filter_snapshot?.jobs).not.toHaveProperty('review');
+    const jobs = matcher?.filter_snapshot?.jobs as Record<string, unknown> | undefined;
+    expect(jobs).not.toHaveProperty('review');
+    expect(jobs?.build).not.toHaveProperty('executions');
+  });
+
+  it('projects only referenced execution fields and output keys', () => {
+    const plan = planListenerFilterSnapshots({
+      on: [
+        {
+          source: 'github',
+          event: 'pull_request',
+          filter: 'jobs.build.executions.exists(e, e.outputs.pr_number == 42)',
+        },
+      ],
+      until: null,
+    });
+    const dependencyJobs = [
+      {
+        job: {
+          key: 'build',
+          status: 'succeeded' as const,
+          outputs: {pr_number: 42, unrelated: 'large'},
+        },
+        outputTypes: {pr_number: 'int' as const, unrelated: 'string' as const},
+        executions: [
+          jobExecution({
+            id: 'exec-build',
+            jobId: 'job-build',
+            outputs: {pr_number: 42, unrelated: 'large'},
+            triggerEvents: [
+              {
+                source: 'github',
+                event: 'push',
+                delivery_id: 'delivery-1',
+                received_at: '2026-06-30T12:00:00.000Z',
+                project: null,
+                repository: null,
+                ref: null,
+                commit: null,
+                data: {unrelated: 'large'},
+              },
+            ],
+          }),
+        ],
+      },
+    ];
+    const context = assembleListenerSnapshotContext({
+      job: {key: 'await'},
+      run,
+      triggerPayload,
+      plan,
+      dependencyJobs,
+    });
+
+    const [matcher] = applyListenerFilterSnapshots(
+      plan.on,
+      context,
+      listenerFilterOutputTypesForJobs(dependencyJobs),
+    );
+
+    expect(matcher?.filter_snapshot).toEqual({
+      jobs: {
+        build: {
+          key: 'build',
+          status: 'succeeded',
+          executions: [{outputs: {pr_number: 42}}],
+        },
+      },
+    });
+    expect(matcher?.filter_output_types).toEqual({build: {pr_number: 'int'}});
+  });
+
+  it('retains map values when a comprehension iterates over outputs', () => {
+    const plan = planListenerFilterSnapshots({
+      on: [
+        {
+          source: 'github',
+          event: 'pull_request',
+          filter:
+            'jobs.build.outputs.size() > 0 && jobs.build.outputs.all(output, output == "ready")',
+        },
+      ],
+      until: null,
+    });
+    const context = assembleListenerSnapshotContext({
+      job: {key: 'await'},
+      run,
+      triggerPayload,
+      plan,
+      dependencyJobs: [
+        {
+          job: {
+            key: 'build',
+            status: 'succeeded',
+            outputs: {status: 'ready', unrelated: 'also-needed-for-map-iteration'},
+          },
+          executions: [],
+        },
+      ],
+    });
+
+    const [matcher] = applyListenerFilterSnapshots(plan.on, context);
+
+    expect(matcher?.filter_snapshot).toEqual({
+      jobs: {
+        build: {
+          key: 'build',
+          status: 'succeeded',
+          outputs: {status: 'ready', unrelated: 'also-needed-for-map-iteration'},
+        },
+      },
+    });
+  });
+
+  it('plans each matcher independently when matchers reference different job paths', () => {
+    const plan = planListenerFilterSnapshots({
+      on: [
+        {
+          source: 'github',
+          event: 'pull_request',
+          filter: 'jobs.build.outputs.pr_number == 42',
+        },
+        {
+          source: 'github',
+          event: 'pull_request',
+          filter: 'jobs.review.outputs.pr_number == 99',
+        },
+      ],
+      until: null,
+    });
+    const context = assembleListenerSnapshotContext({
+      job: {key: 'await'},
+      run,
+      triggerPayload,
+      plan,
+      dependencyJobs: [
+        {
+          job: {
+            key: 'build',
+            status: 'succeeded',
+            outputs: {pr_number: 42, unrelated: 'build-only'},
+          },
+          executions: [],
+        },
+        {
+          job: {
+            key: 'review',
+            status: 'succeeded',
+            outputs: {pr_number: 99, unrelated: 'review-only'},
+          },
+          executions: [],
+        },
+      ],
+    });
+
+    const matchers = applyListenerFilterSnapshots(plan.on, context);
+
+    expect(matchers[0]?.filter_snapshot).toEqual({
+      jobs: {
+        build: {
+          key: 'build',
+          status: 'succeeded',
+          outputs: {pr_number: 42},
+        },
+      },
+    });
+    expect(matchers[1]?.filter_snapshot).toEqual({
+      jobs: {
+        review: {
+          key: 'review',
+          status: 'succeeded',
+          outputs: {pr_number: 99},
+        },
+      },
+    });
   });
 
   it('snapshots vars for listener filters', () => {
@@ -634,10 +807,11 @@ describe('listener filter snapshots', () => {
         job: {
           key: 'build',
           status: 'succeeded' as const,
-          outputs: {details: {count: 42}},
+          outputs: {details: {count: 42}, unrelated: 'large'},
         },
         outputTypes: {
           details: {kind: 'object' as const, fields: {count: 'int' as const}},
+          unrelated: 'string' as const,
         },
         executions: [],
       },
@@ -806,6 +980,46 @@ describe('listener filter snapshots', () => {
           status: 'skipped',
           outputs: {},
         }),
+      },
+    });
+  });
+
+  it('projects only the indexed execution needed by a direct access', () => {
+    const plan = planListenerFilterSnapshots({
+      on: [
+        {
+          source: 'github',
+          event: 'pull_request',
+          filter: 'jobs.build.executions[0].status == "succeeded"',
+        },
+      ],
+      until: null,
+    });
+    const context = assembleListenerSnapshotContext({
+      job: {key: 'await'},
+      run,
+      triggerPayload,
+      plan,
+      dependencyJobs: [
+        {
+          job: {key: 'build', status: 'succeeded', outputs: {unrelated: 'large'}},
+          executions: [
+            jobExecution({status: 'succeeded', outputs: {needed: true}}),
+            jobExecution({sequence: 3, status: 'failed', outputs: {unrelated: 'large'}}),
+          ],
+        },
+      ],
+    });
+
+    const [matcher] = applyListenerFilterSnapshots(plan.on, context);
+
+    expect(matcher?.filter_snapshot).toEqual({
+      jobs: {
+        build: {
+          key: 'build',
+          status: 'succeeded',
+          executions: [{status: 'succeeded'}],
+        },
       },
     });
   });

--- a/libs/api/workflows/src/core/step-config/assemble-run-context.test.ts
+++ b/libs/api/workflows/src/core/step-config/assemble-run-context.test.ts
@@ -661,6 +661,54 @@ describe('listener filter snapshots', () => {
     expect(matcher?.filter_output_types).toEqual({build: {pr_number: 'int'}});
   });
 
+  it('projects a literal wildcard output key without broadening the snapshot', () => {
+    const plan = planListenerFilterSnapshots({
+      on: [
+        {
+          source: 'github',
+          event: 'pull_request',
+          filter: 'jobs.build.outputs["*"] == "ready"',
+        },
+      ],
+      until: null,
+    });
+    const dependencyJobs = [
+      {
+        job: {
+          key: 'build',
+          status: 'succeeded' as const,
+          outputs: {'*': 'ready', unrelated: 'large'},
+        },
+        outputTypes: {'*': 'string' as const, unrelated: 'string' as const},
+        executions: [],
+      },
+    ];
+    const context = assembleListenerSnapshotContext({
+      job: {key: 'await'},
+      run,
+      triggerPayload,
+      plan,
+      dependencyJobs,
+    });
+
+    const [matcher] = applyListenerFilterSnapshots(
+      plan.on,
+      context,
+      listenerFilterOutputTypesForJobs(dependencyJobs),
+    );
+
+    expect(matcher?.filter_snapshot).toEqual({
+      jobs: {
+        build: {
+          key: 'build',
+          status: 'succeeded',
+          outputs: {'*': 'ready'},
+        },
+      },
+    });
+    expect(matcher?.filter_output_types).toEqual({build: {'*': 'string'}});
+  });
+
   it('retains map values when a comprehension iterates over outputs', () => {
     const plan = planListenerFilterSnapshots({
       on: [

--- a/libs/api/workflows/src/core/step-config/assemble-run-context.ts
+++ b/libs/api/workflows/src/core/step-config/assemble-run-context.ts
@@ -609,7 +609,7 @@ function projectValueByPaths(
   const projected: Record<string, unknown> = {};
   for (const path of paths) {
     const segment = path[0];
-    if (typeof segment !== 'string' || !Object.hasOwn(value, segment)) return {};
+    if (typeof segment !== 'string' || !Object.hasOwn(value, segment)) continue;
 
     const child = projectValueByPaths(value[segment], [path.slice(1)]);
     projected[segment] = mergeProjectedValues(projected[segment], child);
@@ -650,8 +650,18 @@ function projectArrayByPaths(
 
 function mergeProjectedValues(left: unknown, right: unknown): unknown {
   if (left === undefined) return right;
+  if (Array.isArray(left) && Array.isArray(right)) {
+    return Array.from({length: Math.max(left.length, right.length)}, (_, index) =>
+      mergeProjectedValues(left[index], right[index]),
+    );
+  }
   if (!isRecord(left) || !isRecord(right)) return right;
-  return {...left, ...right};
+
+  const merged: Record<string, unknown> = {...left};
+  for (const [key, value] of Object.entries(right)) {
+    merged[key] = mergeProjectedValues(merged[key], value);
+  }
+  return merged;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -698,13 +708,45 @@ function projectExpressionTypeRecord(
   const projected: Record<string, ExpressionType> = {};
   for (const path of paths) {
     const [key, ...rest] = path;
-    if (typeof key !== 'string') return {...types};
+    if (key === '*' || typeof key !== 'string') return {...types};
     const type = types[key];
     if (type === undefined) continue;
     const projectedType = projectExpressionType(type, [rest]);
-    if (projectedType !== undefined) projected[key] = projectedType;
+    if (projectedType !== undefined) {
+      projected[key] = mergeProjectedExpressionTypes(projected[key], projectedType);
+    }
   }
   return projected;
+}
+
+function mergeProjectedExpressionTypes(
+  left: ExpressionType | undefined,
+  right: ExpressionType,
+): ExpressionType {
+  if (left === undefined) return right;
+  if (typeof left === 'object' && typeof right === 'object') {
+    if (left.kind === 'object' && right.kind === 'object') {
+      return {
+        kind: 'object',
+        fields: mergeProjectedExpressionTypeRecords(left.fields, right.fields),
+      };
+    }
+    if (left.kind === 'list' && right.kind === 'list') {
+      return {kind: 'list', element: mergeProjectedExpressionTypes(left.element, right.element)};
+    }
+  }
+  return right;
+}
+
+function mergeProjectedExpressionTypeRecords(
+  left: Readonly<Record<string, ExpressionType>>,
+  right: Readonly<Record<string, ExpressionType>>,
+): Record<string, ExpressionType> {
+  const merged: Record<string, ExpressionType> = {...left};
+  for (const [key, value] of Object.entries(right)) {
+    merged[key] = mergeProjectedExpressionTypes(merged[key], value);
+  }
+  return merged;
 }
 
 function projectExpressionType(

--- a/libs/api/workflows/src/core/step-config/assemble-run-context.ts
+++ b/libs/api/workflows/src/core/step-config/assemble-run-context.ts
@@ -226,6 +226,7 @@ export function assembleJobActivationContext(
 
 type ListenerPredicateField = 'listener.on' | 'listener.until';
 type ListenerSnapshotRoot = Exclude<WorkflowPredicateContextRoot<ListenerPredicateField>, 'event'>;
+const simpleIdentifierPattern = /^[A-Za-z_][A-Za-z0-9_]*$/;
 
 export interface MatcherSnapshotPlan {
   readonly matcher: JobListeningTrigger;
@@ -296,7 +297,9 @@ function planMatcherFilterSnapshot(
       const analysis = analyzeContextPathAccess(matcher.filter, ['jobs']);
       jobPaths = analysis.references;
       jobsAreBroad =
-        analysis.unknown.length > 0 || analysis.references.some(isBroadJobsPathReference);
+        analysis.unknown.length > 0 ||
+        analysis.references.some(isBroadJobsPathReference) ||
+        analysis.references.some(isWholeElementJobsPathReference);
     }
   } catch {
     return {
@@ -330,6 +333,14 @@ function planMatcherFilterSnapshot(
 function isBroadJobsPathReference(reference: ContextPathReference): boolean {
   const [jobKey] = reference.segments;
   return jobKey === undefined || jobKey === '*' || typeof jobKey !== 'string';
+}
+
+function isWholeElementJobsPathReference(reference: ContextPathReference): boolean {
+  return (
+    reference.root === 'jobs' &&
+    reference.segments.at(-1) === '*' &&
+    simpleIdentifierPattern.test(reference.source.trim())
+  );
 }
 
 function isListenerSnapshotRoot(

--- a/libs/api/workflows/src/core/step-config/assemble-run-context.ts
+++ b/libs/api/workflows/src/core/step-config/assemble-run-context.ts
@@ -1,5 +1,7 @@
 import {
-  analyzeContextRootKeyAccess,
+  analyzeContextPathAccess,
+  type ContextPathReference,
+  type ContextPathSegment,
   type ExpressionType,
   extractExactContextRoots,
   getWorkflowPredicateContextRoots,
@@ -229,6 +231,8 @@ export interface MatcherSnapshotPlan {
   readonly matcher: JobListeningTrigger;
   readonly roots: ReadonlySet<ListenerSnapshotRoot>;
   readonly jobKeys: ReadonlySet<string>;
+  readonly jobPaths: readonly ContextPathReference[];
+  readonly jobsAreBroad: boolean;
 }
 
 export interface ListenerSnapshotPlan {
@@ -236,6 +240,8 @@ export interface ListenerSnapshotPlan {
   readonly until: readonly MatcherSnapshotPlan[];
   readonly roots: ReadonlySet<ListenerSnapshotRoot>;
   readonly jobKeys: ReadonlySet<string>;
+  readonly jobPaths: readonly ContextPathReference[];
+  readonly jobsAreBroad: boolean;
 }
 
 export type ListenerFilterOutputTypes = Record<string, Record<string, ExpressionType>>;
@@ -246,45 +252,84 @@ export function planListenerFilterSnapshots(params: {
 }): ListenerSnapshotPlan {
   const roots = new Set<ListenerSnapshotRoot>();
   const jobKeys = new Set<string>();
-  const on = params.on.map((matcher) =>
-    planMatcherFilterSnapshot('listener.on', matcher, roots, jobKeys),
-  );
+  const on = params.on.map((matcher) => planMatcherFilterSnapshot('listener.on', matcher));
   const until = (params.until ?? []).map((matcher) =>
-    planMatcherFilterSnapshot('listener.until', matcher, roots, jobKeys),
+    planMatcherFilterSnapshot('listener.until', matcher),
   );
-  return {on, until, roots, jobKeys};
+  const plans = [...on, ...until];
+  for (const plan of plans) {
+    for (const root of plan.roots) roots.add(root);
+    for (const key of plan.jobKeys) jobKeys.add(key);
+  }
+  return {
+    on,
+    until,
+    roots,
+    jobKeys,
+    jobPaths: plans.flatMap((plan) => plan.jobPaths),
+    jobsAreBroad: plans.some((plan) => plan.jobsAreBroad),
+  };
 }
 
 function planMatcherFilterSnapshot(
   field: ListenerPredicateField,
   matcher: JobListeningTrigger,
-  allRoots: Set<ListenerSnapshotRoot>,
-  allJobKeys: Set<string>,
 ): MatcherSnapshotPlan {
-  if (matcher.filter === undefined) return {matcher, roots: new Set(), jobKeys: new Set()};
+  if (matcher.filter === undefined) {
+    return {
+      matcher,
+      roots: new Set(),
+      jobKeys: new Set(),
+      jobPaths: [],
+      jobsAreBroad: false,
+    };
+  }
 
   let roots: ListenerSnapshotRoot[];
+  let jobPaths: readonly ContextPathReference[] = [];
+  let jobsAreBroad = false;
   try {
     roots = extractExactContextRoots(matcher.filter).filter((root) =>
       isListenerSnapshotRoot(field, root),
     );
+    if (roots.includes('jobs')) {
+      const analysis = analyzeContextPathAccess(matcher.filter, ['jobs']);
+      jobPaths = analysis.references;
+      jobsAreBroad =
+        analysis.unknown.length > 0 || analysis.references.some(isBroadJobsPathReference);
+    }
   } catch {
-    return {matcher, roots: new Set(), jobKeys: new Set()};
+    return {
+      matcher,
+      roots: new Set(),
+      jobKeys: new Set(),
+      jobPaths: [],
+      jobsAreBroad: false,
+    };
   }
 
-  if (roots.length === 0) return {matcher, roots: new Set(), jobKeys: new Set()};
+  if (roots.length === 0) {
+    return {
+      matcher,
+      roots: new Set(),
+      jobKeys: new Set(),
+      jobPaths: [],
+      jobsAreBroad: false,
+    };
+  }
 
-  const jobKeys =
-    roots.includes('jobs') && matcher.filter !== undefined
-      ? new Set(
-          analyzeContextRootKeyAccess(matcher.filter, ['jobs']).references.map(
-            (reference) => reference.key,
-          ),
-        )
-      : new Set<string>();
-  for (const root of roots) allRoots.add(root);
-  for (const key of jobKeys) allJobKeys.add(key);
-  return {matcher, roots: new Set(roots), jobKeys};
+  const jobKeys = new Set(
+    jobPaths.flatMap((reference) => {
+      const [jobKey] = reference.segments;
+      return typeof jobKey === 'string' && jobKey !== '*' ? [jobKey] : [];
+    }),
+  );
+  return {matcher, roots: new Set(roots), jobKeys, jobPaths, jobsAreBroad};
+}
+
+function isBroadJobsPathReference(reference: ContextPathReference): boolean {
+  const [jobKey] = reference.segments;
+  return jobKey === undefined || jobKey === '*' || typeof jobKey !== 'string';
 }
 
 function isListenerSnapshotRoot(
@@ -349,26 +394,25 @@ function addListenerDirectContext(
     };
   }
   if (params.plan.roots.has('jobs')) {
-    context.jobs = requestedJobsContext(params.dependencyJobs, params.plan.jobKeys);
+    context.jobs = requestedJobsContext(params.dependencyJobs, params.plan);
   }
 }
 
 function requestedJobsContext(
   dependencyJobs: readonly JobContextInput[],
-  jobKeys: ReadonlySet<string>,
+  plan: Pick<ListenerSnapshotPlan, 'jobKeys' | 'jobPaths' | 'jobsAreBroad'>,
 ): Record<string, unknown> {
   // Listener snapshots cross a JSON outbox boundary; their type metadata is persisted separately.
   const options: AssembleJobsContextOptions = {
     skipCelNativeRehydration: true,
     skipTypedOutputRehydration: true,
   };
-  if (jobKeys.size === 0) {
-    return assembleJobsContext(dependencyJobs, options).jobs;
-  }
-
-  const filtered = dependencyJobs.filter(({job}) => jobKeys.has(job.key));
-
-  return assembleJobsContext(filtered, options).jobs;
+  const selected =
+    plan.jobsAreBroad || plan.jobKeys.size === 0
+      ? dependencyJobs
+      : dependencyJobs.filter(({job}) => plan.jobKeys.has(job.key));
+  const assembled = assembleJobsContext(selected, options).jobs;
+  return projectJobsContext(assembled, plan);
 }
 
 export type ListenerTriggerWithSnapshot = JobListeningTrigger & {
@@ -456,7 +500,11 @@ function filterOutputTypesForPlan(
 
   const entries = Object.keys(jobsSnapshot).flatMap((jobKey) => {
     const types = outputTypes[jobKey];
-    return types === undefined ? [] : [[jobKey, {...types}] as const];
+    if (types === undefined) return [];
+    const paths = outputTypePathsForJob(plan, jobKey);
+    if (paths === undefined) return [];
+    const projected = projectOutputTypes(types, paths);
+    return projected === undefined ? [] : [[jobKey, projected] as const];
   });
   return entries.length === 0 ? undefined : Object.fromEntries(entries);
 }
@@ -488,14 +536,203 @@ function jobsSnapshotForPlan(
   }
 
   const jobsContext = context.jobs as Record<string, unknown>;
-  if (plan.jobKeys.size === 0) return {...jobsContext};
+  return projectJobsContext(jobsContext, plan);
+}
 
-  const snapshot = Object.fromEntries(
-    [...plan.jobKeys].flatMap((key) =>
-      Object.hasOwn(jobsContext, key) ? [[key, jobsContext[key]]] : [],
-    ),
+function projectJobsContext(
+  jobsContext: Record<string, unknown>,
+  plan: Pick<MatcherSnapshotPlan, 'jobKeys' | 'jobPaths' | 'jobsAreBroad'>,
+): Record<string, unknown> {
+  if (plan.jobsAreBroad) return {...jobsContext};
+
+  return Object.fromEntries(
+    [...plan.jobKeys].flatMap((jobKey) => {
+      const job = jobsContext[jobKey];
+      if (!Object.hasOwn(jobsContext, jobKey)) return [];
+
+      const paths = plan.jobPaths.flatMap((reference) => {
+        const [referenceJobKey, ...path] = reference.segments;
+        return referenceJobKey === jobKey ? [path] : [];
+      });
+      return [[jobKey, projectJobContext(job, paths)] as const];
+    }),
   );
-  return snapshot;
+}
+
+function projectJobContext(
+  job: unknown,
+  paths: readonly (readonly ContextPathSegment[])[],
+): unknown {
+  if (!isRecord(job)) return job;
+  const compactPaths = compactProjectionPaths(paths);
+  if (compactPaths.some((path) => path.length === 0)) return {...job};
+
+  const projected = projectValueByPaths(job, compactPaths);
+  if (!isRecord(projected)) return projected;
+
+  return {
+    ...(Object.hasOwn(job, 'key') ? {key: job.key} : {}),
+    ...(Object.hasOwn(job, 'status') ? {status: job.status} : {}),
+    ...projected,
+  };
+}
+
+function compactProjectionPaths(
+  paths: readonly (readonly ContextPathSegment[])[],
+): readonly (readonly ContextPathSegment[])[] {
+  const unique = new Map<string, readonly ContextPathSegment[]>();
+  for (const path of paths) unique.set(JSON.stringify(path), path);
+
+  const values = [...unique.values()];
+  return values.filter(
+    (path) =>
+      !values.some(
+        (candidate) =>
+          candidate.length > path.length && isPathPrefix(path, candidate) && path.at(-1) === '*',
+      ),
+  );
+}
+
+function isPathPrefix(prefix: readonly ContextPathSegment[], path: readonly ContextPathSegment[]) {
+  return prefix.every((segment, index) => segment === path[index]);
+}
+
+function projectValueByPaths(
+  value: unknown,
+  paths: readonly (readonly ContextPathSegment[])[],
+): unknown {
+  if (paths.some((path) => path.length === 0)) return value;
+  if (Array.isArray(value)) return projectArrayByPaths(value, paths);
+  if (!isRecord(value)) return value;
+  if (paths.some((path) => path[0] === '*')) return value;
+
+  const projected: Record<string, unknown> = {};
+  for (const path of paths) {
+    const segment = path[0];
+    if (typeof segment !== 'string' || !Object.hasOwn(value, segment)) return {};
+
+    const child = projectValueByPaths(value[segment], [path.slice(1)]);
+    projected[segment] = mergeProjectedValues(projected[segment], child);
+  }
+  return projected;
+}
+
+function projectArrayByPaths(
+  value: readonly unknown[],
+  paths: readonly (readonly ContextPathSegment[])[],
+): unknown[] {
+  const indexedPaths = new Map<number, (readonly ContextPathSegment[])[]>();
+  const elementPaths: (readonly ContextPathSegment[])[] = [];
+  for (const path of paths) {
+    const segment = path[0];
+    const rest = path.slice(1);
+    if (typeof segment === 'number' && Number.isSafeInteger(segment) && segment >= 0) {
+      const pathsForIndex = indexedPaths.get(segment) ?? [];
+      pathsForIndex.push(rest);
+      indexedPaths.set(segment, pathsForIndex);
+      continue;
+    }
+    elementPaths.push(segment === '*' ? rest : path);
+  }
+
+  if (elementPaths.length > 0) {
+    return value.map((element, index) =>
+      projectValueByPaths(element, [...elementPaths, ...(indexedPaths.get(index) ?? [])]),
+    );
+  }
+
+  const lastIndex = Math.max(...indexedPaths.keys(), -1);
+  return value.slice(0, lastIndex + 1).map((element, index) => {
+    const pathsForIndex = indexedPaths.get(index);
+    return pathsForIndex === undefined ? {} : projectValueByPaths(element, pathsForIndex);
+  });
+}
+
+function mergeProjectedValues(left: unknown, right: unknown): unknown {
+  if (left === undefined) return right;
+  if (!isRecord(left) || !isRecord(right)) return right;
+  return {...left, ...right};
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function outputTypePathsForJob(
+  plan: MatcherSnapshotPlan,
+  jobKey: string,
+): readonly (readonly ContextPathSegment[])[] | undefined {
+  if (plan.jobsAreBroad) return [[]];
+
+  const paths: (readonly ContextPathSegment[])[] = [];
+  for (const reference of plan.jobPaths) {
+    const [referenceJobKey, ...jobPath] = reference.segments;
+    if (referenceJobKey !== jobKey) continue;
+    const outputPath = outputPathFromJobPath(jobPath);
+    if (outputPath !== undefined) paths.push(outputPath);
+  }
+  return paths.length === 0 ? undefined : compactProjectionPaths(paths);
+}
+
+function outputPathFromJobPath(
+  path: readonly ContextPathSegment[],
+): readonly ContextPathSegment[] | undefined {
+  const outputsIndex = path.indexOf('outputs');
+  if (outputsIndex === -1) return undefined;
+  return path.slice(outputsIndex + 1);
+}
+
+function projectOutputTypes(
+  types: Record<string, ExpressionType>,
+  paths: readonly (readonly ContextPathSegment[])[],
+): Record<string, ExpressionType> | undefined {
+  if (paths.some((path) => path.length === 0)) return {...types};
+  const projected = projectExpressionTypeRecord(types, paths);
+  return Object.keys(projected).length === 0 ? undefined : projected;
+}
+
+function projectExpressionTypeRecord(
+  types: Record<string, ExpressionType>,
+  paths: readonly (readonly ContextPathSegment[])[],
+): Record<string, ExpressionType> {
+  const projected: Record<string, ExpressionType> = {};
+  for (const path of paths) {
+    const [key, ...rest] = path;
+    if (typeof key !== 'string') return {...types};
+    const type = types[key];
+    if (type === undefined) continue;
+    const projectedType = projectExpressionType(type, [rest]);
+    if (projectedType !== undefined) projected[key] = projectedType;
+  }
+  return projected;
+}
+
+function projectExpressionType(
+  type: ExpressionType,
+  paths: readonly (readonly ContextPathSegment[])[],
+): ExpressionType | undefined {
+  if (paths.some((path) => path.length === 0)) return type;
+  if (typeof type === 'string') return type;
+
+  switch (type.kind) {
+    case 'dyn':
+      return undefined;
+    case 'map':
+      return type;
+    case 'list': {
+      const elementPaths = paths.map((path) => {
+        const segment = path[0];
+        const rest = path.slice(1);
+        return segment === '*' || typeof segment === 'number' ? rest : path;
+      });
+      const element = projectExpressionType(type.element, elementPaths);
+      return element === undefined ? undefined : {kind: 'list', element};
+    }
+    case 'object': {
+      const fields = projectExpressionTypeRecord(type.fields, paths);
+      return {kind: 'object', fields};
+    }
+  }
 }
 
 function assembleJobContext(

--- a/libs/api/workflows/src/core/step-config/assemble-run-context.ts
+++ b/libs/api/workflows/src/core/step-config/assemble-run-context.ts
@@ -338,6 +338,7 @@ function isBroadJobsPathReference(reference: ContextPathReference): boolean {
 function isWholeElementJobsPathReference(reference: ContextPathReference): boolean {
   return (
     reference.root === 'jobs' &&
+    reference.segments.at(-2) === 'executions' &&
     reference.segments.at(-1) === '*' &&
     simpleIdentifierPattern.test(reference.source.trim())
   );

--- a/libs/api/workflows/src/core/step-config/assemble-run-context.ts
+++ b/libs/api/workflows/src/core/step-config/assemble-run-context.ts
@@ -226,7 +226,6 @@ export function assembleJobActivationContext(
 
 type ListenerPredicateField = 'listener.on' | 'listener.until';
 type ListenerSnapshotRoot = Exclude<WorkflowPredicateContextRoot<ListenerPredicateField>, 'event'>;
-const simpleIdentifierPattern = /^[A-Za-z_][A-Za-z0-9_]*$/;
 
 export interface MatcherSnapshotPlan {
   readonly matcher: JobListeningTrigger;
@@ -297,9 +296,7 @@ function planMatcherFilterSnapshot(
       const analysis = analyzeContextPathAccess(matcher.filter, ['jobs']);
       jobPaths = analysis.references;
       jobsAreBroad =
-        analysis.unknown.length > 0 ||
-        analysis.references.some(isBroadJobsPathReference) ||
-        analysis.references.some(isWholeElementJobsPathReference);
+        analysis.unknown.length > 0 || analysis.references.some(isBroadJobsPathReference);
     }
   } catch {
     return {
@@ -333,15 +330,6 @@ function planMatcherFilterSnapshot(
 function isBroadJobsPathReference(reference: ContextPathReference): boolean {
   const [jobKey] = reference.segments;
   return jobKey === undefined || jobKey === '*' || typeof jobKey !== 'string';
-}
-
-function isWholeElementJobsPathReference(reference: ContextPathReference): boolean {
-  return (
-    reference.root === 'jobs' &&
-    reference.segments.at(-2) === 'executions' &&
-    reference.segments.at(-1) === '*' &&
-    simpleIdentifierPattern.test(reference.source.trim())
-  );
 }
 
 function isListenerSnapshotRoot(
@@ -566,7 +554,11 @@ function projectJobsContext(
         const [referenceJobKey, ...path] = reference.segments;
         return referenceJobKey === jobKey ? [path] : [];
       });
-      return [[jobKey, projectJobContext(job, paths)] as const];
+      const wholeElementPaths = plan.jobPaths.flatMap((reference) => {
+        const [referenceJobKey, ...path] = reference.segments;
+        return referenceJobKey === jobKey && reference.wholeElement === true ? [path] : [];
+      });
+      return [[jobKey, projectJobContext(job, paths, wholeElementPaths)] as const];
     }),
   );
 }
@@ -574,9 +566,10 @@ function projectJobsContext(
 function projectJobContext(
   job: unknown,
   paths: readonly (readonly ContextPathSegment[])[],
+  wholeElementPaths: readonly (readonly ContextPathSegment[])[] = [],
 ): unknown {
   if (!isRecord(job)) return job;
-  const compactPaths = compactProjectionPaths(paths);
+  const compactPaths = compactProjectionPaths(paths, wholeElementPaths);
   if (compactPaths.some((path) => path.length === 0)) return {...job};
 
   const projected = projectValueByPaths(job, compactPaths);
@@ -591,13 +584,16 @@ function projectJobContext(
 
 function compactProjectionPaths(
   paths: readonly (readonly ContextPathSegment[])[],
+  preservedPaths: readonly (readonly ContextPathSegment[])[] = [],
 ): readonly (readonly ContextPathSegment[])[] {
   const unique = new Map<string, readonly ContextPathSegment[]>();
   for (const path of paths) unique.set(JSON.stringify(path), path);
 
   const values = [...unique.values()];
+  const preserved = new Set(preservedPaths.map((path) => JSON.stringify(path)));
   return values.filter(
     (path) =>
+      preserved.has(JSON.stringify(path)) ||
       !values.some(
         (candidate) =>
           candidate.length > path.length && isPathPrefix(path, candidate) && path.at(-1) === '*',
@@ -624,7 +620,7 @@ function projectValueByPaths(
     if (typeof segment !== 'string' || !Object.hasOwn(value, segment)) continue;
 
     const child = projectValueByPaths(value[segment], [path.slice(1)]);
-    projected[segment] = mergeProjectedValues(projected[segment], child);
+    setOwnRecordValue(projected, segment, mergeProjectedValues(projected[segment], child));
   }
   return projected;
 }
@@ -653,7 +649,7 @@ function projectArrayByPaths(
     );
   }
 
-  const lastIndex = Math.max(...indexedPaths.keys(), -1);
+  const lastIndex = Math.min(Math.max(...indexedPaths.keys(), -1), value.length - 1);
   return value.slice(0, lastIndex + 1).map((element, index) => {
     const pathsForIndex = indexedPaths.get(index);
     return pathsForIndex === undefined ? {} : projectValueByPaths(element, pathsForIndex);
@@ -672,13 +668,22 @@ function mergeProjectedValues(left: unknown, right: unknown): unknown {
 
   const merged: Record<string, unknown> = {...left};
   for (const [key, value] of Object.entries(right)) {
-    merged[key] = mergeProjectedValues(merged[key], value);
+    setOwnRecordValue(merged, key, mergeProjectedValues(merged[key], value));
   }
   return merged;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function setOwnRecordValue<T>(record: Record<string, T>, key: string, value: T): void {
+  Object.defineProperty(record, key, {
+    value,
+    enumerable: true,
+    writable: true,
+    configurable: true,
+  });
 }
 
 function outputTypePathsForJob(
@@ -688,13 +693,17 @@ function outputTypePathsForJob(
   if (plan.jobsAreBroad) return [[]];
 
   const paths: (readonly ContextPathSegment[])[] = [];
+  const wholeElementPaths: (readonly ContextPathSegment[])[] = [];
   for (const reference of plan.jobPaths) {
     const [referenceJobKey, ...jobPath] = reference.segments;
     if (referenceJobKey !== jobKey) continue;
     const outputPath = outputPathFromJobPath(jobPath);
-    if (outputPath !== undefined) paths.push(outputPath);
+    if (outputPath !== undefined) {
+      paths.push(outputPath);
+      if (reference.wholeElement === true) wholeElementPaths.push(outputPath);
+    }
   }
-  return paths.length === 0 ? undefined : compactProjectionPaths(paths);
+  return paths.length === 0 ? undefined : compactProjectionPaths(paths, wholeElementPaths);
 }
 
 function outputPathFromJobPath(
@@ -726,7 +735,11 @@ function projectExpressionTypeRecord(
     if (type === undefined) continue;
     const projectedType = projectExpressionType(type, [rest]);
     if (projectedType !== undefined) {
-      projected[key] = mergeProjectedExpressionTypes(projected[key], projectedType);
+      setOwnRecordValue(
+        projected,
+        key,
+        mergeProjectedExpressionTypes(projected[key], projectedType),
+      );
     }
   }
   return projected;
@@ -757,7 +770,7 @@ function mergeProjectedExpressionTypeRecords(
 ): Record<string, ExpressionType> {
   const merged: Record<string, ExpressionType> = {...left};
   for (const [key, value] of Object.entries(right)) {
-    merged[key] = mergeProjectedExpressionTypes(merged[key], value);
+    setOwnRecordValue(merged, key, mergeProjectedExpressionTypes(merged[key], value));
   }
   return merged;
 }

--- a/libs/api/workflows/src/core/step-config/assemble-run-context.ts
+++ b/libs/api/workflows/src/core/step-config/assemble-run-context.ts
@@ -650,6 +650,7 @@ function projectArrayByPaths(
 
 function mergeProjectedValues(left: unknown, right: unknown): unknown {
   if (left === undefined) return right;
+  if (right === undefined) return left;
   if (Array.isArray(left) && Array.isArray(right)) {
     return Array.from({length: Math.max(left.length, right.length)}, (_, index) =>
       mergeProjectedValues(left[index], right[index]),

--- a/libs/api/workflows/src/core/step-config/assemble-run-context.ts
+++ b/libs/api/workflows/src/core/step-config/assemble-run-context.ts
@@ -694,15 +694,20 @@ function outputTypePathsForJob(
 
   const paths: (readonly ContextPathSegment[])[] = [];
   const wholeElementPaths: (readonly ContextPathSegment[])[] = [];
+  let hasWholeElementWithoutOutputPath = false;
   for (const reference of plan.jobPaths) {
     const [referenceJobKey, ...jobPath] = reference.segments;
     if (referenceJobKey !== jobKey) continue;
     const outputPath = outputPathFromJobPath(jobPath);
+    if (reference.wholeElement === true && outputPath === undefined) {
+      hasWholeElementWithoutOutputPath = true;
+    }
     if (outputPath !== undefined) {
       paths.push(outputPath);
       if (reference.wholeElement === true) wholeElementPaths.push(outputPath);
     }
   }
+  if (hasWholeElementWithoutOutputPath) return [[]];
   return paths.length === 0 ? undefined : compactProjectionPaths(paths, wholeElementPaths);
 }
 

--- a/libs/api/workflows/src/core/step-config/assemble-run-context.ts
+++ b/libs/api/workflows/src/core/step-config/assemble-run-context.ts
@@ -694,21 +694,39 @@ function outputTypePathsForJob(
 
   const paths: (readonly ContextPathSegment[])[] = [];
   const wholeElementPaths: (readonly ContextPathSegment[])[] = [];
-  let hasWholeElementWithoutOutputPath = false;
+  const jobPaths: (readonly ContextPathSegment[])[] = [];
+  const wholeElementJobPaths: (readonly ContextPathSegment[])[] = [];
   for (const reference of plan.jobPaths) {
     const [referenceJobKey, ...jobPath] = reference.segments;
     if (referenceJobKey !== jobKey) continue;
+    jobPaths.push(jobPath);
     const outputPath = outputPathFromJobPath(jobPath);
-    if (reference.wholeElement === true && outputPath === undefined) {
-      hasWholeElementWithoutOutputPath = true;
-    }
+    if (reference.wholeElement === true) wholeElementJobPaths.push(jobPath);
     if (outputPath !== undefined) {
       paths.push(outputPath);
       if (reference.wholeElement === true) wholeElementPaths.push(outputPath);
     }
   }
-  if (hasWholeElementWithoutOutputPath) return [[]];
+  const compactJobPaths = compactProjectionPaths(jobPaths, wholeElementJobPaths);
+  if (
+    compactJobPaths.some(
+      (path) => outputPathFromJobPath(path) === undefined && retainsWholeExecutionElements(path),
+    )
+  ) {
+    return [[]];
+  }
   return paths.length === 0 ? undefined : compactProjectionPaths(paths, wholeElementPaths);
+}
+
+function retainsWholeExecutionElements(path: readonly ContextPathSegment[]): boolean {
+  if (path.length === 0) return true;
+  if (path[0] !== 'executions') return false;
+
+  const elementPath = path.slice(1);
+  return (
+    elementPath.length === 0 ||
+    (elementPath.length === 1 && (elementPath[0] === '*' || typeof elementPath[0] === 'number'))
+  );
 }
 
 function outputPathFromJobPath(

--- a/libs/api/workflows/src/core/step-config/assemble-run-context.ts
+++ b/libs/api/workflows/src/core/step-config/assemble-run-context.ts
@@ -1,5 +1,6 @@
 import {
   analyzeContextPathAccess,
+  type ContextPathLiteralSegment,
   type ContextPathReference,
   type ContextPathSegment,
   type ExpressionType,
@@ -321,7 +322,9 @@ function planMatcherFilterSnapshot(
   const jobKeys = new Set(
     jobPaths.flatMap((reference) => {
       const [jobKey] = reference.segments;
-      return typeof jobKey === 'string' && jobKey !== '*' ? [jobKey] : [];
+      if (jobKey === undefined || jobKey === '*') return [];
+      const jobKeyValue = contextPathSegmentValue(jobKey);
+      return typeof jobKeyValue === 'string' ? [jobKeyValue] : [];
     }),
   );
   return {matcher, roots: new Set(roots), jobKeys, jobPaths, jobsAreBroad};
@@ -329,7 +332,9 @@ function planMatcherFilterSnapshot(
 
 function isBroadJobsPathReference(reference: ContextPathReference): boolean {
   const [jobKey] = reference.segments;
-  return jobKey === undefined || jobKey === '*' || typeof jobKey !== 'string';
+  return (
+    jobKey === undefined || jobKey === '*' || typeof contextPathSegmentValue(jobKey) !== 'string'
+  );
 }
 
 function isListenerSnapshotRoot(
@@ -552,11 +557,17 @@ function projectJobsContext(
 
       const paths = plan.jobPaths.flatMap((reference) => {
         const [referenceJobKey, ...path] = reference.segments;
-        return referenceJobKey === jobKey ? [path] : [];
+        return referenceJobKey !== undefined && contextPathSegmentValue(referenceJobKey) === jobKey
+          ? [path]
+          : [];
       });
       const wholeElementPaths = plan.jobPaths.flatMap((reference) => {
         const [referenceJobKey, ...path] = reference.segments;
-        return referenceJobKey === jobKey && reference.wholeElement === true ? [path] : [];
+        return referenceJobKey !== undefined &&
+          contextPathSegmentValue(referenceJobKey) === jobKey &&
+          reference.wholeElement === true
+          ? [path]
+          : [];
       });
       return [[jobKey, projectJobContext(job, paths, wholeElementPaths)] as const];
     }),
@@ -602,7 +613,7 @@ function compactProjectionPaths(
 }
 
 function isPathPrefix(prefix: readonly ContextPathSegment[], path: readonly ContextPathSegment[]) {
-  return prefix.every((segment, index) => segment === path[index]);
+  return prefix.every((segment, index) => sameContextPathSegment(segment, path[index]));
 }
 
 function projectValueByPaths(
@@ -617,10 +628,11 @@ function projectValueByPaths(
   const projected: Record<string, unknown> = {};
   for (const path of paths) {
     const segment = path[0];
-    if (typeof segment !== 'string' || !Object.hasOwn(value, segment)) continue;
+    const key = segment === undefined ? undefined : contextPathSegmentValue(segment);
+    if (typeof key !== 'string' || !Object.hasOwn(value, key)) continue;
 
-    const child = projectValueByPaths(value[segment], [path.slice(1)]);
-    setOwnRecordValue(projected, segment, mergeProjectedValues(projected[segment], child));
+    const child = projectValueByPaths(value[key], [path.slice(1)]);
+    setOwnRecordValue(projected, key, mergeProjectedValues(projected[key], child));
   }
   return projected;
 }
@@ -698,7 +710,9 @@ function outputTypePathsForJob(
   const wholeElementJobPaths: (readonly ContextPathSegment[])[] = [];
   for (const reference of plan.jobPaths) {
     const [referenceJobKey, ...jobPath] = reference.segments;
-    if (referenceJobKey !== jobKey) continue;
+    if (referenceJobKey === undefined || contextPathSegmentValue(referenceJobKey) !== jobKey) {
+      continue;
+    }
     jobPaths.push(jobPath);
     const outputPath = outputPathFromJobPath(jobPath);
     if (reference.wholeElement === true) wholeElementJobPaths.push(jobPath);
@@ -753,19 +767,46 @@ function projectExpressionTypeRecord(
   const projected: Record<string, ExpressionType> = {};
   for (const path of paths) {
     const [key, ...rest] = path;
-    if (key === '*' || typeof key !== 'string') return {...types};
-    const type = types[key];
+    if (key === '*') return {...types};
+    const keyValue = key === undefined ? undefined : contextPathSegmentValue(key);
+    if (typeof keyValue !== 'string') return {...types};
+    const type = types[keyValue];
     if (type === undefined) continue;
     const projectedType = projectExpressionType(type, [rest]);
     if (projectedType !== undefined) {
       setOwnRecordValue(
         projected,
-        key,
-        mergeProjectedExpressionTypes(projected[key], projectedType),
+        keyValue,
+        mergeProjectedExpressionTypes(projected[keyValue], projectedType),
       );
     }
   }
   return projected;
+}
+
+function contextPathSegmentValue(segment: ContextPathSegment): string | number | undefined {
+  if (typeof segment === 'string' || typeof segment === 'number') return segment;
+  if (isContextPathLiteralSegment(segment)) return segment.value;
+  return undefined;
+}
+
+function isContextPathLiteralSegment(
+  segment: ContextPathSegment,
+): segment is ContextPathLiteralSegment {
+  return typeof segment === 'object' && segment.kind === 'literal';
+}
+
+function sameContextPathSegment(
+  left: ContextPathSegment,
+  right: ContextPathSegment | undefined,
+): boolean {
+  if (left === right) return true;
+  return (
+    isContextPathLiteralSegment(left) &&
+    right !== undefined &&
+    isContextPathLiteralSegment(right) &&
+    left.value === right.value
+  );
 }
 
 function mergeProjectedExpressionTypes(

--- a/libs/api/workflows/src/db/job-listeners.test.ts
+++ b/libs/api/workflows/src/db/job-listeners.test.ts
@@ -425,6 +425,39 @@ describe('activateJobListener', () => {
     ).toHaveLength(0);
   });
 
+  it('rejects aggregate filter snapshots before writing activation', async () => {
+    const job = await createListenerWithDependencies({
+      on: [
+        {source: 'github', event: 'pull_request', filter: 'jobs.build'},
+        {source: 'github', event: 'pull_request', filter: 'jobs.build'},
+      ],
+    });
+    await db()
+      .update(jobs)
+      .set({outputs: {payload: 'x'.repeat(Math.floor(MAX_LISTENER_FILTER_SNAPSHOT_BYTES / 2))}})
+      .where(eq(jobs.id, job.buildId));
+
+    await expect(
+      activateJobListener({jobId: job.id, expectedVersion: job.version}),
+    ).rejects.toMatchObject({
+      name: 'WorkflowExecutionPayloadTooLargeError',
+      field: 'filter_snapshot',
+      limitBytes: MAX_LISTENER_FILTER_SNAPSHOT_BYTES,
+      measuredBytes: expect.any(Number),
+      overshootBytes: expect.any(Number),
+    });
+
+    const stored = await readJob(job.id);
+    expect(stored).toMatchObject({status: 'pending', listenerStatus: 'inactive'});
+    const activatedEvents = await db()
+      .select()
+      .from(workflowsOutbox)
+      .where(eq(workflowsOutbox.eventType, WORKFLOWS_JOB_ACTIVATED));
+    expect(
+      activatedEvents.filter((row) => (row.payload as Record<string, unknown>).jobId === job.id),
+    ).toHaveLength(0);
+  });
+
   it('snapshots an empty jobs root when referenced job keys are absent', async () => {
     const job = await createListenerWithDependencies({
       on: [

--- a/libs/api/workflows/src/db/job-listeners.test.ts
+++ b/libs/api/workflows/src/db/job-listeners.test.ts
@@ -1,4 +1,5 @@
 import {
+  MAX_LISTENER_FILTER_SNAPSHOT_BYTES,
   WORKFLOW_DIAGNOSTIC_TRIGGER_EVENTS_MAX_BYTES,
   WORKFLOWS_JOB_ACTIVATED,
   type WorkflowsJobActivatedEventDto,
@@ -225,7 +226,7 @@ async function createListenerWithDependencies(params: {
 
   const updated = await readJob(listener.id);
   if (!updated) throw new Error('Expected listener fixture job');
-  return updated;
+  return {...updated, buildId: build.id};
 }
 
 function template(source: string): string {
@@ -385,12 +386,43 @@ describe('activateJobListener', () => {
         build: expect.objectContaining({
           status: 'succeeded',
           outputs: {pr_number: 42},
-          executions: expect.any(Array),
         }),
       },
     });
     expect(snapshot).not.toHaveProperty('event');
-    expect(snapshot?.jobs).not.toHaveProperty('review');
+    const jobs = snapshot?.jobs as Record<string, unknown> | undefined;
+    expect(jobs).not.toHaveProperty('review');
+    expect(jobs?.build).not.toHaveProperty('executions');
+  });
+
+  it('rejects an oversized filter snapshot before writing activation', async () => {
+    const job = await createListenerWithDependencies({
+      on: [{source: 'github', event: 'pull_request', filter: 'jobs.build'}],
+    });
+    await db()
+      .update(jobs)
+      .set({outputs: {payload: 'x'.repeat(MAX_LISTENER_FILTER_SNAPSHOT_BYTES)}})
+      .where(eq(jobs.id, job.buildId));
+
+    await expect(
+      activateJobListener({jobId: job.id, expectedVersion: job.version}),
+    ).rejects.toMatchObject({
+      name: 'WorkflowExecutionPayloadTooLargeError',
+      field: 'filter_snapshot',
+      limitBytes: MAX_LISTENER_FILTER_SNAPSHOT_BYTES,
+      measuredBytes: expect.any(Number),
+      overshootBytes: expect.any(Number),
+    });
+
+    const stored = await readJob(job.id);
+    expect(stored).toMatchObject({status: 'pending', listenerStatus: 'inactive'});
+    const activatedEvents = await db()
+      .select()
+      .from(workflowsOutbox)
+      .where(eq(workflowsOutbox.eventType, WORKFLOWS_JOB_ACTIVATED));
+    expect(
+      activatedEvents.filter((row) => (row.payload as Record<string, unknown>).jobId === job.id),
+    ).toHaveLength(0);
   });
 
   it('snapshots an empty jobs root when referenced job keys are absent', async () => {

--- a/libs/api/workflows/src/db/job-listeners.test.ts
+++ b/libs/api/workflows/src/db/job-listeners.test.ts
@@ -175,10 +175,11 @@ async function createInactiveListeningJobWithMatchers(params: {
 
 async function createListenerWithDependencies(params: {
   readonly on: readonly JobListeningTrigger[];
+  readonly inputs?: Record<string, unknown>;
 }) {
   const run = await workflowRunFactory.create(
     {
-      inputs: {environment: 'prod'},
+      inputs: {environment: 'prod', ...(params.inputs ?? {})},
       triggerPayload: {
         source: 'github',
         event: 'pull_request',
@@ -393,6 +394,33 @@ describe('activateJobListener', () => {
     const jobs = snapshot?.jobs as Record<string, unknown> | undefined;
     expect(jobs).not.toHaveProperty('review');
     expect(jobs?.build).not.toHaveProperty('executions');
+  });
+
+  it('fetches dependency jobs for a broad filter without literal job keys', async () => {
+    const job = await createListenerWithDependencies({
+      inputs: {target: 'build'},
+      on: [
+        {
+          source: 'github',
+          event: 'pull_request',
+          filter: 'jobs[inputs.target].outputs.pr_number == event.pull_request.number',
+        },
+      ],
+    });
+
+    await activateJobListener({jobId: job.id, expectedVersion: job.version});
+
+    const payload = await activatedPayload(job.id);
+    expectListeningPayload(payload);
+    expect(payload.on[0]?.filter_snapshot).toEqual({
+      inputs: {environment: 'prod', target: 'build'},
+      jobs: expect.objectContaining({
+        build: expect.objectContaining({
+          status: 'succeeded',
+          outputs: {pr_number: 42},
+        }),
+      }),
+    });
   });
 
   it('rejects an oversized filter snapshot before writing activation', async () => {

--- a/libs/api/workflows/src/db/job-listeners.test.ts
+++ b/libs/api/workflows/src/db/job-listeners.test.ts
@@ -175,6 +175,7 @@ async function createInactiveListeningJobWithMatchers(params: {
 
 async function createListenerWithDependencies(params: {
   readonly on: readonly JobListeningTrigger[];
+  readonly until?: readonly JobListeningTrigger[] | null;
   readonly inputs?: Record<string, unknown>;
 }) {
   const run = await workflowRunFactory.create(
@@ -220,7 +221,7 @@ async function createListenerWithDependencies(params: {
       status: 'pending',
       listenerStatus: 'inactive',
       listeningOn: [...params.on],
-      listeningUntil: null,
+      listeningUntil: params.until ? [...params.until] : null,
     })
     .where(eq(jobs.id, listener.id));
   await db().delete(jobExecutions).where(eq(jobExecutions.jobId, listener.id));
@@ -463,6 +464,37 @@ describe('activateJobListener', () => {
     await db()
       .update(jobs)
       .set({outputs: {payload: 'x'.repeat(Math.floor(MAX_LISTENER_FILTER_SNAPSHOT_BYTES / 2))}})
+      .where(eq(jobs.id, job.buildId));
+
+    await expect(
+      activateJobListener({jobId: job.id, expectedVersion: job.version}),
+    ).rejects.toMatchObject({
+      name: 'WorkflowExecutionPayloadTooLargeError',
+      field: 'filter_snapshot',
+      limitBytes: MAX_LISTENER_FILTER_SNAPSHOT_BYTES,
+      measuredBytes: expect.any(Number),
+      overshootBytes: expect.any(Number),
+    });
+
+    const stored = await readJob(job.id);
+    expect(stored).toMatchObject({status: 'pending', listenerStatus: 'inactive'});
+    const activatedEvents = await db()
+      .select()
+      .from(workflowsOutbox)
+      .where(eq(workflowsOutbox.eventType, WORKFLOWS_JOB_ACTIVATED));
+    expect(
+      activatedEvents.filter((row) => (row.payload as Record<string, unknown>).jobId === job.id),
+    ).toHaveLength(0);
+  });
+
+  it('rejects oversized until filter snapshots before writing activation', async () => {
+    const job = await createListenerWithDependencies({
+      on: [],
+      until: [{source: 'github', event: 'pull_request', filter: 'jobs.build'}],
+    });
+    await db()
+      .update(jobs)
+      .set({outputs: {payload: 'x'.repeat(MAX_LISTENER_FILTER_SNAPSHOT_BYTES)}})
       .where(eq(jobs.id, job.buildId));
 
     await expect(

--- a/libs/api/workflows/src/db/job-listeners.ts
+++ b/libs/api/workflows/src/db/job-listeners.ts
@@ -271,8 +271,11 @@ async function writeListenerActivatedEvent(
           snapshotContext,
           listenerOutputTypes,
         );
-  for (const matcher of [...on, ...(until ?? [])]) {
-    assertWorkflowExecutionPayloadSize('filter_snapshot', matcher.filter_snapshot);
+  const filterSnapshots = [...on, ...(until ?? [])].flatMap(({filter_snapshot}) =>
+    filter_snapshot === undefined ? [] : [filter_snapshot],
+  );
+  if (filterSnapshots.length > 0) {
+    assertWorkflowExecutionPayloadSize('filter_snapshot', filterSnapshots);
   }
 
   await writeWorkflowsOutboxEvent(tx, {

--- a/libs/api/workflows/src/db/job-listeners.ts
+++ b/libs/api/workflows/src/db/job-listeners.ts
@@ -245,7 +245,9 @@ async function writeListenerActivatedEvent(
   };
   const snapshotPlan = planListenerFilterSnapshots(matchers);
   const dependencyJobs =
-    snapshotPlan.jobKeys.size === 0 ? [] : await getDirectDependencyJobContexts(jobId, tx);
+    snapshotPlan.jobKeys.size === 0 && !snapshotPlan.jobsAreBroad
+      ? []
+      : await getDirectDependencyJobContexts(jobId, tx);
   const snapshotContext = assembleListenerSnapshotContext({
     job: toJob(target.job),
     run: toWorkflowRun(target.run),
@@ -256,6 +258,22 @@ async function writeListenerActivatedEvent(
     dependencyJobs,
   });
   const listenerOutputTypes = listenerFilterOutputTypesForJobs(dependencyJobs);
+  const on = applyActivatedListenerFilterSnapshots(
+    snapshotPlan.on,
+    snapshotContext,
+    listenerOutputTypes,
+  );
+  const until =
+    matchers.until === null
+      ? null
+      : applyActivatedListenerFilterSnapshots(
+          snapshotPlan.until,
+          snapshotContext,
+          listenerOutputTypes,
+        );
+  for (const matcher of [...on, ...(until ?? [])]) {
+    assertWorkflowExecutionPayloadSize('filter_snapshot', matcher.filter_snapshot);
+  }
 
   await writeWorkflowsOutboxEvent(tx, {
     type: WORKFLOWS_JOB_ACTIVATED,
@@ -264,19 +282,8 @@ async function writeListenerActivatedEvent(
       workflowRunId: target.run.id,
       workspaceId: target.run.workspaceId,
       mode: 'listening',
-      on: applyActivatedListenerFilterSnapshots(
-        snapshotPlan.on,
-        snapshotContext,
-        listenerOutputTypes,
-      ),
-      until:
-        matchers.until === null
-          ? null
-          : applyActivatedListenerFilterSnapshots(
-              snapshotPlan.until,
-              snapshotContext,
-              listenerOutputTypes,
-            ),
+      on,
+      until,
     },
   });
 }

--- a/libs/api/workflows/src/db/job-listeners.ts
+++ b/libs/api/workflows/src/db/job-listeners.ts
@@ -329,7 +329,7 @@ function logOversizedListenerFilterSnapshots(params: {
           matcherIndex,
           matcherKind,
         },
-        'Listener filter snapshot exceeded the aggregate execution byte limit',
+        'Listener filter snapshot contributed to aggregate execution byte limit overflow',
       );
     }
   }

--- a/libs/api/workflows/src/db/job-listeners.ts
+++ b/libs/api/workflows/src/db/job-listeners.ts
@@ -16,6 +16,7 @@ import {
 } from '#core/agent-tools.js';
 import {
   assertWorkflowExecutionPayloadSize,
+  executionPayloadValueByteLength,
   observeWorkflowDiagnosticSize,
 } from '#core/diagnostics.js';
 import {isJobTerminal, type JobStatus, type ResolutionReason} from '#core/entities/job.js';
@@ -275,7 +276,20 @@ async function writeListenerActivatedEvent(
     filter_snapshot === undefined ? [] : [filter_snapshot],
   );
   if (filterSnapshots.length > 0) {
-    assertWorkflowExecutionPayloadSize('filter_snapshot', filterSnapshots);
+    try {
+      assertWorkflowExecutionPayloadSize('filter_snapshot', filterSnapshots);
+    } catch (error) {
+      if (error instanceof WorkflowExecutionPayloadTooLargeError) {
+        logOversizedListenerFilterSnapshots({
+          jobId,
+          jobKey: target.job.key,
+          on,
+          until: until ?? [],
+          error,
+        });
+      }
+      throw error;
+    }
   }
 
   await writeWorkflowsOutboxEvent(tx, {
@@ -289,6 +303,36 @@ async function writeListenerActivatedEvent(
       until,
     },
   });
+}
+
+function logOversizedListenerFilterSnapshots(params: {
+  readonly jobId: string;
+  readonly jobKey: string;
+  readonly on: readonly ListenerTriggerWithSnapshot[];
+  readonly until: readonly ListenerTriggerWithSnapshot[];
+  readonly error: WorkflowExecutionPayloadTooLargeError;
+}): void {
+  for (const [matcherKind, matchers] of [
+    ['on', params.on] as const,
+    ['until', params.until] as const,
+  ]) {
+    for (const [matcherIndex, matcher] of matchers.entries()) {
+      if (matcher.filter_snapshot === undefined) continue;
+      logger().warn(
+        {
+          aggregateMeasuredBytes: params.error.measuredBytes,
+          filterSource: matcher.filter?.slice(0, 256),
+          jobId: params.jobId,
+          jobKey: params.jobKey,
+          limitBytes: params.error.limitBytes,
+          measuredBytes: executionPayloadValueByteLength(matcher.filter_snapshot),
+          matcherIndex,
+          matcherKind,
+        },
+        'Listener filter snapshot exceeded the aggregate execution byte limit',
+      );
+    }
+  }
 }
 
 export type DrainListenerEventsResult =

--- a/libs/api/workflows/src/metrics/instance.test.ts
+++ b/libs/api/workflows/src/metrics/instance.test.ts
@@ -1,3 +1,5 @@
+import {MAX_LISTENER_FILTER_SNAPSHOT_BYTES} from '@shipfox/api-workflows-dto';
+
 const metricMocks = vi.hoisted(() => {
   const metrics = new Map<
     string,
@@ -160,7 +162,14 @@ describe('workflow payload metrics', () => {
         unit: 'By',
         advice: {
           explicitBucketBoundaries: [
-            1_024, 10_240, 65_536, 256_000, 512_000, 524_288, 868_928, 1_000_000,
+            1_024,
+            10_240,
+            65_536,
+            256_000,
+            512_000,
+            MAX_LISTENER_FILTER_SNAPSHOT_BYTES,
+            868_928,
+            1_000_000,
           ],
         },
       }),

--- a/libs/api/workflows/src/metrics/instance.test.ts
+++ b/libs/api/workflows/src/metrics/instance.test.ts
@@ -159,7 +159,9 @@ describe('workflow payload metrics', () => {
       expect.objectContaining({
         unit: 'By',
         advice: {
-          explicitBucketBoundaries: [1_024, 10_240, 65_536, 256_000, 512_000, 868_928, 1_000_000],
+          explicitBucketBoundaries: [
+            1_024, 10_240, 65_536, 256_000, 512_000, 524_288, 868_928, 1_000_000,
+          ],
         },
       }),
     ]);

--- a/libs/api/workflows/src/metrics/instance.ts
+++ b/libs/api/workflows/src/metrics/instance.ts
@@ -145,7 +145,9 @@ const executionPayloadBytes = meter.createHistogram<{
   description: 'Workflow execution payload sizes by bounded owning field',
   unit: 'By',
   advice: {
-    explicitBucketBoundaries: [1_024, 10_240, 65_536, 256_000, 512_000, 868_928, 1_000_000],
+    explicitBucketBoundaries: [
+      1_024, 10_240, 65_536, 256_000, 512_000, 524_288, 868_928, 1_000_000,
+    ],
   },
 });
 

--- a/libs/api/workflows/src/metrics/instance.ts
+++ b/libs/api/workflows/src/metrics/instance.ts
@@ -1,6 +1,7 @@
-import type {
-  WorkflowDiagnosticFieldDto,
-  WorkflowExecutionPayloadFieldDto,
+import {
+  MAX_LISTENER_FILTER_SNAPSHOT_BYTES,
+  type WorkflowDiagnosticFieldDto,
+  type WorkflowExecutionPayloadFieldDto,
 } from '@shipfox/api-workflows-dto';
 import {instanceMetrics} from '@shipfox/node-opentelemetry';
 import type {JobStatus, ResolutionReason} from '#core/entities/job.js';
@@ -146,7 +147,14 @@ const executionPayloadBytes = meter.createHistogram<{
   unit: 'By',
   advice: {
     explicitBucketBoundaries: [
-      1_024, 10_240, 65_536, 256_000, 512_000, 524_288, 868_928, 1_000_000,
+      1_024,
+      10_240,
+      65_536,
+      256_000,
+      512_000,
+      MAX_LISTENER_FILTER_SNAPSHOT_BYTES,
+      868_928,
+      1_000_000,
     ],
   },
 });

--- a/libs/api/workflows/src/temporal/activities/orchestration-activities.test.ts
+++ b/libs/api/workflows/src/temporal/activities/orchestration-activities.test.ts
@@ -1,14 +1,19 @@
+import {MAX_LISTENER_FILTER_SNAPSHOT_BYTES} from '@shipfox/api-workflows-dto';
 import {ApplicationFailure} from '@temporalio/common';
+import {eq} from 'drizzle-orm';
+import {db} from '#db/db.js';
 import {
   createWorkflowRun,
   getJobExecutionsByJobId,
   getJobsByWorkflowRunId,
   updateJobExecutionStatus,
 } from '#db/index.js';
+import {jobs} from '#db/schema/jobs.js';
 import {createTestSecretsClient} from '#test/fixtures/secrets-inter-module.js';
 import {stripSetupStep} from '#test/fixtures/strip-setup-step.js';
 import {workflowModel} from '#test/index.js';
 import {
+  activateJobListenerActivity,
   queueJobExecutionActivity,
   resolveLeaseExpiredJobExecutionActivity,
   setJobStatus,
@@ -87,6 +92,53 @@ describe('queueJobExecutionActivity', () => {
 
     expect(error).toBeInstanceOf(ApplicationFailure);
     expect((error as ApplicationFailure).nonRetryable).toBe(true);
+  });
+});
+
+describe('activateJobListenerActivity', () => {
+  test('classifies an oversized filter snapshot as non-retryable', async () => {
+    const run = await createWorkflowRun({
+      workspaceId,
+      projectId,
+      definitionId,
+      model: workflowModel({
+        jobs: {
+          build: {steps: [{run: 'echo build'}]},
+          listen: {
+            needs: ['build'],
+            listening: {
+              on: [{source: 'github', event: 'pull_request', filter: 'jobs.build'}],
+              onResolve: 'finish',
+            },
+            steps: [{run: 'echo listen'}],
+          },
+        },
+      }),
+      triggerPayload: {
+        source: 'manual',
+        event: 'fire',
+        subscriptionId: crypto.randomUUID(),
+        userId: crypto.randomUUID(),
+      },
+    });
+    const runJobs = await getJobsByWorkflowRunId(run.id);
+    const build = runJobs.find((job) => job.key === 'build');
+    const listener = runJobs.find((job) => job.key === 'listen');
+    if (!build || !listener) throw new Error('Expected listener fixture jobs');
+
+    await db()
+      .update(jobs)
+      .set({outputs: {payload: 'x'.repeat(MAX_LISTENER_FILTER_SNAPSHOT_BYTES)}})
+      .where(eq(jobs.id, build.id));
+
+    const error = await activateJobListenerActivity({
+      jobId: listener.id,
+      expectedVersion: listener.version,
+    }).catch((err: unknown) => err);
+
+    expect(error).toBeInstanceOf(ApplicationFailure);
+    expect((error as ApplicationFailure).nonRetryable).toBe(true);
+    expect((error as ApplicationFailure).type).toBe('WorkflowExecutionPayloadTooLargeError');
   });
 });
 

--- a/libs/api/workflows/src/temporal/activities/orchestration-activities.ts
+++ b/libs/api/workflows/src/temporal/activities/orchestration-activities.ts
@@ -7,7 +7,7 @@ import {defaultJobConditionTrace} from '#core/condition-trace.js';
 import type {JobStatus, JobStatusReason, ResolutionReason} from '#core/entities/job.js';
 import type {PersistedEvaluationTraceEntry, StepStatus} from '#core/entities/step.js';
 import type {WorkflowRunStatus} from '#core/entities/workflow-run.js';
-import {JobNotFoundError} from '#core/errors.js';
+import {JobNotFoundError, WorkflowExecutionPayloadTooLargeError} from '#core/errors.js';
 import type {
   RuntimeCompletionStatus,
   RuntimeDagNode,
@@ -247,7 +247,14 @@ export async function activateJobListenerActivity(params: {
   jobId: string;
   expectedVersion: number;
 }) {
-  return await activateJobListener(params);
+  try {
+    return await activateJobListener(params);
+  } catch (error) {
+    if (error instanceof WorkflowExecutionPayloadTooLargeError) {
+      throw ApplicationFailure.nonRetryable(error.message, error.name);
+    }
+    throw error;
+  }
 }
 
 export function createDrainListenerEventsActivity(clients: {

--- a/libs/api/workflows/src/temporal/workflows/run-orchestration.test.ts
+++ b/libs/api/workflows/src/temporal/workflows/run-orchestration.test.ts
@@ -343,6 +343,27 @@ describe('runOrchestration', () => {
     expect(callsNamed('queueJobExecutionActivity')).toHaveLength(0);
   });
 
+  test('classifies oversized listener activation as an output-size failure', async () => {
+    const jobs = [dagJob('j1', 'listen', [], {mode: 'listening'})];
+    setCfg({
+      dag: makeDag(jobs, 'r-listen-too-large'),
+      jobResults: new Map(),
+      listenerActivationError: 'filter snapshot is too large',
+    });
+
+    await executeRun();
+
+    expect(setJobStatusCalls()).toContainEqual({
+      name: 'setJobStatus',
+      params: expect.objectContaining({
+        jobId: 'j1',
+        status: 'failed',
+        statusReason: 'output_too_large',
+      }),
+    });
+    expect(setRunAttemptStatusCalls().map((c) => c.params.status)).toEqual(['running', 'failed']);
+  });
+
   test('aborts early when the initial running write reports an already-terminal run', async () => {
     const jobs = [dagJob('j1', 'build')];
     setCfg({

--- a/libs/api/workflows/src/temporal/workflows/run-orchestration.ts
+++ b/libs/api/workflows/src/temporal/workflows/run-orchestration.ts
@@ -265,9 +265,35 @@ async function failListenerJob(
     jobId: job.id,
     status: 'failed',
     version: runtimeJobVersion(job, progress),
-    statusReason: 'unknown',
+    statusReason: listenerFailureStatusReason(error),
   });
   return {job, result: {status: 'failed', jobVersion: failed.newVersion}};
+}
+
+function listenerFailureStatusReason(error: unknown): 'output_too_large' | 'unknown' {
+  return hasErrorType(error, 'WorkflowExecutionPayloadTooLargeError')
+    ? 'output_too_large'
+    : 'unknown';
+}
+
+function hasErrorType(error: unknown, type: string): boolean {
+  if (typeof error !== 'object' || error === null) return false;
+  const candidate = error as {
+    readonly type?: unknown;
+    readonly cause?: unknown;
+    readonly failure?: unknown;
+  };
+  if (candidate.type === type) return true;
+  if (hasApplicationFailureType(candidate.failure, type)) return true;
+  return hasErrorType(candidate.cause, type) || hasErrorType(candidate.failure, type);
+}
+
+function hasApplicationFailureType(failure: unknown, type: string): boolean {
+  if (typeof failure !== 'object' || failure === null) return false;
+  const applicationFailureInfo = (failure as {readonly applicationFailureInfo?: unknown})
+    .applicationFailureInfo;
+  if (typeof applicationFailureInfo !== 'object' || applicationFailureInfo === null) return false;
+  return (applicationFailureInfo as {readonly type?: unknown}).type === type;
 }
 
 function launchOneShotJob(

--- a/libs/api/workflows/src/temporal/workflows/test-env.ts
+++ b/libs/api/workflows/src/temporal/workflows/test-env.ts
@@ -53,6 +53,8 @@ export interface TestConfig {
   runningJobStatus?: string;
   /** Result returned by activateJobListenerActivity (defaults to a running listener) */
   listenerActivated?: ActivateJobListenerResult;
+  /** If set, listener activation fails with an oversized-payload application failure. */
+  listenerActivationError?: string;
   /** Scripted drain results consumed in order; once exhausted, drain returns {kind: 'empty'} */
   drainResults?: DrainListenerEventsResult[];
   /** Scripted listener buffer peeks consumed in order; once exhausted, returns an empty buffer */
@@ -370,8 +372,15 @@ function createMockActivities() {
       return {newVersion: nextVersion()};
     },
 
-    activateJobListenerActivity: (params: {jobId: string; expectedVersion: number}) => {
+    activateJobListenerActivity: async (params: {jobId: string; expectedVersion: number}) => {
       calls.push({name: 'activateJobListenerActivity', params});
+      if (cfg.listenerActivationError) {
+        const {ApplicationFailure} = await import('@temporalio/common');
+        throw ApplicationFailure.nonRetryable(
+          cfg.listenerActivationError,
+          'WorkflowExecutionPayloadTooLargeError',
+        );
+      }
       return (
         cfg.listenerActivated ?? {
           status: 'running',

--- a/libs/client/workflows/src/components/job-detail/diagnostic-unavailable.tsx
+++ b/libs/client/workflows/src/components/job-detail/diagnostic-unavailable.tsx
@@ -59,5 +59,7 @@ export function diagnosticFieldLabel(field: WorkflowDiagnosticField): string {
       return 'Condition';
     case 'trigger_events':
       return 'Trigger events';
+    case 'filter_snapshot':
+      return 'Listener filter snapshot';
   }
 }

--- a/libs/client/workflows/src/components/job-detail/job-empty-states.test.ts
+++ b/libs/client/workflows/src/components/job-detail/job-empty-states.test.ts
@@ -203,4 +203,16 @@ describe('materialized output failure descriptions', () => {
       description: fallback,
     });
   });
+
+  test('explains an oversized listener filter snapshot without an execution', () => {
+    expect(
+      emptyStateForMissingExecution(
+        workflowJob({mode: 'listening', status: 'failed', status_reason: 'output_too_large'}),
+      ),
+    ).toMatchObject({
+      title: 'Job failed before an execution was created',
+      description:
+        'The listener filter snapshot exceeded its configured size limit. Review the listener filter and dependency data before re-running the workflow.',
+    });
+  });
 });

--- a/libs/client/workflows/src/components/job-detail/job-empty-states.test.ts
+++ b/libs/client/workflows/src/components/job-detail/job-empty-states.test.ts
@@ -215,4 +215,15 @@ describe('materialized output failure descriptions', () => {
         'The listener filter snapshot exceeded its configured size limit. Review the listener filter and dependency data before re-running the workflow.',
     });
   });
+
+  test('keeps one-shot output-size failures on the materialized-output copy', () => {
+    expect(
+      emptyStateForMissingExecution(
+        workflowJob({status: 'failed', status_reason: 'output_too_large'}),
+      ),
+    ).toMatchObject({
+      description:
+        'The materialized job output exceeded its configured size limit. Review the failure details before re-running the workflow.',
+    });
+  });
 });

--- a/libs/client/workflows/src/components/job-detail/job-empty-states.tsx
+++ b/libs/client/workflows/src/components/job-detail/job-empty-states.tsx
@@ -15,6 +15,8 @@ const MATERIALIZED_OUTPUT_FAILURE_DESCRIPTION =
   'A materialized job output could not be persisted: it exceeded a size or entry cap, contained a non-JSON-safe value, or referenced an unresolved value. Check the output mapping and values before re-running the workflow.';
 const OUTPUT_TOO_LARGE_FAILURE_DESCRIPTION =
   'The materialized job output exceeded its configured size limit. Review the failure details before re-running the workflow.';
+const LISTENER_FILTER_SNAPSHOT_TOO_LARGE_DESCRIPTION =
+  'The listener filter snapshot exceeded its configured size limit. Review the listener filter and dependency data before re-running the workflow.';
 
 export function outputFailureDescriptionForExecution(
   jobExecution: JobExecution,
@@ -176,7 +178,7 @@ export function emptyStateForMissingExecution(job: Job): StepListEmptyState {
   if (job.status === 'failed') {
     return {
       title: 'Job failed before an execution was created',
-      description: preStepFailureDescription(job.statusReason, job.runner),
+      description: missingExecutionFailureDescription(job),
       status: 'failed',
     };
   }
@@ -186,6 +188,13 @@ export function emptyStateForMissingExecution(job: Job): StepListEmptyState {
     description: 'This job finished, but no job execution record is available.',
     status: job.status,
   };
+}
+
+function missingExecutionFailureDescription(job: Job): string {
+  if (job.mode === 'listening' && job.statusReason === 'output_too_large') {
+    return LISTENER_FILTER_SNAPSHOT_TOO_LARGE_DESCRIPTION;
+  }
+  return preStepFailureDescription(job.statusReason, job.runner);
 }
 
 export function skippedJobDescription(reason: Job['statusReason']): string {

--- a/libs/client/workflows/src/components/job-detail/step-troubleshooting.test.tsx
+++ b/libs/client/workflows/src/components/job-detail/step-troubleshooting.test.tsx
@@ -228,6 +228,11 @@ describe('StepInspectorSheet', () => {
                 stored_bytes: 70_000,
                 reason: 'legacy_value_exceeds_inline_limit',
               },
+              {
+                field: 'filter_snapshot',
+                stored_bytes: 524_300,
+                reason: 'value_exceeds_inline_limit',
+              },
             ],
           }),
         ),
@@ -241,6 +246,7 @@ describe('StepInspectorSheet', () => {
     expect(unavailable).toHaveTextContent('Resolved configuration unavailable');
     expect(unavailable).toHaveTextContent('Step output unavailable');
     expect(unavailable).toHaveTextContent('Evaluation unavailable');
+    expect(unavailable).toHaveTextContent('Listener filter snapshot unavailable');
     expect(unavailable).toHaveTextContent('300,000 bytes');
   });
 

--- a/libs/client/workflows/src/core/entities/workflow-diagnostics.ts
+++ b/libs/client/workflows/src/core/entities/workflow-diagnostics.ts
@@ -13,7 +13,8 @@ export type WorkflowDiagnosticField =
   | 'job_evaluation_trace'
   | 'execution_evaluation_trace'
   | 'condition'
-  | 'trigger_events';
+  | 'trigger_events'
+  | 'filter_snapshot';
 
 export type WorkflowDiagnosticUnavailableReason =
   | 'legacy_value_exceeds_inline_limit'

--- a/libs/shared/expression/README.md
+++ b/libs/shared/expression/README.md
@@ -35,6 +35,9 @@ CEL checks and run-time evaluation for Shipfox workflow expressions.
   ordered literal and expression segments.
 - **`extractCelContextRoots`**: Returns the sorted top-level CEL identifiers mentioned
   by an expression for downstream context and agent-selection checks.
+- **`analyzeContextPathAccess`**: Returns exact literal context paths per root and
+  reports dynamic access as unknown for conservative snapshot planning. Its
+  `ContextPath*` types describe path segments, references, and unknown accesses.
 - **Typed errors**: Reports bad text and run failures with stable error classes.
 - **`workflowContextDefinitions`**: Names the workflow contexts (`run`,
   `trigger`, `event`, `inputs`, `job`, `executions`, `execution`, `jobs`, `step`) and

--- a/libs/shared/expression/README.md
+++ b/libs/shared/expression/README.md
@@ -38,6 +38,8 @@ CEL checks and run-time evaluation for Shipfox workflow expressions.
 - **`analyzeContextPathAccess`**: Returns exact literal context paths per root and
   reports dynamic access as unknown for conservative snapshot planning. Its
   `ContextPath*` types describe path segments, references, and unknown accesses.
+  Comprehensions used only for cardinality by `size()` remain projectable; element
+  inspection remains unknown when it cannot be represented by literal paths.
 - **Typed errors**: Reports bad text and run failures with stable error classes.
 - **`workflowContextDefinitions`**: Names the workflow contexts (`run`,
   `trigger`, `event`, `inputs`, `job`, `executions`, `execution`, `jobs`, `step`) and

--- a/libs/shared/expression/src/index.ts
+++ b/libs/shared/expression/src/index.ts
@@ -76,6 +76,14 @@ export {
   evaluationTraceEntry,
   predicateTraceEntry,
 } from './plan/evaluation-trace.js';
+export {
+  analyzeContextPathAccess,
+  type ContextPathAccessAnalysis,
+  type ContextPathAccessUnknown,
+  type ContextPathReference,
+  type ContextPathSegment,
+  extractExactContextPaths,
+} from './plan/extract-context-paths.js';
 export {extractExactContextRoots} from './plan/extract-exact-context-roots.js';
 export {
   type FrozenResolvedField,

--- a/libs/shared/expression/src/index.ts
+++ b/libs/shared/expression/src/index.ts
@@ -82,7 +82,6 @@ export {
   type ContextPathAccessUnknown,
   type ContextPathReference,
   type ContextPathSegment,
-  extractExactContextPaths,
 } from './plan/extract-context-paths.js';
 export {extractExactContextRoots} from './plan/extract-exact-context-roots.js';
 export {

--- a/libs/shared/expression/src/index.ts
+++ b/libs/shared/expression/src/index.ts
@@ -80,6 +80,7 @@ export {
   analyzeContextPathAccess,
   type ContextPathAccessAnalysis,
   type ContextPathAccessUnknown,
+  type ContextPathLiteralSegment,
   type ContextPathReference,
   type ContextPathSegment,
 } from './plan/extract-context-paths.js';

--- a/libs/shared/expression/src/plan/extract-context-paths.test.ts
+++ b/libs/shared/expression/src/plan/extract-context-paths.test.ts
@@ -161,6 +161,30 @@ describe('analyzeContextPathAccess', () => {
     });
   });
 
+  it('marks a comprehension result used as a value as dynamic', () => {
+    const source =
+      'jobs.build.executions.filter(e, e.status == "failed") == jobs.review.executions';
+
+    expect(analyzeContextPathAccess(source, ['jobs'])).toEqual({
+      references: [
+        {root: 'jobs', segments: ['build', 'executions', '*'], source: 'jobs.build.executions'},
+        {
+          root: 'jobs',
+          segments: ['build', 'executions', '*', 'status'],
+          source: 'e.status',
+        },
+        {root: 'jobs', segments: ['review', 'executions'], source: 'jobs.review.executions'},
+      ],
+      unknown: [
+        {
+          root: 'jobs',
+          source: 'jobs.build.executions.filter(e, e.status == "failed")',
+          reason: 'dynamic',
+        },
+      ],
+    });
+  });
+
   it('records whole comprehension element aliases', () => {
     const source =
       'jobs.build.executions.exists(e, e.name == "Build #0" || e in jobs.review.executions)';
@@ -173,7 +197,12 @@ describe('analyzeContextPathAccess', () => {
           segments: ['build', 'executions', '*', 'name'],
           source: 'e.name',
         },
-        {root: 'jobs', segments: ['build', 'executions', '*'], source: 'e'},
+        {
+          root: 'jobs',
+          segments: ['build', 'executions', '*'],
+          source: 'e',
+          wholeElement: true,
+        },
         {root: 'jobs', segments: ['review', 'executions'], source: 'jobs.review.executions'},
       ],
       unknown: [],

--- a/libs/shared/expression/src/plan/extract-context-paths.test.ts
+++ b/libs/shared/expression/src/plan/extract-context-paths.test.ts
@@ -185,6 +185,24 @@ describe('analyzeContextPathAccess', () => {
     });
   });
 
+  it('keeps cardinality-only comprehension results projectable', () => {
+    expect(
+      analyzeContextPathAccess('size(jobs.build.executions.filter(e, e.status == "failed")) > 0', [
+        'jobs',
+      ]),
+    ).toEqual({
+      references: [
+        {root: 'jobs', segments: ['build', 'executions', '*'], source: 'jobs.build.executions'},
+        {
+          root: 'jobs',
+          segments: ['build', 'executions', '*', 'status'],
+          source: 'e.status',
+        },
+      ],
+      unknown: [],
+    });
+  });
+
   it('records whole comprehension element aliases', () => {
     const source =
       'jobs.build.executions.exists(e, e.name == "Build #0" || e in jobs.review.executions)';

--- a/libs/shared/expression/src/plan/extract-context-paths.test.ts
+++ b/libs/shared/expression/src/plan/extract-context-paths.test.ts
@@ -137,4 +137,46 @@ describe('analyzeContextPathAccess', () => {
       unknown: [],
     });
   });
+
+  it('marks suffixes after filtered comprehension access as dynamic', () => {
+    const source =
+      'jobs.build.executions.filter(e, e.status == "failed")[0].outputs.pr_number == 42';
+
+    expect(analyzeContextPathAccess(source, ['jobs'])).toEqual({
+      references: [
+        {root: 'jobs', segments: ['build', 'executions', '*'], source: 'jobs.build.executions'},
+        {
+          root: 'jobs',
+          segments: ['build', 'executions', '*', 'status'],
+          source: 'e.status',
+        },
+      ],
+      unknown: [
+        {
+          root: 'jobs',
+          source: 'jobs.build.executions.filter(e, e.status == "failed")[0].outputs.pr_number',
+          reason: 'dynamic',
+        },
+      ],
+    });
+  });
+
+  it('records whole comprehension element aliases', () => {
+    const source =
+      'jobs.build.executions.exists(e, e.name == "Build #0" || e in jobs.review.executions)';
+
+    expect(analyzeContextPathAccess(source, ['jobs'])).toEqual({
+      references: [
+        {root: 'jobs', segments: ['build', 'executions', '*'], source: 'jobs.build.executions'},
+        {
+          root: 'jobs',
+          segments: ['build', 'executions', '*', 'name'],
+          source: 'e.name',
+        },
+        {root: 'jobs', segments: ['build', 'executions', '*'], source: 'e'},
+        {root: 'jobs', segments: ['review', 'executions'], source: 'jobs.review.executions'},
+      ],
+      unknown: [],
+    });
+  });
 });

--- a/libs/shared/expression/src/plan/extract-context-paths.test.ts
+++ b/libs/shared/expression/src/plan/extract-context-paths.test.ts
@@ -185,12 +185,11 @@ describe('analyzeContextPathAccess', () => {
     });
   });
 
-  it('keeps cardinality-only comprehension results projectable', () => {
-    expect(
-      analyzeContextPathAccess('size(jobs.build.executions.filter(e, e.status == "failed")) > 0', [
-        'jobs',
-      ]),
-    ).toEqual({
+  it.each([
+    'size(jobs.build.executions.filter(e, e.status == "failed")) > 0',
+    'jobs.build.executions.filter(e, e.status == "failed").size() > 0',
+  ])('keeps cardinality-only comprehension results projectable: %s', (source) => {
+    expect(analyzeContextPathAccess(source, ['jobs'])).toEqual({
       references: [
         {root: 'jobs', segments: ['build', 'executions', '*'], source: 'jobs.build.executions'},
         {

--- a/libs/shared/expression/src/plan/extract-context-paths.test.ts
+++ b/libs/shared/expression/src/plan/extract-context-paths.test.ts
@@ -1,0 +1,109 @@
+import {analyzeContextPathAccess, extractExactContextPaths} from './extract-context-paths.js';
+
+describe('analyzeContextPathAccess', () => {
+  it('extracts exact nested and indexed paths', () => {
+    const source =
+      'jobs.remember.outputs.pr_number == 42 && jobs.remember.executions[0].status == "succeeded"';
+
+    expect(analyzeContextPathAccess(source, ['jobs'])).toEqual({
+      references: [
+        {
+          root: 'jobs',
+          segments: ['remember', 'outputs', 'pr_number'],
+          source: 'jobs.remember.outputs.pr_number',
+        },
+        {
+          root: 'jobs',
+          segments: ['remember', 'executions', 0, 'status'],
+          source: 'jobs.remember.executions[0].status',
+        },
+      ],
+      unknown: [],
+    });
+  });
+
+  it('treats literal string indexes as exact paths', () => {
+    expect(analyzeContextPathAccess('jobs["remember"].outputs.pr_number', ['jobs'])).toEqual({
+      references: [
+        {
+          root: 'jobs',
+          segments: ['remember', 'outputs', 'pr_number'],
+          source: 'jobs["remember"].outputs.pr_number',
+        },
+      ],
+      unknown: [],
+    });
+  });
+
+  it('reports dynamic access explicitly instead of treating it as exact', () => {
+    expect(analyzeContextPathAccess('jobs[inputs.target].outputs.pr_number', ['jobs'])).toEqual({
+      references: [],
+      unknown: [
+        {
+          root: 'jobs',
+          source: 'jobs[inputs.target].outputs.pr_number',
+          reason: 'dynamic',
+        },
+      ],
+    });
+
+    expect(analyzeContextPathAccess('jobs[inputs.target].outputs.pr_number')).toEqual({
+      references: [{root: 'inputs', segments: ['target'], source: 'inputs.target'}],
+      unknown: [
+        {
+          root: 'jobs',
+          source: 'jobs[inputs.target].outputs.pr_number',
+          reason: 'dynamic',
+        },
+      ],
+    });
+  });
+
+  it('keeps comprehension aliases on their source collection path', () => {
+    expect(
+      analyzeContextPathAccess('jobs.remember.executions.map(e, e.outputs.pr_number)', ['jobs']),
+    ).toEqual({
+      references: [
+        {
+          root: 'jobs',
+          segments: ['remember', 'executions', '*'],
+          source: 'jobs.remember.executions',
+        },
+        {
+          root: 'jobs',
+          segments: ['remember', 'executions', '*', 'outputs', 'pr_number'],
+          source: 'e.outputs.pr_number',
+        },
+      ],
+      unknown: [],
+    });
+  });
+
+  it('supports nested historical event paths for future audits', () => {
+    const source = 'executions.map(e, e.trigger_events.map(event, event.data.action))';
+
+    expect(extractExactContextPaths(source)).toEqual({
+      references: [
+        {root: 'executions', segments: ['*'], source: 'executions'},
+        {
+          root: 'executions',
+          segments: ['*', 'trigger_events', '*'],
+          source: 'e.trigger_events',
+        },
+        {
+          root: 'executions',
+          segments: ['*', 'trigger_events', '*', 'data', 'action'],
+          source: 'event.data.action',
+        },
+      ],
+      unknown: [],
+    });
+  });
+
+  it('represents broad root access as an empty known path', () => {
+    expect(analyzeContextPathAccess('jobs', ['jobs'])).toEqual({
+      references: [{root: 'jobs', segments: [], source: 'jobs'}],
+      unknown: [],
+    });
+  });
+});

--- a/libs/shared/expression/src/plan/extract-context-paths.test.ts
+++ b/libs/shared/expression/src/plan/extract-context-paths.test.ts
@@ -1,4 +1,4 @@
-import {analyzeContextPathAccess, extractExactContextPaths} from './extract-context-paths.js';
+import {analyzeContextPathAccess} from './extract-context-paths.js';
 
 describe('analyzeContextPathAccess', () => {
   it('extracts exact nested and indexed paths', () => {
@@ -82,7 +82,7 @@ describe('analyzeContextPathAccess', () => {
   it('supports nested historical event paths for future audits', () => {
     const source = 'executions.map(e, e.trigger_events.map(event, event.data.action))';
 
-    expect(extractExactContextPaths(source)).toEqual({
+    expect(analyzeContextPathAccess(source)).toEqual({
       references: [
         {root: 'executions', segments: ['*'], source: 'executions'},
         {
@@ -103,6 +103,37 @@ describe('analyzeContextPathAccess', () => {
   it('represents broad root access as an empty known path', () => {
     expect(analyzeContextPathAccess('jobs', ['jobs'])).toEqual({
       references: [{root: 'jobs', segments: [], source: 'jobs'}],
+      unknown: [],
+    });
+  });
+
+  it('keeps selected roots referenced by dynamic index dependencies', () => {
+    expect(analyzeContextPathAccess('inputs[jobs.target]', ['jobs'])).toEqual({
+      references: [{root: 'jobs', segments: ['target'], source: 'jobs.target'}],
+      unknown: [],
+    });
+  });
+
+  it('propagates paths through chained comprehensions', () => {
+    expect(
+      analyzeContextPathAccess(
+        'jobs.build.executions.filter(e, e.status == "failed").exists(x, x.outputs.pr_number == 42)',
+        ['jobs'],
+      ),
+    ).toEqual({
+      references: [
+        {root: 'jobs', segments: ['build', 'executions', '*'], source: 'jobs.build.executions'},
+        {
+          root: 'jobs',
+          segments: ['build', 'executions', '*', 'status'],
+          source: 'e.status',
+        },
+        {
+          root: 'jobs',
+          segments: ['build', 'executions', '*', 'outputs', 'pr_number'],
+          source: 'x.outputs.pr_number',
+        },
+      ],
       unknown: [],
     });
   });

--- a/libs/shared/expression/src/plan/extract-context-paths.test.ts
+++ b/libs/shared/expression/src/plan/extract-context-paths.test.ts
@@ -35,6 +35,19 @@ describe('analyzeContextPathAccess', () => {
     });
   });
 
+  it('keeps a literal wildcard key distinct from a comprehension wildcard', () => {
+    expect(analyzeContextPathAccess('jobs.build.outputs["*"]', ['jobs'])).toEqual({
+      references: [
+        {
+          root: 'jobs',
+          segments: ['build', 'outputs', {kind: 'literal', value: '*'}],
+          source: 'jobs.build.outputs["*"]',
+        },
+      ],
+      unknown: [],
+    });
+  });
+
   it('reports dynamic access explicitly instead of treating it as exact', () => {
     expect(analyzeContextPathAccess('jobs[inputs.target].outputs.pr_number', ['jobs'])).toEqual({
       references: [],

--- a/libs/shared/expression/src/plan/extract-context-paths.ts
+++ b/libs/shared/expression/src/plan/extract-context-paths.ts
@@ -60,9 +60,6 @@ export function analyzeContextPathAccess(
   return {references, unknown};
 }
 
-/** Alias for callers that use the extractor terminology for expression planning. */
-export const extractExactContextPaths = analyzeContextPathAccess;
-
 function collectContextPaths(
   node: ASTNode,
   source: string,
@@ -320,15 +317,29 @@ function bindComprehensionAlias(
   const [alias] = args;
   if (alias?.op !== 'id') return {scopedPaths, skipArgs: 0};
 
-  const receiverPath = accessChain(receiver, scopedPaths);
-  const aliasPath =
-    receiverPath === undefined
-      ? null
-      : {...receiverPath, segments: [...receiverPath.segments, '*']};
+  const receiverPath = comprehensionElementPath(receiver, scopedPaths);
+  const aliasPath = receiverPath === undefined ? null : receiverPath;
   const nextScopedPaths = new Map(scopedPaths);
   nextScopedPaths.set(alias.args, aliasPath);
 
   return {scopedPaths: nextScopedPaths, skipArgs: 1};
+}
+
+function comprehensionElementPath(
+  receiver: ASTNode,
+  scopedPaths: ScopedPaths,
+): PathChain | undefined {
+  const chain = accessChain(receiver, scopedPaths);
+  if (chain !== undefined) return {...chain, segments: [...chain.segments, '*']};
+
+  if (receiver.op !== 'rcall') return undefined;
+  const [method, nestedReceiver, args] = receiver.args as [string, ASTNode, ASTNode[]];
+  if (!comprehensionMethods.has(method) || args[0]?.op !== 'id') return undefined;
+
+  const nestedPath = comprehensionElementPath(nestedReceiver, scopedPaths);
+  return method === 'filter' || nestedPath === undefined
+    ? nestedPath
+    : {...nestedPath, unknown: 'dynamic'};
 }
 
 function sourceForNode(node: ASTNode, source: string): string {

--- a/libs/shared/expression/src/plan/extract-context-paths.ts
+++ b/libs/shared/expression/src/plan/extract-context-paths.ts
@@ -51,6 +51,11 @@ interface RecordPathOptions {
   readonly wholeElement?: boolean;
 }
 
+/**
+ * Analyzes literal context paths and marks accesses that cannot be projected
+ * safely. A comprehension result used only for cardinality by `size()` stays
+ * projectable; consumers that inspect its elements remain dynamic.
+ */
 export function analyzeContextPathAccess(
   expression: WorkflowExpression | string,
   roots?: readonly string[],
@@ -153,6 +158,8 @@ function collectContextPathChildren(
         selectedRoots,
         references,
         unknown,
+        // `size()` consumes only cardinality, so its comprehension result does
+        // not need to retain whole elements in a snapshot.
         node.args[0] !== 'size',
       );
       return;
@@ -259,7 +266,17 @@ function collectRelativeCallContextPaths(
       unknown,
     );
   } else {
-    collectContextPaths(receiver, source, scopedPaths, selectedRoots, references, unknown, true);
+    collectContextPaths(
+      receiver,
+      source,
+      scopedPaths,
+      selectedRoots,
+      references,
+      unknown,
+      // The member form `filtered.size()` has the same cardinality-only
+      // semantics as `size(filtered)`.
+      method !== 'size',
+    );
   }
 
   const binding = bindComprehensionAlias(method, args, scopedPaths, receiver);

--- a/libs/shared/expression/src/plan/extract-context-paths.ts
+++ b/libs/shared/expression/src/plan/extract-context-paths.ts
@@ -1,0 +1,336 @@
+import {type ASTNode, type BinaryOperator, parse as parseCel} from '@marcbachmann/cel-js';
+import type {WorkflowExpression} from '../expression/workflow-expression.js';
+
+const binaryOperators = new Set<BinaryOperator>([
+  '!=',
+  '==',
+  'in',
+  '+',
+  '-',
+  '*',
+  '/',
+  '%',
+  '<',
+  '<=',
+  '>',
+  '>=',
+]);
+
+const comprehensionMethods = new Set(['all', 'exists', 'exists_one', 'filter', 'map']);
+
+/** A literal object key, array index, or comprehension element in a context path. */
+export type ContextPathSegment = string | number | '*';
+
+export interface ContextPathReference {
+  readonly root: string;
+  readonly segments: readonly ContextPathSegment[];
+  readonly source: string;
+}
+
+export interface ContextPathAccessUnknown {
+  readonly root: string;
+  readonly source: string;
+  readonly reason: 'dynamic';
+}
+
+export interface ContextPathAccessAnalysis {
+  readonly references: readonly ContextPathReference[];
+  readonly unknown: readonly ContextPathAccessUnknown[];
+}
+
+interface PathChain {
+  readonly root: string;
+  readonly segments: readonly ContextPathSegment[];
+  readonly unknown?: 'dynamic';
+}
+
+type ScopedPaths = ReadonlyMap<string, PathChain | null>;
+
+export function analyzeContextPathAccess(
+  expression: WorkflowExpression | string,
+  roots?: readonly string[],
+): ContextPathAccessAnalysis {
+  const source = typeof expression === 'string' ? expression : expression.source;
+  const references: ContextPathReference[] = [];
+  const unknown: ContextPathAccessUnknown[] = [];
+  const selectedRoots = roots === undefined ? undefined : new Set(roots);
+
+  collectContextPaths(parseCel(source).ast, source, new Map(), selectedRoots, references, unknown);
+
+  return {references, unknown};
+}
+
+/** Alias for callers that use the extractor terminology for expression planning. */
+export const extractExactContextPaths = analyzeContextPathAccess;
+
+function collectContextPaths(
+  node: ASTNode,
+  source: string,
+  scopedPaths: ScopedPaths,
+  selectedRoots: ReadonlySet<string> | undefined,
+  references: ContextPathReference[],
+  unknown: ContextPathAccessUnknown[],
+): void {
+  if (binaryOperators.has(node.op as BinaryOperator) || node.op === '||' || node.op === '&&') {
+    collectBinaryContextPaths(
+      node.args as [ASTNode, ASTNode],
+      source,
+      scopedPaths,
+      selectedRoots,
+      references,
+      unknown,
+    );
+    return;
+  }
+
+  const chain = accessChain(node, scopedPaths);
+  if (chain !== undefined) {
+    recordPath(chain, sourceForNode(node, source), selectedRoots, references, unknown);
+    if (chain.unknown !== undefined) {
+      collectDynamicDependencies(node, source, scopedPaths, selectedRoots, references, unknown);
+    }
+    return;
+  }
+
+  collectContextPathChildren(node, source, scopedPaths, selectedRoots, references, unknown);
+}
+
+function collectContextPathChildren(
+  node: ASTNode,
+  source: string,
+  scopedPaths: ScopedPaths,
+  selectedRoots: ReadonlySet<string> | undefined,
+  references: ContextPathReference[],
+  unknown: ContextPathAccessUnknown[],
+): void {
+  switch (node.op) {
+    case 'id':
+    case 'value':
+      return;
+    case '.':
+    case '.?':
+      collectContextPaths(node.args[0], source, scopedPaths, selectedRoots, references, unknown);
+      return;
+    case '[]':
+    case '[?]':
+      collectBinaryContextPaths(node.args, source, scopedPaths, selectedRoots, references, unknown);
+      return;
+    case 'call':
+      for (const argument of node.args[1]) {
+        collectContextPaths(argument, source, scopedPaths, selectedRoots, references, unknown);
+      }
+      return;
+    case 'rcall': {
+      const [method, receiver, args] = node.args as [string, ASTNode, ASTNode[]];
+      if (comprehensionMethods.has(method) && args[0]?.op === 'id') {
+        collectComprehensionReceiverPath(
+          receiver,
+          source,
+          scopedPaths,
+          selectedRoots,
+          references,
+          unknown,
+        );
+      } else {
+        collectContextPaths(receiver, source, scopedPaths, selectedRoots, references, unknown);
+      }
+      const binding = bindComprehensionAlias(method, args, scopedPaths, receiver);
+      for (const argument of args.slice(binding.skipArgs)) {
+        collectContextPaths(
+          argument,
+          source,
+          binding.scopedPaths,
+          selectedRoots,
+          references,
+          unknown,
+        );
+      }
+      return;
+    }
+    case 'list':
+      for (const element of node.args) {
+        collectContextPaths(element, source, scopedPaths, selectedRoots, references, unknown);
+      }
+      return;
+    case 'map':
+      for (const [key, value] of node.args) {
+        if (key.op !== 'id') {
+          collectContextPaths(key, source, scopedPaths, selectedRoots, references, unknown);
+        }
+        collectContextPaths(value, source, scopedPaths, selectedRoots, references, unknown);
+      }
+      return;
+    case '?:':
+      collectContextPaths(node.args[0], source, scopedPaths, selectedRoots, references, unknown);
+      collectContextPaths(node.args[1], source, scopedPaths, selectedRoots, references, unknown);
+      collectContextPaths(node.args[2], source, scopedPaths, selectedRoots, references, unknown);
+      return;
+    case '!_':
+    case '-_':
+      collectContextPaths(node.args, source, scopedPaths, selectedRoots, references, unknown);
+      return;
+  }
+
+  throw new Error(`Unsupported CEL AST operator: ${(node as {op: string}).op}`);
+}
+
+function collectComprehensionReceiverPath(
+  receiver: ASTNode,
+  source: string,
+  scopedPaths: ScopedPaths,
+  selectedRoots: ReadonlySet<string> | undefined,
+  references: ContextPathReference[],
+  unknown: ContextPathAccessUnknown[],
+): void {
+  const chain = accessChain(receiver, scopedPaths);
+  if (chain === undefined) {
+    collectContextPaths(receiver, source, scopedPaths, selectedRoots, references, unknown);
+    return;
+  }
+
+  recordPath(
+    {...chain, segments: [...chain.segments, '*']},
+    sourceForNode(receiver, source),
+    selectedRoots,
+    references,
+    unknown,
+  );
+  if (chain.unknown !== undefined) {
+    collectDynamicDependencies(receiver, source, scopedPaths, selectedRoots, references, unknown);
+  }
+}
+
+function collectBinaryContextPaths(
+  [left, right]: [ASTNode, ASTNode],
+  source: string,
+  scopedPaths: ScopedPaths,
+  selectedRoots: ReadonlySet<string> | undefined,
+  references: ContextPathReference[],
+  unknown: ContextPathAccessUnknown[],
+): void {
+  collectContextPaths(left, source, scopedPaths, selectedRoots, references, unknown);
+  collectContextPaths(right, source, scopedPaths, selectedRoots, references, unknown);
+}
+
+function collectDynamicDependencies(
+  node: ASTNode,
+  source: string,
+  scopedPaths: ScopedPaths,
+  selectedRoots: ReadonlySet<string> | undefined,
+  references: ContextPathReference[],
+  unknown: ContextPathAccessUnknown[],
+): void {
+  switch (node.op) {
+    case '.':
+    case '.?':
+      collectDynamicDependencies(
+        node.args[0],
+        source,
+        scopedPaths,
+        selectedRoots,
+        references,
+        unknown,
+      );
+      return;
+    case '[]':
+    case '[?]':
+      collectDynamicDependencies(
+        node.args[0],
+        source,
+        scopedPaths,
+        selectedRoots,
+        references,
+        unknown,
+      );
+      collectContextPaths(node.args[1], source, scopedPaths, selectedRoots, references, unknown);
+      return;
+    default:
+      return;
+  }
+}
+
+function recordPath(
+  chain: PathChain,
+  expressionSource: string,
+  selectedRoots: ReadonlySet<string> | undefined,
+  references: ContextPathReference[],
+  unknown: ContextPathAccessUnknown[],
+): void {
+  if (selectedRoots !== undefined && !selectedRoots.has(chain.root)) return;
+
+  if (chain.unknown !== undefined) {
+    unknown.push({root: chain.root, source: expressionSource, reason: chain.unknown});
+    return;
+  }
+
+  references.push({root: chain.root, segments: chain.segments, source: expressionSource});
+}
+
+function accessChain(node: ASTNode, scopedPaths: ScopedPaths): PathChain | undefined {
+  switch (node.op) {
+    case 'id':
+      if (scopedPaths.has(node.args)) return scopedPaths.get(node.args) ?? undefined;
+      return {root: node.args, segments: []};
+    case '.': {
+      const target = accessChain(node.args[0], scopedPaths);
+      if (target === undefined) return undefined;
+      return {...target, segments: [...target.segments, node.args[1]]};
+    }
+    case '.?': {
+      const target = accessChain(node.args[0], scopedPaths);
+      if (target === undefined) return undefined;
+      return {...target, segments: [...target.segments, node.args[1]]};
+    }
+    case '[]':
+    case '[?]': {
+      const target = accessChain(node.args[0], scopedPaths);
+      if (target === undefined) return undefined;
+      const literalSegment = node.op === '[]' ? literalPathSegment(node.args[1]) : undefined;
+      return literalSegment === undefined
+        ? {...target, unknown: 'dynamic'}
+        : {...target, segments: [...target.segments, literalSegment]};
+    }
+    default:
+      return undefined;
+  }
+}
+
+function literalPathSegment(node: ASTNode): ContextPathSegment | undefined {
+  if (node.op !== 'value') return undefined;
+  if (typeof node.args === 'string') return node.args;
+  if (typeof node.args === 'number' && Number.isSafeInteger(node.args)) return node.args;
+  if (
+    typeof node.args === 'bigint' &&
+    node.args <= BigInt(Number.MAX_SAFE_INTEGER) &&
+    node.args >= BigInt(Number.MIN_SAFE_INTEGER)
+  ) {
+    return Number(node.args);
+  }
+  return undefined;
+}
+
+function bindComprehensionAlias(
+  method: string,
+  args: readonly ASTNode[],
+  scopedPaths: ScopedPaths,
+  receiver: ASTNode,
+): {readonly scopedPaths: ScopedPaths; readonly skipArgs: number} {
+  if (!comprehensionMethods.has(method)) return {scopedPaths, skipArgs: 0};
+
+  const [alias] = args;
+  if (alias?.op !== 'id') return {scopedPaths, skipArgs: 0};
+
+  const receiverPath = accessChain(receiver, scopedPaths);
+  const aliasPath =
+    receiverPath === undefined
+      ? null
+      : {...receiverPath, segments: [...receiverPath.segments, '*']};
+  const nextScopedPaths = new Map(scopedPaths);
+  nextScopedPaths.set(alias.args, aliasPath);
+
+  return {scopedPaths: nextScopedPaths, skipArgs: 1};
+}
+
+function sourceForNode(node: ASTNode, source: string): string {
+  return source.slice(node.start, node.end);
+}

--- a/libs/shared/expression/src/plan/extract-context-paths.ts
+++ b/libs/shared/expression/src/plan/extract-context-paths.ts
@@ -153,7 +153,7 @@ function collectContextPathChildren(
         selectedRoots,
         references,
         unknown,
-        true,
+        node.args[0] !== 'size',
       );
       return;
     case 'rcall':

--- a/libs/shared/expression/src/plan/extract-context-paths.ts
+++ b/libs/shared/expression/src/plan/extract-context-paths.ts
@@ -89,6 +89,22 @@ function collectContextPaths(
     return;
   }
 
+  const base = accessBase(node);
+  if (base !== undefined) {
+    const baseRoots = collectUnresolvedAccessDependencies(
+      base,
+      source,
+      scopedPaths,
+      selectedRoots,
+      references,
+      unknown,
+    );
+    for (const root of baseRoots) {
+      unknown.push({root, source: sourceForNode(node, source), reason: 'dynamic'});
+    }
+    return;
+  }
+
   collectContextPathChildren(node, source, scopedPaths, selectedRoots, references, unknown);
 }
 
@@ -261,6 +277,53 @@ function recordPath(
   }
 
   references.push({root: chain.root, segments: chain.segments, source: expressionSource});
+}
+
+function collectUnresolvedAccessDependencies(
+  node: ASTNode,
+  source: string,
+  scopedPaths: ScopedPaths,
+  selectedRoots: ReadonlySet<string> | undefined,
+  references: ContextPathReference[],
+  unknown: ContextPathAccessUnknown[],
+): Set<string> {
+  const base = accessBase(node);
+  if (base === undefined) {
+    const baseReferences: ContextPathReference[] = [];
+    const baseUnknown: ContextPathAccessUnknown[] = [];
+    collectContextPaths(node, source, scopedPaths, selectedRoots, baseReferences, baseUnknown);
+    references.push(...baseReferences);
+    unknown.push(...baseUnknown);
+    return new Set([
+      ...baseReferences.map((reference) => reference.root),
+      ...baseUnknown.map((access) => access.root),
+    ]);
+  }
+
+  const roots = collectUnresolvedAccessDependencies(
+    base,
+    source,
+    scopedPaths,
+    selectedRoots,
+    references,
+    unknown,
+  );
+  if (node.op === '[]' || node.op === '[?]') {
+    collectContextPaths(node.args[1], source, scopedPaths, selectedRoots, references, unknown);
+  }
+  return roots;
+}
+
+function accessBase(node: ASTNode): ASTNode | undefined {
+  switch (node.op) {
+    case '.':
+    case '.?':
+    case '[]':
+    case '[?]':
+      return node.args[0];
+    default:
+      return undefined;
+  }
 }
 
 function accessChain(node: ASTNode, scopedPaths: ScopedPaths): PathChain | undefined {

--- a/libs/shared/expression/src/plan/extract-context-paths.ts
+++ b/libs/shared/expression/src/plan/extract-context-paths.ts
@@ -25,6 +25,7 @@ export interface ContextPathReference {
   readonly root: string;
   readonly segments: readonly ContextPathSegment[];
   readonly source: string;
+  readonly wholeElement?: true;
 }
 
 export interface ContextPathAccessUnknown {
@@ -45,6 +46,10 @@ interface PathChain {
 }
 
 type ScopedPaths = ReadonlyMap<string, PathChain | null>;
+
+interface RecordPathOptions {
+  readonly wholeElement?: boolean;
+}
 
 export function analyzeContextPathAccess(
   expression: WorkflowExpression | string,
@@ -67,6 +72,7 @@ function collectContextPaths(
   selectedRoots: ReadonlySet<string> | undefined,
   references: ContextPathReference[],
   unknown: ContextPathAccessUnknown[],
+  allowComprehensionResultUnknown = false,
 ): void {
   if (binaryOperators.has(node.op as BinaryOperator) || node.op === '||' || node.op === '&&') {
     collectBinaryContextPaths(
@@ -82,7 +88,9 @@ function collectContextPaths(
 
   const chain = accessChain(node, scopedPaths);
   if (chain !== undefined) {
-    recordPath(chain, sourceForNode(node, source), selectedRoots, references, unknown);
+    recordPath(chain, sourceForNode(node, source), selectedRoots, references, unknown, {
+      wholeElement: node.op === 'id' && scopedPaths.has(node.args) && chain.segments.at(-1) === '*',
+    });
     if (chain.unknown !== undefined) {
       collectDynamicDependencies(node, source, scopedPaths, selectedRoots, references, unknown);
     }
@@ -105,7 +113,15 @@ function collectContextPaths(
     return;
   }
 
-  collectContextPathChildren(node, source, scopedPaths, selectedRoots, references, unknown);
+  collectContextPathChildren(
+    node,
+    source,
+    scopedPaths,
+    selectedRoots,
+    references,
+    unknown,
+    allowComprehensionResultUnknown,
+  );
 }
 
 function collectContextPathChildren(
@@ -115,6 +131,7 @@ function collectContextPathChildren(
   selectedRoots: ReadonlySet<string> | undefined,
   references: ContextPathReference[],
   unknown: ContextPathAccessUnknown[],
+  allowComprehensionResultUnknown = false,
 ): void {
   switch (node.op) {
     case 'id':
@@ -129,62 +146,163 @@ function collectContextPathChildren(
       collectBinaryContextPaths(node.args, source, scopedPaths, selectedRoots, references, unknown);
       return;
     case 'call':
-      for (const argument of node.args[1]) {
-        collectContextPaths(argument, source, scopedPaths, selectedRoots, references, unknown);
-      }
+      collectContextPathArguments(
+        node.args[1],
+        source,
+        scopedPaths,
+        selectedRoots,
+        references,
+        unknown,
+        true,
+      );
       return;
-    case 'rcall': {
-      const [method, receiver, args] = node.args as [string, ASTNode, ASTNode[]];
-      if (comprehensionMethods.has(method) && args[0]?.op === 'id') {
-        collectComprehensionReceiverPath(
-          receiver,
-          source,
-          scopedPaths,
-          selectedRoots,
-          references,
-          unknown,
-        );
-      } else {
-        collectContextPaths(receiver, source, scopedPaths, selectedRoots, references, unknown);
-      }
-      const binding = bindComprehensionAlias(method, args, scopedPaths, receiver);
-      for (const argument of args.slice(binding.skipArgs)) {
-        collectContextPaths(
-          argument,
-          source,
-          binding.scopedPaths,
-          selectedRoots,
-          references,
-          unknown,
-        );
-      }
+    case 'rcall':
+      collectRelativeCallContextPaths(
+        node,
+        source,
+        scopedPaths,
+        selectedRoots,
+        references,
+        unknown,
+        allowComprehensionResultUnknown,
+      );
       return;
-    }
     case 'list':
-      for (const element of node.args) {
-        collectContextPaths(element, source, scopedPaths, selectedRoots, references, unknown);
-      }
+      collectContextPathArguments(
+        node.args,
+        source,
+        scopedPaths,
+        selectedRoots,
+        references,
+        unknown,
+        true,
+      );
       return;
     case 'map':
-      for (const [key, value] of node.args) {
-        if (key.op !== 'id') {
-          collectContextPaths(key, source, scopedPaths, selectedRoots, references, unknown);
-        }
-        collectContextPaths(value, source, scopedPaths, selectedRoots, references, unknown);
-      }
+      collectMapContextPaths(node.args, source, scopedPaths, selectedRoots, references, unknown);
       return;
     case '?:':
-      collectContextPaths(node.args[0], source, scopedPaths, selectedRoots, references, unknown);
-      collectContextPaths(node.args[1], source, scopedPaths, selectedRoots, references, unknown);
-      collectContextPaths(node.args[2], source, scopedPaths, selectedRoots, references, unknown);
+      collectContextPathArguments(
+        node.args,
+        source,
+        scopedPaths,
+        selectedRoots,
+        references,
+        unknown,
+        true,
+      );
       return;
     case '!_':
     case '-_':
-      collectContextPaths(node.args, source, scopedPaths, selectedRoots, references, unknown);
+      collectContextPaths(node.args, source, scopedPaths, selectedRoots, references, unknown, true);
       return;
   }
 
   throw new Error(`Unsupported CEL AST operator: ${(node as {op: string}).op}`);
+}
+
+function collectContextPathArguments(
+  arguments_: readonly ASTNode[],
+  source: string,
+  scopedPaths: ScopedPaths,
+  selectedRoots: ReadonlySet<string> | undefined,
+  references: ContextPathReference[],
+  unknown: ContextPathAccessUnknown[],
+  allowComprehensionResultUnknown: boolean,
+): void {
+  for (const argument of arguments_) {
+    collectContextPaths(
+      argument,
+      source,
+      scopedPaths,
+      selectedRoots,
+      references,
+      unknown,
+      allowComprehensionResultUnknown,
+    );
+  }
+}
+
+function collectMapContextPaths(
+  entries: readonly (readonly [ASTNode, ASTNode])[],
+  source: string,
+  scopedPaths: ScopedPaths,
+  selectedRoots: ReadonlySet<string> | undefined,
+  references: ContextPathReference[],
+  unknown: ContextPathAccessUnknown[],
+): void {
+  for (const [key, value] of entries) {
+    if (key.op !== 'id') {
+      collectContextPaths(key, source, scopedPaths, selectedRoots, references, unknown, true);
+    }
+    collectContextPaths(value, source, scopedPaths, selectedRoots, references, unknown, true);
+  }
+}
+
+function collectRelativeCallContextPaths(
+  node: ASTNode,
+  source: string,
+  scopedPaths: ScopedPaths,
+  selectedRoots: ReadonlySet<string> | undefined,
+  references: ContextPathReference[],
+  unknown: ContextPathAccessUnknown[],
+  allowComprehensionResultUnknown: boolean,
+): void {
+  const [method, receiver, args] = node.args as [string, ASTNode, ASTNode[]];
+  if (comprehensionMethods.has(method) && args[0]?.op === 'id') {
+    collectComprehensionReceiverPath(
+      receiver,
+      source,
+      scopedPaths,
+      selectedRoots,
+      references,
+      unknown,
+    );
+  } else {
+    collectContextPaths(receiver, source, scopedPaths, selectedRoots, references, unknown, true);
+  }
+
+  const binding = bindComprehensionAlias(method, args, scopedPaths, receiver);
+  collectContextPathArguments(
+    args.slice(binding.skipArgs),
+    source,
+    binding.scopedPaths,
+    selectedRoots,
+    references,
+    unknown,
+    !comprehensionMethods.has(method),
+  );
+  if (allowComprehensionResultUnknown && (method === 'filter' || method === 'map')) {
+    collectComprehensionResultUnknown(node, receiver, source, scopedPaths, selectedRoots, unknown);
+  }
+}
+
+function collectComprehensionResultUnknown(
+  node: ASTNode,
+  receiver: ASTNode,
+  source: string,
+  scopedPaths: ScopedPaths,
+  selectedRoots: ReadonlySet<string> | undefined,
+  unknown: ContextPathAccessUnknown[],
+): void {
+  const receiverReferences: ContextPathReference[] = [];
+  const receiverUnknown: ContextPathAccessUnknown[] = [];
+  collectContextPaths(
+    receiver,
+    source,
+    scopedPaths,
+    selectedRoots,
+    receiverReferences,
+    receiverUnknown,
+    false,
+  );
+  const receiverRoots = new Set([
+    ...receiverReferences.map((reference) => reference.root),
+    ...receiverUnknown.map((access) => access.root),
+  ]);
+  for (const root of receiverRoots) {
+    unknown.push({root, source: sourceForNode(node, source), reason: 'dynamic'});
+  }
 }
 
 function collectComprehensionReceiverPath(
@@ -197,7 +315,7 @@ function collectComprehensionReceiverPath(
 ): void {
   const chain = accessChain(receiver, scopedPaths);
   if (chain === undefined) {
-    collectContextPaths(receiver, source, scopedPaths, selectedRoots, references, unknown);
+    collectContextPaths(receiver, source, scopedPaths, selectedRoots, references, unknown, false);
     return;
   }
 
@@ -221,8 +339,8 @@ function collectBinaryContextPaths(
   references: ContextPathReference[],
   unknown: ContextPathAccessUnknown[],
 ): void {
-  collectContextPaths(left, source, scopedPaths, selectedRoots, references, unknown);
-  collectContextPaths(right, source, scopedPaths, selectedRoots, references, unknown);
+  collectContextPaths(left, source, scopedPaths, selectedRoots, references, unknown, true);
+  collectContextPaths(right, source, scopedPaths, selectedRoots, references, unknown, true);
 }
 
 function collectDynamicDependencies(
@@ -255,7 +373,15 @@ function collectDynamicDependencies(
         references,
         unknown,
       );
-      collectContextPaths(node.args[1], source, scopedPaths, selectedRoots, references, unknown);
+      collectContextPaths(
+        node.args[1],
+        source,
+        scopedPaths,
+        selectedRoots,
+        references,
+        unknown,
+        true,
+      );
       return;
     default:
       return;
@@ -268,6 +394,7 @@ function recordPath(
   selectedRoots: ReadonlySet<string> | undefined,
   references: ContextPathReference[],
   unknown: ContextPathAccessUnknown[],
+  options: RecordPathOptions = {},
 ): void {
   if (selectedRoots !== undefined && !selectedRoots.has(chain.root)) return;
 
@@ -276,7 +403,12 @@ function recordPath(
     return;
   }
 
-  references.push({root: chain.root, segments: chain.segments, source: expressionSource});
+  references.push({
+    root: chain.root,
+    segments: chain.segments,
+    source: expressionSource,
+    ...(options.wholeElement === true ? {wholeElement: true} : {}),
+  });
 }
 
 function collectUnresolvedAccessDependencies(
@@ -291,7 +423,15 @@ function collectUnresolvedAccessDependencies(
   if (base === undefined) {
     const baseReferences: ContextPathReference[] = [];
     const baseUnknown: ContextPathAccessUnknown[] = [];
-    collectContextPaths(node, source, scopedPaths, selectedRoots, baseReferences, baseUnknown);
+    collectContextPaths(
+      node,
+      source,
+      scopedPaths,
+      selectedRoots,
+      baseReferences,
+      baseUnknown,
+      false,
+    );
     references.push(...baseReferences);
     unknown.push(...baseUnknown);
     return new Set([

--- a/libs/shared/expression/src/plan/extract-context-paths.ts
+++ b/libs/shared/expression/src/plan/extract-context-paths.ts
@@ -18,8 +18,14 @@ const binaryOperators = new Set<BinaryOperator>([
 
 const comprehensionMethods = new Set(['all', 'exists', 'exists_one', 'filter', 'map']);
 
+/** Distinguishes a literal `"*"` key from the comprehension wildcard sentinel. */
+export interface ContextPathLiteralSegment {
+  readonly kind: 'literal';
+  readonly value: string;
+}
+
 /** A literal object key, array index, or comprehension element in a context path. */
-export type ContextPathSegment = string | number | '*';
+export type ContextPathSegment = string | number | ContextPathLiteralSegment | '*';
 
 export interface ContextPathReference {
   readonly root: string;
@@ -514,7 +520,9 @@ function accessChain(node: ASTNode, scopedPaths: ScopedPaths): PathChain | undef
 
 function literalPathSegment(node: ASTNode): ContextPathSegment | undefined {
   if (node.op !== 'value') return undefined;
-  if (typeof node.args === 'string') return node.args;
+  if (typeof node.args === 'string') {
+    return node.args === '*' ? {kind: 'literal', value: node.args} : node.args;
+  }
   if (typeof node.args === 'number' && Number.isSafeInteger(node.args)) return node.args;
   if (
     typeof node.args === 'bigint' &&


### PR DESCRIPTION
Listener activation previously retained complete dependency job contexts whenever a filter referenced `jobs`, allowing output and execution history to amplify outbox payloads beyond the product job-output limit.

This change adds a reusable CEL context-path analyzer and projects each listener matcher to the exact job, output, execution, and nested paths it references. Dynamic, broad, and comprehension access is handled conservatively. Computed snapshots now have an independent 512 KiB `filter_snapshot` execution payload limit; oversized activation fails before the activation outbox event is written and is classified as non-retryable in Temporal.

The cap is intentionally separate from `MAX_JOB_OUTPUTS_TOTAL_BYTES` and is set against the observed snapshot amplification from the issue evidence.

Closes ENG-1555

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Listener activation previously copied complete dependency job contexts into outbox payloads whenever a filter referenced `jobs`, so output and execution history could inflate payloads well beyond the job-output limit. Listener filter snapshots now keep only the exact context paths each filter references, enforce an independent 512 KiB `filter_snapshot` limit, and fail oversized activation as non-retryable `output_too_large` before the outbox event is written.

**Refactors**
- Adds a reusable CEL context-path analyzer in `@shipfox/expression` covering exact, indexed, dynamic, broad, comprehension, and chained-comprehension access.
- Projects output type metadata to the same referenced paths and preserves whole elements and earlier indexed projections without broadening unrelated jobs.
- Handles dynamic and broad access conservatively, fetches all dependency jobs for dynamic job keys, and covers `until` matchers and literal wildcard keys.
- Logs bounded per-matcher sizes when the aggregate snapshot budget is rejected.
- Surfaces `filter_snapshot` in diagnostics and client labels, and explains oversized activation failures when no execution is created.
- Aligns execution payload histograms with the snapshot cap and keeps one-shot output-size failures on the materialized-output copy.

Closes ENG-1555.

<sup>Written for commit cada89fc8b29fb16b513427975cfb0b0a47a30f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1704?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

