### PR TITLE
[api-workflows] Prevent false oversized result failures

### DIFF
--- a/.changeset/calm-tools-count.md
+++ b/.changeset/calm-tools-count.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-workflows": patch
+---
+
+Normalizes CEL-native tool output mappings before persisting workflow step results.

--- a/.changeset/calm-tools-count.md
+++ b/.changeset/calm-tools-count.md
@@ -2,4 +2,4 @@
 "@shipfox/api-workflows": patch
 ---
 
-Normalizes CEL-native tool output mappings before persisting workflow step results.
+Fixes tool steps with integer CEL output mappings so results such as collection sizes persist instead of reporting an infinite-size failure.

--- a/.changeset/calm-tools-count.md
+++ b/.changeset/calm-tools-count.md
@@ -2,4 +2,4 @@
 "@shipfox/api-workflows": patch
 ---
 
-Fixes false oversized errors for valid CEL integer tool outputs. The platform now rejects values that JSON cannot represent safely.
+Fixes false oversized errors for CEL integer tool outputs. Tool mappings now reject non-finite values, unsafe integers, unsupported objects, cycles, and excessive nesting.

--- a/.changeset/calm-tools-count.md
+++ b/.changeset/calm-tools-count.md
@@ -2,4 +2,4 @@
 "@shipfox/api-workflows": patch
 ---
 
-Fixes tool steps with integer CEL output mappings so results such as collection sizes persist instead of reporting an infinite-size failure.
+Fixes false oversized errors for valid CEL integer tool outputs. The platform now rejects values that JSON cannot represent safely.

--- a/apps/docs/content/docs/reference/limits.mdx
+++ b/apps/docs/content/docs/reference/limits.mdx
@@ -25,6 +25,10 @@ can change the values marked configurable.
 | Declared outputs per step | 128 entries | No | The `outputs:` map on one step. |
 | Agent output re-prompts | 2 | No | An agent step missing a declared output is re-prompted this many times before the step fails. |
 
+Persisted step outputs use JSON-safe values. Tool mappings convert safe CEL
+integers to JSON numbers. They reject unsafe integers, non-finite numbers,
+unsupported objects, cyclic values, and values nested beyond 64 levels.
+
 ## Job outputs
 
 | Limit | Default | Configurable | Details |

--- a/libs/api/workflows/src/core/tool-step/tool-step-executor.test.ts
+++ b/libs/api/workflows/src/core/tool-step/tool-step-executor.test.ts
@@ -239,6 +239,57 @@ describe('tool step executor', () => {
     });
   });
 
+  test('rejects unsafe CEL integer output mappings without rounding', async () => {
+    const {jobId} = await arrangeToolStep('read', {
+      outputDeclarations: {
+        result: {type: 'json'},
+        issue_count: {type: 'number'},
+      },
+      outputMappings: {
+        issue_count: createWorkflowExpression({
+          source: '9007199254740993',
+          check: {mode: 'syntax'},
+        }),
+      },
+    });
+    const callTool = vi.fn<IntegrationsModuleClient['callTool']>().mockResolvedValue({
+      outcome: 'success' as const,
+      result: {issues: []},
+      content: [],
+    });
+    const appendServerRecords = vi
+      .fn<LogsModuleClient['appendServerRecords']>()
+      .mockResolvedValue({committedLength: 0, capped: false});
+    const executorParams = {
+      integrations: {callTool} as unknown as IntegrationsModuleClient,
+      logs: {appendServerRecords} as unknown as LogsModuleClient,
+      signal: new AbortController().signal,
+      claimOwner: 'executor-test',
+      concurrency: 8,
+      callTimeoutMs: 30_000,
+    };
+
+    await nextStepForJob(jobId);
+    await runToolStepExecutorCycle(executorParams);
+    await runToolStepExecutorCycle(executorParams);
+
+    const [step] = await getStepsByJobId(jobId);
+    expect(step).toMatchObject({
+      status: 'failed',
+      error: {
+        code: 'output_invalid',
+        reason: 'output_invalid',
+        message:
+          'Tool output mapping "issue_count" cannot be persisted as JSON: integers must be between -9007199254740991 and 9007199254740991',
+      },
+    });
+    const [attempt] = await getStepAttempts(jobId);
+    expect(attempt?.invocations).toEqual([
+      expect.objectContaining({call_index: 0, outcome: 'success'}),
+    ]);
+    expect(callTool).toHaveBeenCalledOnce();
+  });
+
   test.each([
     ['null', {result: null, content: []}, null],
     ['a scalar', {result: null, content: [{type: 'text', text: '42'}]}, 42],

--- a/libs/api/workflows/src/core/tool-step/tool-step-executor.test.ts
+++ b/libs/api/workflows/src/core/tool-step/tool-step-executor.test.ts
@@ -199,6 +199,46 @@ describe('tool step executor', () => {
     });
   });
 
+  test('normalizes CEL integer output mappings before persistence', async () => {
+    const {jobId} = await arrangeToolStep('read', {
+      outputDeclarations: {
+        result: {type: 'json'},
+        issue_count: {type: 'number'},
+      },
+      outputMappings: {
+        issue_count: createWorkflowExpression({
+          source: 'result.issues.size()',
+          check: {mode: 'syntax'},
+        }),
+      },
+    });
+    const result = {issues: [{id: 1}, {id: 2}, {id: 3}]};
+    const callTool = vi.fn<IntegrationsModuleClient['callTool']>().mockResolvedValue({
+      outcome: 'success' as const,
+      result,
+      content: [],
+    });
+    const appendServerRecords = vi
+      .fn<LogsModuleClient['appendServerRecords']>()
+      .mockResolvedValue({committedLength: 0, capped: false});
+
+    await nextStepForJob(jobId);
+    await runToolStepExecutorCycle({
+      integrations: {callTool} as unknown as IntegrationsModuleClient,
+      logs: {appendServerRecords} as unknown as LogsModuleClient,
+      signal: new AbortController().signal,
+      claimOwner: 'executor-test',
+      concurrency: 8,
+      callTimeoutMs: 30_000,
+    });
+
+    const [attempt] = await getStepAttempts(jobId);
+    expect(attempt).toMatchObject({
+      status: 'succeeded',
+      output: {result, issue_count: 3},
+    });
+  });
+
   test.each([
     ['null', {result: null, content: []}, null],
     ['a scalar', {result: null, content: [{type: 'text', text: '42'}]}, 42],

--- a/libs/api/workflows/src/core/tool-step/tool-step-executor.test.ts
+++ b/libs/api/workflows/src/core/tool-step/tool-step-executor.test.ts
@@ -5,6 +5,7 @@ import {createWorkflowExpression, type OutputDeclarations} from '@shipfox/expres
 import {createInterModuleKnownError} from '@shipfox/inter-module';
 import {createOutboxRegistry} from '@shipfox/node-module';
 import {eq} from 'drizzle-orm';
+import {MAX_JOB_OUTPUT_NESTING_DEPTH} from '#core/step-config/job-output-limits.js';
 import {db} from '#db/db.js';
 import {stepAttempts as stepAttemptsTable} from '#db/schema/step-attempts.js';
 import {steps as stepsTable} from '#db/schema/steps.js';
@@ -239,10 +240,61 @@ describe('tool step executor', () => {
     });
   });
 
+  test('preserves the largest safe CEL integer output mapping', async () => {
+    const {jobId} = await arrangeToolStep('read', {
+      outputDeclarations: {
+        result: {type: 'json'},
+        issue_count: {type: 'number'},
+      },
+      outputMappings: {
+        issue_count: createWorkflowExpression({
+          source: '9007199254740991',
+          check: {mode: 'syntax'},
+        }),
+      },
+    });
+    const callTool = vi.fn<IntegrationsModuleClient['callTool']>().mockResolvedValue({
+      outcome: 'success' as const,
+      result: {issues: []},
+      content: [],
+    });
+    const appendServerRecords = vi
+      .fn<LogsModuleClient['appendServerRecords']>()
+      .mockResolvedValue({committedLength: 0, capped: false});
+
+    await nextStepForJob(jobId);
+    await runToolStepExecutorCycle({
+      integrations: {callTool} as unknown as IntegrationsModuleClient,
+      logs: {appendServerRecords} as unknown as LogsModuleClient,
+      signal: new AbortController().signal,
+      claimOwner: 'executor-test',
+      concurrency: 8,
+      callTimeoutMs: 30_000,
+    });
+
+    const [attempt] = await getStepAttempts(jobId);
+    expect(attempt).toMatchObject({
+      status: 'succeeded',
+      output: {result: {issues: []}, issue_count: Number.MAX_SAFE_INTEGER},
+    });
+  });
+
   test.each([
     {
       description: 'an unsafe CEL integer without rounding',
       source: '9007199254740993',
+      result: {issues: []},
+      issue: 'integers must be between -9007199254740991 and 9007199254740991',
+    },
+    {
+      description: 'an unsafe CEL integer nested in a list',
+      source: '[9007199254740993]',
+      result: {issues: []},
+      issue: 'integers must be between -9007199254740991 and 9007199254740991',
+    },
+    {
+      description: 'an unsafe negative CEL integer',
+      source: '-9007199254740992',
       result: {issues: []},
       issue: 'integers must be between -9007199254740991 and 9007199254740991',
     },
@@ -296,10 +348,55 @@ describe('tool step executor', () => {
       },
     });
     const [attempt] = await getStepAttempts(jobId);
+    expect(attempt).toMatchObject({status: 'failed', output: null});
     expect(attempt?.invocations).toEqual([
       expect.objectContaining({call_index: 0, outcome: 'success'}),
     ]);
     expect(callTool).toHaveBeenCalledOnce();
+  });
+
+  test('reports the canonical nesting-limit error for deeply nested mappings', async () => {
+    let result: Record<string, unknown> = {value: 'leaf'};
+    for (let depth = 1; depth <= MAX_JOB_OUTPUT_NESTING_DEPTH; depth += 1) {
+      result = {value: result};
+    }
+    const {jobId} = await arrangeToolStep('read', {
+      outputDeclarations: {
+        result: {type: 'json'},
+        payload: {type: 'json'},
+      },
+      outputMappings: {
+        payload: createWorkflowExpression({source: 'result', check: {mode: 'syntax'}}),
+      },
+    });
+    const callTool = vi.fn<IntegrationsModuleClient['callTool']>().mockResolvedValue({
+      outcome: 'success' as const,
+      result,
+      content: [],
+    });
+    const appendServerRecords = vi
+      .fn<LogsModuleClient['appendServerRecords']>()
+      .mockResolvedValue({committedLength: 0, capped: false});
+
+    await nextStepForJob(jobId);
+    await runToolStepExecutorCycle({
+      integrations: {callTool} as unknown as IntegrationsModuleClient,
+      logs: {appendServerRecords} as unknown as LogsModuleClient,
+      signal: new AbortController().signal,
+      claimOwner: 'executor-test',
+      concurrency: 8,
+      callTimeoutMs: 30_000,
+    });
+
+    const [step] = await getStepsByJobId(jobId);
+    expect(step).toMatchObject({
+      status: 'failed',
+      error: {
+        code: 'output_invalid',
+        reason: 'output_invalid',
+        message: `Tool output mapping "payload" cannot be persisted as JSON: values cannot be nested deeper than ${MAX_JOB_OUTPUT_NESTING_DEPTH} levels`,
+      },
+    });
   });
 
   test.each([

--- a/libs/api/workflows/src/core/tool-step/tool-step-executor.test.ts
+++ b/libs/api/workflows/src/core/tool-step/tool-step-executor.test.ts
@@ -239,7 +239,20 @@ describe('tool step executor', () => {
     });
   });
 
-  test('rejects unsafe CEL integer output mappings without rounding', async () => {
+  test.each([
+    {
+      description: 'an unsafe CEL integer without rounding',
+      source: '9007199254740993',
+      result: {issues: []},
+      issue: 'integers must be between -9007199254740991 and 9007199254740991',
+    },
+    {
+      description: 'a non-finite CEL number',
+      source: 'result.open / result.total',
+      result: {open: 1, total: 0},
+      issue: 'numbers must be finite',
+    },
+  ])('rejects $description as output_invalid', async ({source, result, issue}) => {
     const {jobId} = await arrangeToolStep('read', {
       outputDeclarations: {
         result: {type: 'json'},
@@ -247,14 +260,14 @@ describe('tool step executor', () => {
       },
       outputMappings: {
         issue_count: createWorkflowExpression({
-          source: '9007199254740993',
+          source,
           check: {mode: 'syntax'},
         }),
       },
     });
     const callTool = vi.fn<IntegrationsModuleClient['callTool']>().mockResolvedValue({
       outcome: 'success' as const,
-      result: {issues: []},
+      result,
       content: [],
     });
     const appendServerRecords = vi
@@ -279,8 +292,7 @@ describe('tool step executor', () => {
       error: {
         code: 'output_invalid',
         reason: 'output_invalid',
-        message:
-          'Tool output mapping "issue_count" cannot be persisted as JSON: integers must be between -9007199254740991 and 9007199254740991',
+        message: `Tool output mapping "issue_count" cannot be persisted as JSON: ${issue}`,
       },
     });
     const [attempt] = await getStepAttempts(jobId);

--- a/libs/api/workflows/src/core/tool-step/tool-step-executor.ts
+++ b/libs/api/workflows/src/core/tool-step/tool-step-executor.ts
@@ -14,6 +14,7 @@ import {reportError} from '@shipfox/node-error-monitoring';
 import type {ModuleService} from '@shipfox/node-module';
 import {logger} from '@shipfox/node-opentelemetry';
 import {config} from '#config.js';
+import {JobOutputNotJsonSafeError} from '#core/errors.js';
 import {recordStepProgressionMetrics, recordStepResultInTransaction} from '#core/job-execution.js';
 import {normalizeJobOutputValue} from '#core/step-config/job-output-limits.js';
 import {type Tx, withTransaction} from '#db/db.js';
@@ -455,7 +456,7 @@ function mapToolOutputs(
         {cause: error},
       );
     }
-    const normalizedValue = normalizeJobOutputValue(value, key);
+    const normalizedValue = normalizeToolOutputMappingValue(value, key);
     Object.defineProperty(output, key, {
       configurable: true,
       enumerable: true,
@@ -464,6 +465,48 @@ function mapToolOutputs(
     });
   }
   return output;
+}
+
+type CelIntegerSafety = 'none' | 'safe' | 'unsafe';
+
+function normalizeToolOutputMappingValue(value: unknown, key: string): unknown {
+  const integerSafety = celIntegerSafety(value, new WeakSet<object>());
+  if (integerSafety === 'none') return value;
+  if (integerSafety === 'unsafe') {
+    throw new Error(
+      `Tool output mapping "${key}" cannot be persisted as JSON: integers must be between ${Number.MIN_SAFE_INTEGER} and ${Number.MAX_SAFE_INTEGER}`,
+    );
+  }
+
+  try {
+    return normalizeJobOutputValue(value, key);
+  } catch (error) {
+    if (error instanceof JobOutputNotJsonSafeError) {
+      throw new Error(`Tool output mapping "${key}" cannot be persisted as JSON: ${error.reason}`, {
+        cause: error,
+      });
+    }
+    throw error;
+  }
+}
+
+function celIntegerSafety(value: unknown, visited: WeakSet<object>): CelIntegerSafety {
+  if (typeof value === 'bigint') {
+    return Number.isSafeInteger(Number(value)) ? 'safe' : 'unsafe';
+  }
+  if (value === null || typeof value !== 'object' || visited.has(value)) return 'none';
+
+  visited.add(value);
+  let safety: CelIntegerSafety = 'none';
+  const values = Array.isArray(value)
+    ? value
+    : Object.keys(value).map((key) => (value as Record<string, unknown>)[key]);
+  for (const nestedValue of values) {
+    const nestedSafety = celIntegerSafety(nestedValue, visited);
+    if (nestedSafety === 'unsafe') return 'unsafe';
+    if (nestedSafety === 'safe') safety = 'safe';
+  }
+  return safety;
 }
 
 interface ToolExecutionError {

--- a/libs/api/workflows/src/core/tool-step/tool-step-executor.ts
+++ b/libs/api/workflows/src/core/tool-step/tool-step-executor.ts
@@ -15,6 +15,7 @@ import type {ModuleService} from '@shipfox/node-module';
 import {logger} from '@shipfox/node-opentelemetry';
 import {config} from '#config.js';
 import {recordStepProgressionMetrics, recordStepResultInTransaction} from '#core/job-execution.js';
+import {normalizeJobOutputValue} from '#core/step-config/job-output-limits.js';
 import {type Tx, withTransaction} from '#db/db.js';
 import {
   claimToolInvocations,
@@ -454,10 +455,11 @@ function mapToolOutputs(
         {cause: error},
       );
     }
+    const normalizedValue = normalizeJobOutputValue(value, key);
     Object.defineProperty(output, key, {
       configurable: true,
       enumerable: true,
-      value,
+      value: normalizedValue,
       writable: true,
     });
   }

--- a/libs/api/workflows/src/core/tool-step/tool-step-executor.ts
+++ b/libs/api/workflows/src/core/tool-step/tool-step-executor.ts
@@ -467,18 +467,14 @@ function mapToolOutputs(
   return output;
 }
 
-type CelIntegerSafety = 'none' | 'safe' | 'unsafe';
-
 function normalizeToolOutputMappingValue(value: unknown, key: string): unknown {
-  const integerSafety = celIntegerSafety(value, new WeakSet<object>());
-  if (integerSafety === 'none') return value;
-  if (integerSafety === 'unsafe') {
-    throw new Error(
-      `Tool output mapping "${key}" cannot be persisted as JSON: integers must be between ${Number.MIN_SAFE_INTEGER} and ${Number.MAX_SAFE_INTEGER}`,
-    );
-  }
-
   try {
+    if (containsUnsafeCelInteger(value, new WeakSet<object>())) {
+      throw new JobOutputNotJsonSafeError(
+        key,
+        `integers must be between ${Number.MIN_SAFE_INTEGER} and ${Number.MAX_SAFE_INTEGER}`,
+      );
+    }
     return normalizeJobOutputValue(value, key);
   } catch (error) {
     if (error instanceof JobOutputNotJsonSafeError) {
@@ -490,23 +486,17 @@ function normalizeToolOutputMappingValue(value: unknown, key: string): unknown {
   }
 }
 
-function celIntegerSafety(value: unknown, visited: WeakSet<object>): CelIntegerSafety {
+function containsUnsafeCelInteger(value: unknown, visited: WeakSet<object>): boolean {
   if (typeof value === 'bigint') {
-    return Number.isSafeInteger(Number(value)) ? 'safe' : 'unsafe';
+    return !Number.isSafeInteger(Number(value));
   }
-  if (value === null || typeof value !== 'object' || visited.has(value)) return 'none';
+  if (value === null || typeof value !== 'object' || visited.has(value)) return false;
 
   visited.add(value);
-  let safety: CelIntegerSafety = 'none';
   const values = Array.isArray(value)
     ? value
     : Object.keys(value).map((key) => (value as Record<string, unknown>)[key]);
-  for (const nestedValue of values) {
-    const nestedSafety = celIntegerSafety(nestedValue, visited);
-    if (nestedSafety === 'unsafe') return 'unsafe';
-    if (nestedSafety === 'safe') safety = 'safe';
-  }
-  return safety;
+  return values.some((nestedValue) => containsUnsafeCelInteger(nestedValue, visited));
 }
 
 interface ToolExecutionError {

--- a/libs/api/workflows/src/core/tool-step/tool-step-executor.ts
+++ b/libs/api/workflows/src/core/tool-step/tool-step-executor.ts
@@ -469,13 +469,14 @@ function mapToolOutputs(
 
 function normalizeToolOutputMappingValue(value: unknown, key: string): unknown {
   try {
+    const normalizedValue = normalizeJobOutputValue(value, key);
     if (containsUnsafeCelInteger(value, new WeakSet<object>())) {
       throw new JobOutputNotJsonSafeError(
         key,
         `integers must be between ${Number.MIN_SAFE_INTEGER} and ${Number.MAX_SAFE_INTEGER}`,
       );
     }
-    return normalizeJobOutputValue(value, key);
+    return normalizedValue;
   } catch (error) {
     if (error instanceof JobOutputNotJsonSafeError) {
       throw new Error(`Tool output mapping "${key}" cannot be persisted as JSON: ${error.reason}`, {


### PR DESCRIPTION
## Summary

CEL integer expressions such as `result.issue_types.size()` evaluate to a native integer value. Tool output mappings previously kept that raw value, so JSON serialization failed during step-result size accounting and the platform reported an `Infinity`-byte result.

Normalize mapped tool outputs through the existing job-output boundary before size enforcement and persistence. This preserves the 262144-byte limit while converting CEL-native values to JSON-safe output. A database-backed executor regression covers a `.size()` mapping and its persisted numeric result.

## Validation

- `mise exec -- turbo check type test --filter=@shipfox/api-workflows...`
- `mise exec -- turbo verify --filter=@shipfox/prose-policy`
- `mise exec -- pnpm exec changeset status`
- `mise exec -- vale --config=.vale.ini .changeset/calm-tools-count.md`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents valid CEL mappings such as `result.issues.size()` from being reported as `Infinity`-byte oversized results. Mapped tool outputs now normalize to JSON-safe values before the existing 262144-byte size check and persistence; unsafe integers, non-finite numbers, and values nested beyond 64 levels fail with clear `output_invalid` errors.

- Adds regression coverage for persisted `.size()` results and rejected unsafe, non-finite, or too-deeply-nested mappings.
- Documents the JSON-safe output requirements and nesting limit in the limits reference.

<sup>Written for commit 9da14d12685bedf23a496da61f410b8f87aa2894. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1706?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

