### PR TITLE
Enable renewable inference in managed runner images

### DIFF
--- a/.changeset/renewable-inference-gateway.md
+++ b/.changeset/renewable-inference-gateway.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-server": patch
+---
+
+Adds the E2E managed inference gateway configuration export for renewable Pi and Claude credentials.

--- a/.changeset/renewable-inference-gateway.md
+++ b/.changeset/renewable-inference-gateway.md
@@ -2,4 +2,4 @@
 "@shipfox/api-server": minor
 ---
 
-Adds the ./config entry point so applications can read server and E2E route settings (E2E_ENABLED, E2E_ADMIN_API_KEY, API_PORT, API_TRUST_PROXY) at runtime.
+Adds the ./config entry point for server and E2E route settings, and exposes shouldMountE2eRoutes for composition roots.

--- a/.changeset/renewable-inference-gateway.md
+++ b/.changeset/renewable-inference-gateway.md
@@ -2,4 +2,4 @@
 "@shipfox/api-server": minor
 ---
 
-Exposes the API server configuration entry point for application composition and E2E route gating.
+Exposes the API server configuration entry point so applications can read server and E2E route settings at runtime.

--- a/.changeset/renewable-inference-gateway.md
+++ b/.changeset/renewable-inference-gateway.md
@@ -2,4 +2,4 @@
 "@shipfox/api-server": minor
 ---
 
-Adds the ./config entry point so applications can read server and E2E route settings, including E2E_MANAGED_PROVIDER_BASE_URL, at runtime.
+Adds the ./config entry point so applications can read server and E2E route settings (E2E_ENABLED, E2E_ADMIN_API_KEY, API_PORT, API_TRUST_PROXY) at runtime.

--- a/.changeset/renewable-inference-gateway.md
+++ b/.changeset/renewable-inference-gateway.md
@@ -2,4 +2,4 @@
 "@shipfox/api-server": minor
 ---
 
-Exposes the API server configuration entry point so applications can read server and E2E route settings at runtime.
+Adds the ./config entry point so applications can read server and E2E route settings, including E2E_MANAGED_PROVIDER_BASE_URL, at runtime.

--- a/.changeset/renewable-inference-gateway.md
+++ b/.changeset/renewable-inference-gateway.md
@@ -1,5 +1,5 @@
 ---
-"@shipfox/api-server": patch
+"@shipfox/api-server": minor
 ---
 
-Adds the E2E managed inference gateway configuration export for renewable Pi and Claude credentials.
+Exposes the API server configuration entry point for application composition and E2E route gating.

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -20,8 +20,11 @@
     "type:emit": "shipfox-tsc-emit"
   },
   "dependencies": {
+    "@shipfox/api-agent-dto": "workspace:*",
     "@shipfox/api-server": "workspace:*",
     "@shipfox/node-error-monitoring": "workspace:*",
+    "@shipfox/node-fastify": "workspace:*",
+    "@shipfox/node-module": "workspace:*",
     "@shipfox/node-opentelemetry": "workspace:*"
   },
   "devDependencies": {

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@shipfox/api-agent-dto": "workspace:*",
     "@shipfox/api-server": "workspace:*",
+    "@shipfox/config": "workspace:*",
     "@shipfox/node-error-monitoring": "workspace:*",
     "@shipfox/node-fastify": "workspace:*",
     "@shipfox/node-module": "workspace:*",

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -1,0 +1,8 @@
+import {createConfig, url} from '@shipfox/config';
+
+export const config = createConfig({
+  E2E_MANAGED_PROVIDER_BASE_URL: url({
+    desc: 'Gateway root for the E2E-only managed model provider fixture. Leave unset outside the E2E harness.',
+    default: undefined,
+  }),
+});

--- a/apps/api/src/e2e-managed-inference.test.ts
+++ b/apps/api/src/e2e-managed-inference.test.ts
@@ -1,0 +1,89 @@
+import {closeApp, createApp} from '@shipfox/node-fastify';
+import {afterEach, describe, expect, it} from '@shipfox/vitest/vi';
+import {createE2eManagedInferenceProvider} from './e2e-managed-inference.js';
+
+const JOB_IDENTITY = {
+  projectId: '00000000-0000-4000-8000-000000000001',
+  jobId: '00000000-0000-4000-8000-000000000002',
+  jobExecutionId: '00000000-0000-4000-8000-000000000003',
+  stepId: '00000000-0000-4000-8000-000000000004',
+  attempt: 1,
+};
+const UUID_V4_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/iu;
+
+afterEach(async () => {
+  await closeApp();
+});
+
+describe('E2E managed inference fixture', () => {
+  it('accepts generation one for static credentials', async () => {
+    const fixture = createE2eManagedInferenceProvider('http://provider.test');
+    if (fixture === undefined) throw new Error('fixture should be configured');
+    const app = await createApp({
+      auth: fixture.module.auth ?? [],
+      routes: fixture.module.routes ?? [],
+      swagger: false,
+    });
+    const runtimeConfig = await fixture.provider.resolveCredentials({
+      workspaceId: 'workspace',
+      runId: 'run',
+      stepAttemptId: 'static-step',
+      jobIdentity: JOB_IDENTITY,
+      model: 'e2e-renewable-pi',
+      renewableInference: false,
+    });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/__e2e-managed-inference/v1/chat/completions',
+      headers: {authorization: `Bearer ${runtimeConfig.credentials.api_key}`},
+      payload: {model: 'e2e-renewable-pi'},
+    });
+
+    expect(response.statusCode).toBe(200);
+  });
+
+  it('rejects renewable generation one and accepts the refreshed generation', async () => {
+    const fixture = createE2eManagedInferenceProvider('http://provider.test');
+    if (fixture === undefined) throw new Error('fixture should be configured');
+    const app = await createApp({
+      auth: fixture.module.auth ?? [],
+      routes: fixture.module.routes ?? [],
+      swagger: false,
+    });
+    const first = await fixture.provider.resolveCredentials({
+      workspaceId: 'workspace',
+      runId: 'run',
+      stepAttemptId: 'renewable-step',
+      jobIdentity: JOB_IDENTITY,
+      model: 'e2e-renewable-pi',
+      renewableInference: true,
+    });
+    expect(first.generation).toMatch(UUID_V4_PATTERN);
+
+    const rejected = await app.inject({
+      method: 'POST',
+      url: '/__e2e-managed-inference/v1/chat/completions',
+      headers: {authorization: `Bearer ${first.credentials.api_key}`},
+      payload: {model: 'e2e-renewable-pi'},
+    });
+    expect(rejected.statusCode).toBe(401);
+
+    const refreshed = await fixture.provider.resolveCredentials({
+      workspaceId: 'workspace',
+      runId: 'run',
+      stepAttemptId: 'renewable-step',
+      jobIdentity: JOB_IDENTITY,
+      model: 'e2e-renewable-pi',
+      renewableInference: true,
+    });
+    const accepted = await app.inject({
+      method: 'POST',
+      url: '/__e2e-managed-inference/v1/chat/completions',
+      headers: {authorization: `Bearer ${refreshed.credentials.api_key}`},
+      payload: {model: 'e2e-renewable-pi'},
+    });
+
+    expect(accepted.statusCode).toBe(200);
+  });
+});

--- a/apps/api/src/e2e-managed-inference.test.ts
+++ b/apps/api/src/e2e-managed-inference.test.ts
@@ -182,7 +182,7 @@ describe('E2E managed inference fixture', () => {
     expect(acceptedRefreshAt.statusCode).toBe(200);
   });
 
-  it('keeps credential state bounded and excludes unknown tokens from generation stats', async () => {
+  it('keeps credential state bounded and excludes unissued generations from stats', async () => {
     const fixture = createE2eManagedInferenceProvider('http://provider.test', 'e2e-admin-key');
     if (fixture === undefined) throw new Error('fixture should be configured');
     const app = await createApp({
@@ -238,6 +238,14 @@ describe('E2E managed inference fixture', () => {
     expect(newest.statusCode).toBe(200);
 
     const before = await app.inject({method: 'GET', url: '/managed-inference/stats'});
+    const unissuedGeneration = await app.inject({
+      method: 'POST',
+      url: '/__e2e-managed-inference/v1/chat/completions',
+      headers: {authorization: 'Bearer shipfox-e2e-bounded-step-1000-g999'},
+      payload: {model: 'e2e-renewable-pi'},
+    });
+    expect(unissuedGeneration.statusCode).toBe(401);
+
     for (let index = 0; index < 10; index += 1) {
       const unknown = await app.inject({
         method: 'POST',

--- a/apps/api/src/e2e-managed-inference.test.ts
+++ b/apps/api/src/e2e-managed-inference.test.ts
@@ -17,7 +17,7 @@ afterEach(async () => {
 
 describe('E2E managed inference fixture', () => {
   it('accepts generation one for static credentials', async () => {
-    const fixture = createE2eManagedInferenceProvider('http://provider.test');
+    const fixture = createE2eManagedInferenceProvider('http://provider.test', 'e2e-admin-key');
     if (fixture === undefined) throw new Error('fixture should be configured');
     const app = await createApp({
       auth: fixture.module.auth ?? [],
@@ -41,10 +41,18 @@ describe('E2E managed inference fixture', () => {
     });
 
     expect(response.statusCode).toBe(200);
+
+    const adminResponse = await app.inject({
+      method: 'POST',
+      url: '/__e2e-managed-inference/v1/chat/completions',
+      headers: {authorization: 'Bearer e2e-admin-key'},
+      payload: {model: 'e2e-renewable-pi'},
+    });
+    expect(adminResponse.statusCode).toBe(200);
   });
 
   it('rejects renewable generation one and accepts the refreshed generation', async () => {
-    const fixture = createE2eManagedInferenceProvider('http://provider.test');
+    const fixture = createE2eManagedInferenceProvider('http://provider.test', 'e2e-admin-key');
     if (fixture === undefined) throw new Error('fixture should be configured');
     const app = await createApp({
       auth: fixture.module.auth ?? [],
@@ -68,6 +76,7 @@ describe('E2E managed inference fixture', () => {
       payload: {model: 'e2e-renewable-pi'},
     });
     expect(rejected.statusCode).toBe(401);
+    expect(rejected.json()).toEqual({error: {code: 'unauthorized'}});
 
     const refreshed = await fixture.provider.resolveCredentials({
       workspaceId: 'workspace',

--- a/apps/api/src/e2e-managed-inference.test.ts
+++ b/apps/api/src/e2e-managed-inference.test.ts
@@ -1,5 +1,5 @@
 import {closeApp, createApp} from '@shipfox/node-fastify';
-import {afterEach, describe, expect, it} from '@shipfox/vitest/vi';
+import {afterEach, describe, expect, it, vi} from '@shipfox/vitest/vi';
 import {createE2eManagedInferenceProvider} from './e2e-managed-inference.js';
 
 const JOB_IDENTITY = {
@@ -12,6 +12,8 @@ const JOB_IDENTITY = {
 const UUID_V4_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/iu;
 
 afterEach(async () => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
   await closeApp();
 });
 
@@ -94,5 +96,210 @@ describe('E2E managed inference fixture', () => {
     });
 
     expect(accepted.statusCode).toBe(200);
+  });
+
+  it('serves Claude and refresh-at credentials through the matching API route', async () => {
+    const fixture = createE2eManagedInferenceProvider('http://provider.test', 'e2e-admin-key');
+    if (fixture === undefined) throw new Error('fixture should be configured');
+    const app = await createApp({
+      auth: fixture.module.auth ?? [],
+      routes: fixture.module.routes ?? [],
+      swagger: false,
+    });
+
+    const firstClaude = await fixture.provider.resolveCredentials({
+      workspaceId: 'workspace',
+      runId: 'run',
+      stepAttemptId: 'claude-step',
+      jobIdentity: JOB_IDENTITY,
+      model: 'e2e-renewable-claude',
+      renewableInference: true,
+    });
+    const rejectedClaude = await app.inject({
+      method: 'POST',
+      url: '/__e2e-managed-inference/v1/messages',
+      headers: {'x-api-key': firstClaude.credentials.api_key},
+      payload: {model: 'e2e-renewable-claude'},
+    });
+    expect(rejectedClaude.statusCode).toBe(401);
+    expect(rejectedClaude.json()).toEqual({
+      type: 'error',
+      error: {type: 'authentication_error', message: 'unauthorized'},
+    });
+
+    const refreshedClaude = await fixture.provider.resolveCredentials({
+      workspaceId: 'workspace',
+      runId: 'run',
+      stepAttemptId: 'claude-step',
+      jobIdentity: JOB_IDENTITY,
+      model: 'e2e-renewable-claude',
+      renewableInference: true,
+    });
+    const acceptedClaude = await app.inject({
+      method: 'POST',
+      url: '/__e2e-managed-inference/v1/messages',
+      headers: {'x-api-key': refreshedClaude.credentials.api_key},
+      payload: {model: 'e2e-renewable-claude'},
+    });
+    expect(acceptedClaude.statusCode).toBe(200);
+
+    const firstRefreshAt = await fixture.provider.resolveCredentials({
+      workspaceId: 'workspace',
+      runId: 'run',
+      stepAttemptId: 'refresh-at-step',
+      jobIdentity: JOB_IDENTITY,
+      model: 'e2e-refresh-renewable-claude',
+      renewableInference: true,
+    });
+    if (firstRefreshAt.renewal?.mode !== 'refresh-at' || firstRefreshAt.expiresAt === undefined) {
+      throw new Error('refresh-at credentials should include a renewal window');
+    }
+    expect(firstRefreshAt.renewal.refreshAt.getTime()).toBeLessThan(
+      firstRefreshAt.expiresAt.getTime(),
+    );
+    const rejectedRefreshAt = await app.inject({
+      method: 'POST',
+      url: '/__e2e-managed-inference/v1/messages',
+      headers: {'x-api-key': firstRefreshAt.credentials.api_key},
+      payload: {model: 'e2e-refresh-renewable-claude'},
+    });
+    expect(rejectedRefreshAt.statusCode).toBe(401);
+
+    const refreshedRefreshAt = await fixture.provider.resolveCredentials({
+      workspaceId: 'workspace',
+      runId: 'run',
+      stepAttemptId: 'refresh-at-step',
+      jobIdentity: JOB_IDENTITY,
+      model: 'e2e-refresh-renewable-claude',
+      renewableInference: true,
+    });
+    const acceptedRefreshAt = await app.inject({
+      method: 'POST',
+      url: '/__e2e-managed-inference/v1/messages',
+      headers: {'x-api-key': refreshedRefreshAt.credentials.api_key},
+      payload: {model: 'e2e-refresh-renewable-claude'},
+    });
+    expect(acceptedRefreshAt.statusCode).toBe(200);
+  });
+
+  it('keeps credential state bounded and excludes unknown tokens from generation stats', async () => {
+    const fixture = createE2eManagedInferenceProvider('http://provider.test', 'e2e-admin-key');
+    if (fixture === undefined) throw new Error('fixture should be configured');
+    const app = await createApp({
+      auth: fixture.module.auth ?? [],
+      routes: [...(fixture.module.routes ?? []), ...(fixture.module.e2eRoutes ?? [])],
+      swagger: false,
+    });
+
+    let oldestToken = '';
+    let newestToken = '';
+    for (let index = 0; index <= 1_000; index += 1) {
+      const runtimeConfig = await fixture.provider.resolveCredentials({
+        workspaceId: 'workspace',
+        runId: 'run',
+        stepAttemptId: `bounded-step-${index}`,
+        jobIdentity: JOB_IDENTITY,
+        model: 'e2e-renewable-pi',
+        renewableInference: false,
+      });
+      const token = runtimeConfig.credentials.api_key;
+      if (token === undefined) throw new Error('E2E credentials should include an API key');
+      if (index === 0) oldestToken = token;
+      newestToken = token;
+    }
+
+    const evicted = await app.inject({
+      method: 'POST',
+      url: '/__e2e-managed-inference/v1/chat/completions',
+      headers: {authorization: `Bearer ${oldestToken}`},
+      payload: {model: 'e2e-renewable-pi'},
+    });
+    expect(evicted.statusCode).toBe(401);
+
+    const newest = await app.inject({
+      method: 'POST',
+      url: '/__e2e-managed-inference/v1/chat/completions',
+      headers: {authorization: `Bearer ${newestToken}`},
+      payload: {model: 'e2e-renewable-pi'},
+    });
+    expect(newest.statusCode).toBe(200);
+
+    const before = await app.inject({method: 'GET', url: '/managed-inference/stats'});
+    for (let index = 0; index < 10; index += 1) {
+      const unknown = await app.inject({
+        method: 'POST',
+        url: '/__e2e-managed-inference/v1/chat/completions',
+        headers: {authorization: `Bearer shipfox-e2e-unknown-step-${index}-g1`},
+        payload: {model: 'e2e-renewable-pi'},
+      });
+      expect(unknown.statusCode).toBe(401);
+    }
+    const after = await app.inject({method: 'GET', url: '/managed-inference/stats'});
+    expect(after.json().requestsByGeneration).toEqual(before.json().requestsByGeneration);
+  });
+
+  it('retains static credential state past the renewable state TTL', async () => {
+    let now = Date.now();
+    vi.spyOn(Date, 'now').mockImplementation(() => now);
+    const fixture = createE2eManagedInferenceProvider('http://provider.test', 'e2e-admin-key');
+    if (fixture === undefined) throw new Error('fixture should be configured');
+    const app = await createApp({
+      auth: fixture.module.auth ?? [],
+      routes: fixture.module.routes ?? [],
+      swagger: false,
+    });
+    const runtimeConfig = await fixture.provider.resolveCredentials({
+      workspaceId: 'workspace',
+      runId: 'run',
+      stepAttemptId: 'static-retention-step',
+      jobIdentity: JOB_IDENTITY,
+      model: 'e2e-renewable-pi',
+      renewableInference: false,
+    });
+
+    now += 600_001;
+    const response = await app.inject({
+      method: 'POST',
+      url: '/__e2e-managed-inference/v1/chat/completions',
+      headers: {authorization: `Bearer ${runtimeConfig.credentials.api_key}`},
+      payload: {model: 'e2e-renewable-pi'},
+    });
+
+    expect(response.statusCode).toBe(200);
+  });
+
+  it('rejects model and renewable mode changes for a credential identity', async () => {
+    const fixture = createE2eManagedInferenceProvider('http://provider.test', 'e2e-admin-key');
+    if (fixture === undefined) throw new Error('fixture should be configured');
+    const credentialParams = {
+      workspaceId: 'workspace',
+      runId: 'run',
+      stepAttemptId: 'guard-step',
+      jobIdentity: JOB_IDENTITY,
+    };
+    await fixture.provider.resolveCredentials({
+      ...credentialParams,
+      model: 'e2e-renewable-pi',
+      renewableInference: false,
+    });
+
+    await expect(
+      Promise.resolve().then(() =>
+        fixture.provider.resolveCredentials({
+          ...credentialParams,
+          model: 'e2e-renewable-claude',
+          renewableInference: false,
+        }),
+      ),
+    ).rejects.toThrow('model changed during credential renewal');
+    await expect(
+      Promise.resolve().then(() =>
+        fixture.provider.resolveCredentials({
+          ...credentialParams,
+          model: 'e2e-renewable-pi',
+          renewableInference: true,
+        }),
+      ),
+    ).rejects.toThrow('renewable mode changed during credential renewal');
   });
 });

--- a/apps/api/src/e2e-managed-inference.test.ts
+++ b/apps/api/src/e2e-managed-inference.test.ts
@@ -216,6 +216,19 @@ describe('E2E managed inference fixture', () => {
     });
     expect(evicted.statusCode).toBe(401);
 
+    await expect(
+      Promise.resolve().then(() =>
+        fixture.provider.resolveCredentials({
+          workspaceId: 'workspace',
+          runId: 'run',
+          stepAttemptId: 'bounded-step-0',
+          jobIdentity: JOB_IDENTITY,
+          model: 'e2e-renewable-claude',
+          renewableInference: false,
+        }),
+      ),
+    ).rejects.toThrow('model changed during credential renewal');
+
     const newest = await app.inject({
       method: 'POST',
       url: '/__e2e-managed-inference/v1/chat/completions',

--- a/apps/api/src/e2e-managed-inference.ts
+++ b/apps/api/src/e2e-managed-inference.ts
@@ -237,16 +237,12 @@ function createInferenceAuth(state: InferenceState, adminApiKey: string | undefi
       if (!isCurrentCredential(credential)) {
         state.stats.expiredRequests += 1;
         if (credential.tokenDetails !== undefined && credential.credentialState !== undefined) {
-          recordGeneration(
-            state,
-            credential.tokenDetails.generation,
-            credential.credentialState.model,
-          );
+          recordGeneration(state, credential.tokenDetails.generation, credential.credentialState);
         }
         throw new ClientError('Expired credential', 'unauthorized', {status: 401});
       }
       state.stats.acceptedRequests += 1;
-      recordGeneration(state, credential.tokenDetails.generation, credential.credentialState.model);
+      recordGeneration(state, credential.tokenDetails.generation, credential.credentialState);
       return Promise.resolve();
     },
   };
@@ -505,14 +501,16 @@ function bodyBoolean(body: unknown, key: string): boolean {
 function recordGeneration(
   state: InferenceState,
   generation: number,
-  model: string | undefined,
+  credentialState: CredentialState,
 ): void {
+  if (generation >= credentialState.nextGeneration) return;
+
   const key = String(generation);
   state.stats.requestsByGeneration[key] = (state.stats.requestsByGeneration[key] ?? 0) + 1;
-  if (model === undefined) return;
 
-  const requestsByGeneration = state.stats.requestsByModelAndGeneration[model] ?? {};
-  state.stats.requestsByModelAndGeneration[model] = requestsByGeneration;
+  const requestsByGeneration =
+    state.stats.requestsByModelAndGeneration[credentialState.model] ?? {};
+  state.stats.requestsByModelAndGeneration[credentialState.model] = requestsByGeneration;
   requestsByGeneration[key] = (requestsByGeneration[key] ?? 0) + 1;
 }
 

--- a/apps/api/src/e2e-managed-inference.ts
+++ b/apps/api/src/e2e-managed-inference.ts
@@ -1,9 +1,10 @@
+import {randomUUID} from 'node:crypto';
 import type {
   ManagedModelApi,
   ManagedModelProvider,
   ManagedProviderRuntimeConfig,
 } from '@shipfox/api-agent-dto';
-import {defineRoute, type RouteGroup} from '@shipfox/node-fastify';
+import {type AuthMethod, ClientError, defineRoute, type RouteGroup} from '@shipfox/node-fastify';
 import type {ShipfoxModule} from '@shipfox/node-module';
 
 const E2E_MANAGED_PROVIDER_ID = 'shipfox';
@@ -14,8 +15,12 @@ const E2E_REFRESH_CLAUDE_MODEL = 'e2e-refresh-renewable-claude';
 const E2E_CLAUDE_MODEL_ID = 'claude-opus-4-8';
 const E2E_RESPONSE_TEXT = 'ok';
 const E2E_CREDENTIAL_LIFETIME_MS = 300_000;
+const E2E_CREDENTIAL_STATE_TTL_MS = E2E_CREDENTIAL_LIFETIME_MS * 2;
+const E2E_MAX_CREDENTIAL_STATES = 1_000;
 const E2E_RENEWAL_DELAY_MS = 30_000;
 const E2E_INFERENCE_ROUTE_PREFIX = '/__e2e-managed-inference';
+const E2E_INFERENCE_STATS_ROUTE_PREFIX = '/managed-inference';
+const E2E_MANAGED_INFERENCE_AUTH = 'e2e-managed-inference';
 const TOKEN_PATTERN = /^shipfox-e2e-(.+)-g(\d+)$/u;
 
 const E2E_MODELS = [
@@ -42,6 +47,8 @@ const E2E_MODELS = [
 interface CredentialState {
   nextGeneration: number;
   model: string;
+  renewableInference: boolean;
+  lastTouchedAt: number;
 }
 
 interface InferenceStats {
@@ -50,6 +57,7 @@ interface InferenceStats {
   acceptedRequests: number;
   resolutionsByModel: Record<string, number>;
   requestsByGeneration: Record<string, number>;
+  requestsByModelAndGeneration: Record<string, Record<string, number>>;
 }
 
 interface InferenceState {
@@ -70,6 +78,7 @@ export function createE2eManagedInferenceProvider(
       acceptedRequests: 0,
       resolutionsByModel: {},
       requestsByGeneration: {},
+      requestsByModelAndGeneration: {},
     },
   };
 
@@ -90,15 +99,24 @@ export function createE2eManagedInferenceProvider(
       }
 
       const key = params.stepAttemptId;
+      const now = Date.now();
+      pruneCredentialStates(state, now);
+      const renewableInference = params.renewableInference === true;
       const credentialState = state.credentials.get(key) ?? {
         nextGeneration: 1,
         model: model.id,
+        renewableInference,
+        lastTouchedAt: now,
       };
       if (credentialState.model !== model.id) {
         throw new Error('E2E managed provider model changed during credential renewal');
       }
+      if (credentialState.renewableInference !== renewableInference) {
+        throw new Error('E2E managed provider renewable mode changed during credential renewal');
+      }
       const generation = credentialState.nextGeneration;
       credentialState.nextGeneration += 1;
+      credentialState.lastTouchedAt = now;
       state.credentials.set(key, credentialState);
       state.stats.resolutions += 1;
       state.stats.resolutionsByModel[model.id] =
@@ -110,13 +128,12 @@ export function createE2eManagedInferenceProvider(
         baseUrl,
         credentials: {api_key: token},
       };
-      if (params.renewableInference !== true) return Promise.resolve(runtimeConfig);
+      if (!renewableInference) return Promise.resolve(runtimeConfig);
 
-      const now = Date.now();
       return Promise.resolve({
         ...runtimeConfig,
         expiresAt: new Date(now + E2E_CREDENTIAL_LIFETIME_MS),
-        generation: `generation-${generation}`,
+        generation: randomUUID(),
         renewal: {
           mode: 'refresh-at',
           refreshAt: new Date(
@@ -131,7 +148,9 @@ export function createE2eManagedInferenceProvider(
     provider,
     module: {
       name: 'e2e-managed-inference',
+      auth: [createInferenceAuth(state)],
       routes: [createInferenceRoutes(state)],
+      e2eRoutes: [createInferenceStatsRoutes(state)],
     },
   };
 }
@@ -139,13 +158,8 @@ export function createE2eManagedInferenceProvider(
 function createInferenceRoutes(state: InferenceState): RouteGroup {
   return {
     prefix: E2E_INFERENCE_ROUTE_PREFIX,
+    auth: E2E_MANAGED_INFERENCE_AUTH,
     routes: [
-      defineRoute({
-        method: 'GET',
-        path: '/stats',
-        description: 'Returns non-secret E2E managed inference fixture counters.',
-        handler: () => state.stats,
-      }),
       defineRoute({
         method: 'POST',
         path: '/v1/chat/completions',
@@ -176,6 +190,51 @@ function createInferenceRoutes(state: InferenceState): RouteGroup {
   };
 }
 
+function createInferenceStatsRoutes(state: InferenceState): RouteGroup {
+  return {
+    prefix: E2E_INFERENCE_STATS_ROUTE_PREFIX,
+    routes: [
+      defineRoute({
+        method: 'GET',
+        path: '/stats',
+        description: 'Returns non-secret E2E managed inference fixture counters.',
+        handler: () => state.stats,
+      }),
+    ],
+  };
+}
+
+function createInferenceAuth(state: InferenceState): AuthMethod {
+  return {
+    name: E2E_MANAGED_INFERENCE_AUTH,
+    authenticate: (request) => {
+      const token = requestToken(request.headers);
+      if (token === undefined) {
+        throw new ClientError('Missing credential', 'unauthorized', {status: 401});
+      }
+
+      const tokenDetails = parseToken(token);
+      const credentialState =
+        tokenDetails === undefined
+          ? undefined
+          : currentCredentialState(state, tokenDetails.stepAttemptId);
+      const credential = {tokenDetails, credentialState};
+      if (!isCurrentCredential(credential)) {
+        state.stats.expiredRequests += 1;
+        if (credential.tokenDetails !== undefined) {
+          recordGeneration(
+            state,
+            credential.tokenDetails.generation,
+            credential.credentialState?.model,
+          );
+        }
+        throw new ClientError('Expired credential', 'unauthorized', {status: 401});
+      }
+      return Promise.resolve();
+    },
+  };
+}
+
 function respondToInferenceRequest(params: {
   api: ManagedModelApi;
   body: unknown;
@@ -199,23 +258,29 @@ function respondToInferenceRequest(params: {
   if (token === undefined) {
     return params.reply.code(401).send({code: 'unauthorized', message: 'missing credential'});
   }
-  const currentGeneration =
+  const credentialState =
     tokenDetails === undefined
       ? undefined
-      : currentCredentialGeneration(params.state, tokenDetails.stepAttemptId);
-  if (
-    tokenDetails === undefined ||
-    currentGeneration === undefined ||
-    tokenDetails.generation !== currentGeneration ||
-    tokenDetails.generation === 1
-  ) {
+      : currentCredentialState(params.state, tokenDetails.stepAttemptId);
+  const credential = {tokenDetails, credentialState};
+  if (!isCurrentCredential(credential)) {
     params.state.stats.expiredRequests += 1;
-    if (tokenDetails !== undefined) recordGeneration(params.state, tokenDetails.generation);
+    if (credential.tokenDetails !== undefined) {
+      recordGeneration(
+        params.state,
+        credential.tokenDetails.generation,
+        credential.credentialState?.model,
+      );
+    }
     return params.reply.code(401).send({code: 'unauthorized', message: 'expired'});
   }
 
   params.state.stats.acceptedRequests += 1;
-  recordGeneration(params.state, tokenDetails.generation);
+  recordGeneration(
+    params.state,
+    credential.tokenDetails.generation,
+    credential.credentialState.model,
+  );
   if (params.api === 'openai-completions') {
     return respondWithOpenAiCompletion(params.reply, requestModel, params.body);
   }
@@ -375,12 +440,37 @@ function parseToken(
     : undefined;
 }
 
-function currentCredentialGeneration(
+function currentCredentialState(
   state: InferenceState,
   stepAttemptId: string,
-): number | undefined {
+): CredentialState | undefined {
+  const now = Date.now();
+  pruneCredentialStates(state, now);
   const credentialState = state.credentials.get(stepAttemptId);
-  return credentialState === undefined ? undefined : credentialState.nextGeneration - 1;
+  if (credentialState !== undefined) credentialState.lastTouchedAt = now;
+  return credentialState;
+}
+
+interface CredentialCandidate {
+  tokenDetails: {generation: number} | undefined;
+  credentialState: CredentialState | undefined;
+}
+
+interface CurrentCredentialCandidate {
+  tokenDetails: {generation: number};
+  credentialState: CredentialState;
+}
+
+function isCurrentCredential(
+  credential: CredentialCandidate,
+): credential is CurrentCredentialCandidate {
+  const {tokenDetails, credentialState} = credential;
+  return (
+    tokenDetails !== undefined &&
+    credentialState !== undefined &&
+    tokenDetails.generation === credentialState.nextGeneration - 1 &&
+    (!credentialState.renewableInference || tokenDetails.generation !== 1)
+  );
 }
 
 function headerValue(value: unknown): string | undefined {
@@ -400,9 +490,39 @@ function bodyBoolean(body: unknown, key: string): boolean {
   return (body as Record<string, unknown>)[key] === true;
 }
 
-function recordGeneration(state: InferenceState, generation: number): void {
+function recordGeneration(
+  state: InferenceState,
+  generation: number,
+  model: string | undefined,
+): void {
   const key = String(generation);
   state.stats.requestsByGeneration[key] = (state.stats.requestsByGeneration[key] ?? 0) + 1;
+  if (model === undefined) return;
+
+  const requestsByGeneration = state.stats.requestsByModelAndGeneration[model] ?? {};
+  state.stats.requestsByModelAndGeneration[model] = requestsByGeneration;
+  requestsByGeneration[key] = (requestsByGeneration[key] ?? 0) + 1;
+}
+
+function pruneCredentialStates(state: InferenceState, now: number): void {
+  for (const [key, credentialState] of state.credentials) {
+    if (now - credentialState.lastTouchedAt > E2E_CREDENTIAL_STATE_TTL_MS) {
+      state.credentials.delete(key);
+    }
+  }
+
+  while (state.credentials.size > E2E_MAX_CREDENTIAL_STATES) {
+    let oldestKey: string | undefined;
+    let oldestTouchedAt = Number.POSITIVE_INFINITY;
+    for (const [key, credentialState] of state.credentials) {
+      if (credentialState.lastTouchedAt < oldestTouchedAt) {
+        oldestKey = key;
+        oldestTouchedAt = credentialState.lastTouchedAt;
+      }
+    }
+    if (oldestKey === undefined) return;
+    state.credentials.delete(oldestKey);
+  }
 }
 
 function isRefreshAtModel(model: string): boolean {

--- a/apps/api/src/e2e-managed-inference.ts
+++ b/apps/api/src/e2e-managed-inference.ts
@@ -4,7 +4,15 @@ import type {
   ManagedModelProvider,
   ManagedProviderRuntimeConfig,
 } from '@shipfox/api-agent-dto';
-import {type AuthMethod, ClientError, defineRoute, type RouteGroup} from '@shipfox/node-fastify';
+import {
+  type AuthMethod,
+  ClientError,
+  errorHandler as defaultErrorHandler,
+  defineRoute,
+  type FastifyReply,
+  type FastifyRequest,
+  type RouteGroup,
+} from '@shipfox/node-fastify';
 import type {ShipfoxModule} from '@shipfox/node-module';
 
 const E2E_MANAGED_PROVIDER_ID = 'shipfox';
@@ -67,6 +75,7 @@ interface InferenceState {
 
 export function createE2eManagedInferenceProvider(
   baseUrl: string | undefined,
+  adminApiKey?: string,
 ): {provider: ManagedModelProvider; module: ShipfoxModule} | undefined {
   if (baseUrl === undefined) return undefined;
 
@@ -148,14 +157,14 @@ export function createE2eManagedInferenceProvider(
     provider,
     module: {
       name: 'e2e-managed-inference',
-      auth: [createInferenceAuth(state)],
-      routes: [createInferenceRoutes(state)],
+      auth: [createInferenceAuth(state, adminApiKey)],
+      routes: [createInferenceRoutes(state, adminApiKey)],
       e2eRoutes: [createInferenceStatsRoutes(state)],
     },
   };
 }
 
-function createInferenceRoutes(state: InferenceState): RouteGroup {
+function createInferenceRoutes(state: InferenceState, adminApiKey: string | undefined): RouteGroup {
   return {
     prefix: E2E_INFERENCE_ROUTE_PREFIX,
     auth: E2E_MANAGED_INFERENCE_AUTH,
@@ -164,11 +173,13 @@ function createInferenceRoutes(state: InferenceState): RouteGroup {
         method: 'POST',
         path: '/v1/chat/completions',
         description: 'Serves the scripted OpenAI-compatible E2E managed inference response.',
+        errorHandler: inferenceAuthenticationErrorHandler,
         handler: (request, reply) =>
           respondToInferenceRequest({
             api: 'openai-completions',
             body: request.body,
             headers: request.headers,
+            adminApiKey,
             reply,
             state,
           }),
@@ -177,11 +188,13 @@ function createInferenceRoutes(state: InferenceState): RouteGroup {
         method: 'POST',
         path: '/v1/messages',
         description: 'Serves the scripted Anthropic-compatible E2E managed inference response.',
+        errorHandler: inferenceAuthenticationErrorHandler,
         handler: (request, reply) =>
           respondToInferenceRequest({
             api: 'anthropic-messages',
             body: request.body,
             headers: request.headers,
+            adminApiKey,
             reply,
             state,
           }),
@@ -204,7 +217,7 @@ function createInferenceStatsRoutes(state: InferenceState): RouteGroup {
   };
 }
 
-function createInferenceAuth(state: InferenceState): AuthMethod {
+function createInferenceAuth(state: InferenceState, adminApiKey: string | undefined): AuthMethod {
   return {
     name: E2E_MANAGED_INFERENCE_AUTH,
     authenticate: (request) => {
@@ -212,6 +225,7 @@ function createInferenceAuth(state: InferenceState): AuthMethod {
       if (token === undefined) {
         throw new ClientError('Missing credential', 'unauthorized', {status: 401});
       }
+      if (adminApiKey !== undefined && token === adminApiKey) return Promise.resolve();
 
       const tokenDetails = parseToken(token);
       const credentialState =
@@ -235,10 +249,29 @@ function createInferenceAuth(state: InferenceState): AuthMethod {
   };
 }
 
+function inferenceAuthenticationErrorHandler(
+  error: unknown,
+  request: FastifyRequest,
+  reply: FastifyReply,
+): unknown {
+  if (!(error instanceof ClientError) || error.code !== 'unauthorized') {
+    return defaultErrorHandler(error, request, reply);
+  }
+
+  if (request.url.includes('/v1/messages')) {
+    return reply.code(401).send({
+      type: 'error',
+      error: {type: 'authentication_error', message: 'unauthorized'},
+    });
+  }
+  return reply.code(401).send({error: {code: 'unauthorized'}});
+}
+
 function respondToInferenceRequest(params: {
   api: ManagedModelApi;
   body: unknown;
   headers: Record<string, unknown>;
+  adminApiKey: string | undefined;
   reply: {
     code(statusCode: number): {send(payload: unknown): unknown};
     header(name: string, value: string): unknown;
@@ -257,6 +290,13 @@ function respondToInferenceRequest(params: {
   const requestModel = bodyString(params.body, 'model') ?? 'unknown';
   if (token === undefined) {
     return params.reply.code(401).send({code: 'unauthorized', message: 'missing credential'});
+  }
+  if (params.adminApiKey !== undefined && token === params.adminApiKey) {
+    params.state.stats.acceptedRequests += 1;
+    if (params.api === 'openai-completions') {
+      return respondWithOpenAiCompletion(params.reply, requestModel, params.body);
+    }
+    return respondWithAnthropicMessage(params.reply, requestModel, params.body);
   }
   const credentialState =
     tokenDetails === undefined

--- a/apps/api/src/e2e-managed-inference.ts
+++ b/apps/api/src/e2e-managed-inference.ts
@@ -1,0 +1,410 @@
+import type {
+  ManagedModelApi,
+  ManagedModelProvider,
+  ManagedProviderRuntimeConfig,
+} from '@shipfox/api-agent-dto';
+import {defineRoute, type RouteGroup} from '@shipfox/node-fastify';
+import type {ShipfoxModule} from '@shipfox/node-module';
+
+const E2E_MANAGED_PROVIDER_ID = 'shipfox';
+const E2E_PI_MODEL = 'e2e-renewable-pi';
+const E2E_CLAUDE_MODEL = 'e2e-renewable-claude';
+const E2E_REFRESH_PI_MODEL = 'e2e-refresh-renewable-pi';
+const E2E_REFRESH_CLAUDE_MODEL = 'e2e-refresh-renewable-claude';
+const E2E_CLAUDE_MODEL_ID = 'claude-opus-4-8';
+const E2E_RESPONSE_TEXT = 'ok';
+const E2E_CREDENTIAL_LIFETIME_MS = 300_000;
+const E2E_RENEWAL_DELAY_MS = 30_000;
+const E2E_INFERENCE_ROUTE_PREFIX = '/__e2e-managed-inference';
+const TOKEN_PATTERN = /^shipfox-e2e-(.+)-g(\d+)$/u;
+
+const E2E_MODELS = [
+  {id: E2E_PI_MODEL, label: 'E2E renewable Pi', api: 'openai-completions' as const},
+  {
+    id: E2E_CLAUDE_MODEL,
+    label: 'E2E renewable Claude',
+    api: 'anthropic-messages' as const,
+    claudeModelId: E2E_CLAUDE_MODEL_ID,
+  },
+  {
+    id: E2E_REFRESH_PI_MODEL,
+    label: 'E2E refresh-at Pi',
+    api: 'openai-completions' as const,
+  },
+  {
+    id: E2E_REFRESH_CLAUDE_MODEL,
+    label: 'E2E refresh-at Claude',
+    api: 'anthropic-messages' as const,
+    claudeModelId: E2E_CLAUDE_MODEL_ID,
+  },
+] as const satisfies ManagedModelProvider['models'];
+
+interface CredentialState {
+  nextGeneration: number;
+  model: string;
+}
+
+interface InferenceStats {
+  resolutions: number;
+  expiredRequests: number;
+  acceptedRequests: number;
+  resolutionsByModel: Record<string, number>;
+  requestsByGeneration: Record<string, number>;
+}
+
+interface InferenceState {
+  readonly credentials: Map<string, CredentialState>;
+  readonly stats: InferenceStats;
+}
+
+export function createE2eManagedInferenceProvider(
+  baseUrl: string | undefined,
+): {provider: ManagedModelProvider; module: ShipfoxModule} | undefined {
+  if (baseUrl === undefined) return undefined;
+
+  const state: InferenceState = {
+    credentials: new Map(),
+    stats: {
+      resolutions: 0,
+      expiredRequests: 0,
+      acceptedRequests: 0,
+      resolutionsByModel: {},
+      requestsByGeneration: {},
+    },
+  };
+
+  const provider: ManagedModelProvider = {
+    id: E2E_MANAGED_PROVIDER_ID,
+    label: 'Shipfox E2E managed provider',
+    models: E2E_MODELS,
+    defaultModel: E2E_PI_MODEL,
+    defaultThinking: 'low',
+    resolveCredentials: (params) => {
+      if (params.jobIdentity === undefined) {
+        throw new Error('E2E managed provider requires the leased job identity');
+      }
+
+      const model = E2E_MODELS.find((candidate) => candidate.id === params.model);
+      if (model === undefined) {
+        throw new Error(`E2E managed provider does not know model ${params.model}`);
+      }
+
+      const key = params.stepAttemptId;
+      const credentialState = state.credentials.get(key) ?? {
+        nextGeneration: 1,
+        model: model.id,
+      };
+      if (credentialState.model !== model.id) {
+        throw new Error('E2E managed provider model changed during credential renewal');
+      }
+      const generation = credentialState.nextGeneration;
+      credentialState.nextGeneration += 1;
+      state.credentials.set(key, credentialState);
+      state.stats.resolutions += 1;
+      state.stats.resolutionsByModel[model.id] =
+        (state.stats.resolutionsByModel[model.id] ?? 0) + 1;
+
+      const token = `shipfox-e2e-${params.stepAttemptId}-g${generation}`;
+      const runtimeConfig: ManagedProviderRuntimeConfig = {
+        api: model.api,
+        baseUrl,
+        credentials: {api_key: token},
+      };
+      if (params.renewableInference !== true) return Promise.resolve(runtimeConfig);
+
+      const now = Date.now();
+      return Promise.resolve({
+        ...runtimeConfig,
+        expiresAt: new Date(now + E2E_CREDENTIAL_LIFETIME_MS),
+        generation: `generation-${generation}`,
+        renewal: {
+          mode: 'refresh-at',
+          refreshAt: new Date(
+            now + (isRefreshAtModel(model.id) && generation === 1 ? -1_000 : E2E_RENEWAL_DELAY_MS),
+          ),
+        },
+      });
+    },
+  };
+
+  return {
+    provider,
+    module: {
+      name: 'e2e-managed-inference',
+      routes: [createInferenceRoutes(state)],
+    },
+  };
+}
+
+function createInferenceRoutes(state: InferenceState): RouteGroup {
+  return {
+    prefix: E2E_INFERENCE_ROUTE_PREFIX,
+    routes: [
+      defineRoute({
+        method: 'GET',
+        path: '/stats',
+        description: 'Returns non-secret E2E managed inference fixture counters.',
+        handler: () => state.stats,
+      }),
+      defineRoute({
+        method: 'POST',
+        path: '/v1/chat/completions',
+        description: 'Serves the scripted OpenAI-compatible E2E managed inference response.',
+        handler: (request, reply) =>
+          respondToInferenceRequest({
+            api: 'openai-completions',
+            body: request.body,
+            headers: request.headers,
+            reply,
+            state,
+          }),
+      }),
+      defineRoute({
+        method: 'POST',
+        path: '/v1/messages',
+        description: 'Serves the scripted Anthropic-compatible E2E managed inference response.',
+        handler: (request, reply) =>
+          respondToInferenceRequest({
+            api: 'anthropic-messages',
+            body: request.body,
+            headers: request.headers,
+            reply,
+            state,
+          }),
+      }),
+    ],
+  };
+}
+
+function respondToInferenceRequest(params: {
+  api: ManagedModelApi;
+  body: unknown;
+  headers: Record<string, unknown>;
+  reply: {
+    code(statusCode: number): {send(payload: unknown): unknown};
+    header(name: string, value: string): unknown;
+    hijack(): unknown;
+    raw: {
+      end(chunk?: string): unknown;
+      write(chunk: string): unknown;
+      writeHead(statusCode: number, headers: Record<string, string>): unknown;
+    };
+    send(payload: unknown): unknown;
+  };
+  state: InferenceState;
+}): unknown {
+  const token = requestToken(params.headers);
+  const tokenDetails = parseToken(token);
+  const requestModel = bodyString(params.body, 'model') ?? 'unknown';
+  if (token === undefined) {
+    return params.reply.code(401).send({code: 'unauthorized', message: 'missing credential'});
+  }
+  const currentGeneration =
+    tokenDetails === undefined
+      ? undefined
+      : currentCredentialGeneration(params.state, tokenDetails.stepAttemptId);
+  if (
+    tokenDetails === undefined ||
+    currentGeneration === undefined ||
+    tokenDetails.generation !== currentGeneration ||
+    tokenDetails.generation === 1
+  ) {
+    params.state.stats.expiredRequests += 1;
+    if (tokenDetails !== undefined) recordGeneration(params.state, tokenDetails.generation);
+    return params.reply.code(401).send({code: 'unauthorized', message: 'expired'});
+  }
+
+  params.state.stats.acceptedRequests += 1;
+  recordGeneration(params.state, tokenDetails.generation);
+  if (params.api === 'openai-completions') {
+    return respondWithOpenAiCompletion(params.reply, requestModel, params.body);
+  }
+  return respondWithAnthropicMessage(params.reply, requestModel, params.body);
+}
+
+function respondWithOpenAiCompletion(
+  reply: {
+    hijack(): unknown;
+    raw: {
+      end(chunk?: string): unknown;
+      write(chunk: string): unknown;
+      writeHead(statusCode: number, headers: Record<string, string>): unknown;
+    };
+    send(payload: unknown): unknown;
+  },
+  model: string,
+  body: unknown,
+): unknown {
+  const completion = {
+    id: `chatcmpl-e2e-${model}`,
+    object: 'chat.completion' as const,
+    created: 1_783_344_000,
+    model,
+    choices: [
+      {
+        index: 0,
+        message: {role: 'assistant' as const, content: E2E_RESPONSE_TEXT},
+        finish_reason: 'stop' as const,
+      },
+    ],
+    usage: {prompt_tokens: 1, completion_tokens: 1, total_tokens: 2},
+  };
+  if (!bodyBoolean(body, 'stream')) return reply.send(completion);
+
+  reply.hijack();
+  reply.raw.writeHead(200, {
+    'cache-control': 'no-cache',
+    'content-type': 'text/event-stream; charset=utf-8',
+  });
+  const base = {
+    id: completion.id,
+    object: 'chat.completion.chunk' as const,
+    created: completion.created,
+    model,
+  };
+  reply.raw.write(
+    `data: ${JSON.stringify({
+      ...base,
+      choices: [
+        {
+          index: 0,
+          delta: {role: 'assistant', content: E2E_RESPONSE_TEXT},
+          finish_reason: null,
+        },
+      ],
+    })}\n\n`,
+  );
+  reply.raw.write(
+    `data: ${JSON.stringify({
+      ...base,
+      choices: [{index: 0, delta: {}, finish_reason: 'stop'}],
+    })}\n\n`,
+  );
+  return reply.raw.end('data: [DONE]\n\n');
+}
+
+function respondWithAnthropicMessage(
+  reply: {
+    hijack(): unknown;
+    raw: {
+      end(chunk?: string): unknown;
+      write(chunk: string): unknown;
+      writeHead(statusCode: number, headers: Record<string, string>): unknown;
+    };
+    send(payload: unknown): unknown;
+  },
+  model: string,
+  body: unknown,
+): unknown {
+  const message = {
+    id: `msg-e2e-${model}`,
+    type: 'message' as const,
+    role: 'assistant' as const,
+    model,
+    content: [{type: 'text' as const, text: E2E_RESPONSE_TEXT}],
+    stop_reason: 'end_turn' as const,
+    stop_sequence: null,
+    usage: {input_tokens: 1, output_tokens: 1},
+  };
+  if (!bodyBoolean(body, 'stream')) return reply.send(message);
+
+  reply.hijack();
+  reply.raw.writeHead(200, {
+    'cache-control': 'no-cache',
+    'content-type': 'text/event-stream; charset=utf-8',
+  });
+  const events = [
+    {
+      event: 'message_start',
+      data: {
+        type: 'message_start',
+        message: {
+          ...message,
+          content: [],
+          stop_reason: null,
+          usage: {input_tokens: 1, output_tokens: 0},
+        },
+      },
+    },
+    {
+      event: 'content_block_start',
+      data: {type: 'content_block_start', index: 0, content_block: {type: 'text', text: ''}},
+    },
+    {
+      event: 'content_block_delta',
+      data: {
+        type: 'content_block_delta',
+        index: 0,
+        delta: {type: 'text_delta', text: E2E_RESPONSE_TEXT},
+      },
+    },
+    {event: 'content_block_stop', data: {type: 'content_block_stop', index: 0}},
+    {
+      event: 'message_delta',
+      data: {
+        type: 'message_delta',
+        delta: {stop_reason: 'end_turn', stop_sequence: null},
+        usage: {output_tokens: 1},
+      },
+    },
+    {event: 'message_stop', data: {type: 'message_stop'}},
+  ];
+  for (const event of events) {
+    reply.raw.write(`event: ${event.event}\ndata: ${JSON.stringify(event.data)}\n\n`);
+  }
+  return reply.raw.end();
+}
+
+function requestToken(headers: Record<string, unknown>): string | undefined {
+  const authorization = headerValue(headers.authorization);
+  if (authorization?.startsWith('Bearer ')) return authorization.slice('Bearer '.length);
+  return headerValue(headers['x-api-key']);
+}
+
+function parseToken(
+  token: string | undefined,
+): {stepAttemptId: string; generation: number} | undefined {
+  const match = token === undefined ? undefined : TOKEN_PATTERN.exec(token);
+  if (match === null || match === undefined) return undefined;
+  const stepAttemptId = match[1];
+  const rawGeneration = match[2];
+  if (stepAttemptId === undefined || rawGeneration === undefined) return undefined;
+  const generation = Number(rawGeneration);
+  return stepAttemptId.length > 0 && Number.isSafeInteger(generation) && generation > 0
+    ? {stepAttemptId, generation}
+    : undefined;
+}
+
+function currentCredentialGeneration(
+  state: InferenceState,
+  stepAttemptId: string,
+): number | undefined {
+  const credentialState = state.credentials.get(stepAttemptId);
+  return credentialState === undefined ? undefined : credentialState.nextGeneration - 1;
+}
+
+function headerValue(value: unknown): string | undefined {
+  if (typeof value === 'string') return value;
+  if (Array.isArray(value) && typeof value[0] === 'string') return value[0];
+  return undefined;
+}
+
+function bodyString(body: unknown, key: string): string | undefined {
+  if (!body || typeof body !== 'object') return undefined;
+  const value = (body as Record<string, unknown>)[key];
+  return typeof value === 'string' ? value : undefined;
+}
+
+function bodyBoolean(body: unknown, key: string): boolean {
+  if (!body || typeof body !== 'object') return false;
+  return (body as Record<string, unknown>)[key] === true;
+}
+
+function recordGeneration(state: InferenceState, generation: number): void {
+  const key = String(generation);
+  state.stats.requestsByGeneration[key] = (state.stats.requestsByGeneration[key] ?? 0) + 1;
+}
+
+function isRefreshAtModel(model: string): boolean {
+  return model === E2E_REFRESH_PI_MODEL || model === E2E_REFRESH_CLAUDE_MODEL;
+}

--- a/apps/api/src/e2e-managed-inference.ts
+++ b/apps/api/src/e2e-managed-inference.ts
@@ -235,11 +235,11 @@ function createInferenceAuth(state: InferenceState, adminApiKey: string | undefi
       const credential = {tokenDetails, credentialState};
       if (!isCurrentCredential(credential)) {
         state.stats.expiredRequests += 1;
-        if (credential.tokenDetails !== undefined) {
+        if (credential.tokenDetails !== undefined && credential.credentialState !== undefined) {
           recordGeneration(
             state,
             credential.tokenDetails.generation,
-            credential.credentialState?.model,
+            credential.credentialState.model,
           );
         }
         throw new ClientError('Expired credential', 'unauthorized', {status: 401});
@@ -305,11 +305,11 @@ function respondToInferenceRequest(params: {
   const credential = {tokenDetails, credentialState};
   if (!isCurrentCredential(credential)) {
     params.state.stats.expiredRequests += 1;
-    if (credential.tokenDetails !== undefined) {
+    if (credential.tokenDetails !== undefined && credential.credentialState !== undefined) {
       recordGeneration(
         params.state,
         credential.tokenDetails.generation,
-        credential.credentialState?.model,
+        credential.credentialState.model,
       );
     }
     return params.reply.code(401).send({code: 'unauthorized', message: 'expired'});
@@ -546,7 +546,10 @@ function recordGeneration(
 
 function pruneCredentialStates(state: InferenceState, now: number): void {
   for (const [key, credentialState] of state.credentials) {
-    if (now - credentialState.lastTouchedAt > E2E_CREDENTIAL_STATE_TTL_MS) {
+    if (
+      credentialState.renewableInference &&
+      now - credentialState.lastTouchedAt > E2E_CREDENTIAL_STATE_TTL_MS
+    ) {
       state.credentials.delete(key);
     }
   }

--- a/apps/api/src/e2e-managed-inference.ts
+++ b/apps/api/src/e2e-managed-inference.ts
@@ -1,4 +1,4 @@
-import {randomUUID} from 'node:crypto';
+import {randomUUID, timingSafeEqual} from 'node:crypto';
 import type {
   ManagedModelApi,
   ManagedModelProvider,
@@ -225,7 +225,7 @@ function createInferenceAuth(state: InferenceState, adminApiKey: string | undefi
       if (token === undefined) {
         throw new ClientError('Missing credential', 'unauthorized', {status: 401});
       }
-      if (adminApiKey !== undefined && token === adminApiKey) return Promise.resolve();
+      if (adminApiKey !== undefined && tokensMatch(token, adminApiKey)) return Promise.resolve();
 
       const tokenDetails = parseToken(token);
       const credentialState =
@@ -291,7 +291,7 @@ function respondToInferenceRequest(params: {
   if (token === undefined) {
     return params.reply.code(401).send({code: 'unauthorized', message: 'missing credential'});
   }
-  if (params.adminApiKey !== undefined && token === params.adminApiKey) {
+  if (params.adminApiKey !== undefined && tokensMatch(token, params.adminApiKey)) {
     params.state.stats.acceptedRequests += 1;
     if (params.api === 'openai-completions') {
       return respondWithOpenAiCompletion(params.reply, requestModel, params.body);
@@ -464,6 +464,14 @@ function requestToken(headers: Record<string, unknown>): string | undefined {
   const authorization = headerValue(headers.authorization);
   if (authorization?.startsWith('Bearer ')) return authorization.slice('Bearer '.length);
   return headerValue(headers['x-api-key']);
+}
+
+function tokensMatch(actual: string, expected: string): boolean {
+  const actualBuffer = Buffer.from(actual);
+  const expectedBuffer = Buffer.from(expected);
+  return (
+    actualBuffer.length === expectedBuffer.length && timingSafeEqual(actualBuffer, expectedBuffer)
+  );
 }
 
 function parseToken(

--- a/apps/api/src/e2e-managed-inference.ts
+++ b/apps/api/src/e2e-managed-inference.ts
@@ -70,6 +70,7 @@ interface InferenceStats {
 
 interface InferenceState {
   readonly credentials: Map<string, CredentialState>;
+  readonly tombstones: Map<string, CredentialState>;
   readonly stats: InferenceStats;
 }
 
@@ -81,6 +82,7 @@ export function createE2eManagedInferenceProvider(
 
   const state: InferenceState = {
     credentials: new Map(),
+    tombstones: new Map(),
     stats: {
       resolutions: 0,
       expiredRequests: 0,
@@ -111,12 +113,13 @@ export function createE2eManagedInferenceProvider(
       const now = Date.now();
       pruneCredentialStates(state, now);
       const renewableInference = params.renewableInference === true;
-      const credentialState = state.credentials.get(key) ?? {
-        nextGeneration: 1,
-        model: model.id,
-        renewableInference,
-        lastTouchedAt: now,
-      };
+      const credentialState = state.credentials.get(key) ??
+        state.tombstones.get(key) ?? {
+          nextGeneration: 1,
+          model: model.id,
+          renewableInference,
+          lastTouchedAt: now,
+        };
       if (credentialState.model !== model.id) {
         throw new Error('E2E managed provider model changed during credential renewal');
       }
@@ -126,6 +129,7 @@ export function createE2eManagedInferenceProvider(
       const generation = credentialState.nextGeneration;
       credentialState.nextGeneration += 1;
       credentialState.lastTouchedAt = now;
+      state.tombstones.delete(key);
       state.credentials.set(key, credentialState);
       state.stats.resolutions += 1;
       state.stats.resolutionsByModel[model.id] =
@@ -158,13 +162,13 @@ export function createE2eManagedInferenceProvider(
     module: {
       name: 'e2e-managed-inference',
       auth: [createInferenceAuth(state, adminApiKey)],
-      routes: [createInferenceRoutes(state, adminApiKey)],
+      routes: [createInferenceRoutes()],
       e2eRoutes: [createInferenceStatsRoutes(state)],
     },
   };
 }
 
-function createInferenceRoutes(state: InferenceState, adminApiKey: string | undefined): RouteGroup {
+function createInferenceRoutes(): RouteGroup {
   return {
     prefix: E2E_INFERENCE_ROUTE_PREFIX,
     auth: E2E_MANAGED_INFERENCE_AUTH,
@@ -178,10 +182,7 @@ function createInferenceRoutes(state: InferenceState, adminApiKey: string | unde
           respondToInferenceRequest({
             api: 'openai-completions',
             body: request.body,
-            headers: request.headers,
-            adminApiKey,
             reply,
-            state,
           }),
       }),
       defineRoute({
@@ -193,10 +194,7 @@ function createInferenceRoutes(state: InferenceState, adminApiKey: string | unde
           respondToInferenceRequest({
             api: 'anthropic-messages',
             body: request.body,
-            headers: request.headers,
-            adminApiKey,
             reply,
-            state,
           }),
       }),
     ],
@@ -225,7 +223,10 @@ function createInferenceAuth(state: InferenceState, adminApiKey: string | undefi
       if (token === undefined) {
         throw new ClientError('Missing credential', 'unauthorized', {status: 401});
       }
-      if (adminApiKey !== undefined && tokensMatch(token, adminApiKey)) return Promise.resolve();
+      if (adminApiKey !== undefined && tokensMatch(token, adminApiKey)) {
+        state.stats.acceptedRequests += 1;
+        return Promise.resolve();
+      }
 
       const tokenDetails = parseToken(token);
       const credentialState =
@@ -244,6 +245,8 @@ function createInferenceAuth(state: InferenceState, adminApiKey: string | undefi
         }
         throw new ClientError('Expired credential', 'unauthorized', {status: 401});
       }
+      state.stats.acceptedRequests += 1;
+      recordGeneration(state, credential.tokenDetails.generation, credential.credentialState.model);
       return Promise.resolve();
     },
   };
@@ -270,10 +273,7 @@ function inferenceAuthenticationErrorHandler(
 function respondToInferenceRequest(params: {
   api: ManagedModelApi;
   body: unknown;
-  headers: Record<string, unknown>;
-  adminApiKey: string | undefined;
   reply: {
-    code(statusCode: number): {send(payload: unknown): unknown};
     header(name: string, value: string): unknown;
     hijack(): unknown;
     raw: {
@@ -283,44 +283,8 @@ function respondToInferenceRequest(params: {
     };
     send(payload: unknown): unknown;
   };
-  state: InferenceState;
 }): unknown {
-  const token = requestToken(params.headers);
-  const tokenDetails = parseToken(token);
   const requestModel = bodyString(params.body, 'model') ?? 'unknown';
-  if (token === undefined) {
-    return params.reply.code(401).send({code: 'unauthorized', message: 'missing credential'});
-  }
-  if (params.adminApiKey !== undefined && tokensMatch(token, params.adminApiKey)) {
-    params.state.stats.acceptedRequests += 1;
-    if (params.api === 'openai-completions') {
-      return respondWithOpenAiCompletion(params.reply, requestModel, params.body);
-    }
-    return respondWithAnthropicMessage(params.reply, requestModel, params.body);
-  }
-  const credentialState =
-    tokenDetails === undefined
-      ? undefined
-      : currentCredentialState(params.state, tokenDetails.stepAttemptId);
-  const credential = {tokenDetails, credentialState};
-  if (!isCurrentCredential(credential)) {
-    params.state.stats.expiredRequests += 1;
-    if (credential.tokenDetails !== undefined && credential.credentialState !== undefined) {
-      recordGeneration(
-        params.state,
-        credential.tokenDetails.generation,
-        credential.credentialState.model,
-      );
-    }
-    return params.reply.code(401).send({code: 'unauthorized', message: 'expired'});
-  }
-
-  params.state.stats.acceptedRequests += 1;
-  recordGeneration(
-    params.state,
-    credential.tokenDetails.generation,
-    credential.credentialState.model,
-  );
   if (params.api === 'openai-completions') {
     return respondWithOpenAiCompletion(params.reply, requestModel, params.body);
   }
@@ -559,6 +523,7 @@ function pruneCredentialStates(state: InferenceState, now: number): void {
       now - credentialState.lastTouchedAt > E2E_CREDENTIAL_STATE_TTL_MS
     ) {
       state.credentials.delete(key);
+      rememberCredentialTombstone(state, key, credentialState);
     }
   }
 
@@ -572,7 +537,29 @@ function pruneCredentialStates(state: InferenceState, now: number): void {
       }
     }
     if (oldestKey === undefined) return;
+    const oldestState = state.credentials.get(oldestKey);
     state.credentials.delete(oldestKey);
+    if (oldestState !== undefined) rememberCredentialTombstone(state, oldestKey, oldestState);
+  }
+}
+
+function rememberCredentialTombstone(
+  state: InferenceState,
+  key: string,
+  credentialState: CredentialState,
+): void {
+  state.tombstones.set(key, credentialState);
+  while (state.tombstones.size > E2E_MAX_CREDENTIAL_STATES) {
+    let oldestKey: string | undefined;
+    let oldestTouchedAt = Number.POSITIVE_INFINITY;
+    for (const [tombstoneKey, tombstone] of state.tombstones) {
+      if (tombstone.lastTouchedAt < oldestTouchedAt) {
+        oldestKey = tombstoneKey;
+        oldestTouchedAt = tombstone.lastTouchedAt;
+      }
+    }
+    if (oldestKey === undefined) return;
+    state.tombstones.delete(oldestKey);
   }
 }
 

--- a/apps/api/src/index.test.ts
+++ b/apps/api/src/index.test.ts
@@ -6,11 +6,13 @@ const mocks = vi.hoisted(() => ({
   },
   defaultModules: vi.fn(),
   runServer: vi.fn(),
+  shouldMountE2eRoutes: vi.fn(),
 }));
 
 vi.mock('@shipfox/api-server', () => ({
   defaultModules: mocks.defaultModules,
   runServer: mocks.runServer,
+  shouldMountE2eRoutes: mocks.shouldMountE2eRoutes,
 }));
 
 vi.mock('@shipfox/node-error-monitoring', () => ({
@@ -30,8 +32,10 @@ describe('index', () => {
     mocks.logger.error.mockReset();
     mocks.defaultModules.mockReset();
     mocks.runServer.mockReset();
+    mocks.shouldMountE2eRoutes.mockReset();
     mocks.closeErrorMonitoring.mockResolvedValue(true);
     mocks.defaultModules.mockResolvedValue([]);
+    mocks.shouldMountE2eRoutes.mockReturnValue(false);
   });
 
   afterEach(() => {

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -15,6 +15,7 @@ try {
       ? undefined
       : (await import('./e2e-managed-inference.js')).createE2eManagedInferenceProvider(
           e2eManagedProviderBaseUrl,
+          apiServerConfig.E2E_ADMIN_API_KEY,
         );
   await runServer({
     modules: await defaultModules(

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,11 +1,29 @@
 import {defaultModules, runServer} from '@shipfox/api-server';
+import {config as apiConfig} from '@shipfox/api-server/config';
 import {closeErrorMonitoring, reportError} from '@shipfox/node-error-monitoring';
 import {logger} from '@shipfox/node-opentelemetry';
 
 const STARTUP_ERROR_MONITORING_SHUTDOWN_TIMEOUT_MS = 2_000;
 try {
+  const e2eManagedProviderBaseUrl =
+    apiConfig.E2E_ENABLED && apiConfig.E2E_ADMIN_API_KEY
+      ? apiConfig.E2E_MANAGED_PROVIDER_BASE_URL
+      : undefined;
+  const e2eManagedInference =
+    e2eManagedProviderBaseUrl === undefined
+      ? undefined
+      : (await import('./e2e-managed-inference.js')).createE2eManagedInferenceProvider(
+          e2eManagedProviderBaseUrl,
+        );
   await runServer({
-    modules: await defaultModules(),
+    modules: await defaultModules(
+      e2eManagedInference === undefined
+        ? {}
+        : {
+            agentModuleOptions: {managedProvider: e2eManagedInference.provider},
+            extension: () => [e2eManagedInference.module],
+          },
+    ),
     onStartupFailure: (error) => {
       reportError(error, {boundary: 'api.startup'});
     },

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,12 +1,13 @@
 import {defaultModules, runServer} from '@shipfox/api-server';
-import {config as apiConfig} from '@shipfox/api-server/config';
+import {config as apiServerConfig} from '@shipfox/api-server/config';
 import {closeErrorMonitoring, reportError} from '@shipfox/node-error-monitoring';
 import {logger} from '@shipfox/node-opentelemetry';
+import {config as apiConfig} from './config.js';
 
 const STARTUP_ERROR_MONITORING_SHUTDOWN_TIMEOUT_MS = 2_000;
 try {
   const e2eManagedProviderBaseUrl =
-    apiConfig.E2E_ENABLED && apiConfig.E2E_ADMIN_API_KEY
+    apiServerConfig.E2E_ENABLED && apiServerConfig.E2E_ADMIN_API_KEY
       ? apiConfig.E2E_MANAGED_PROVIDER_BASE_URL
       : undefined;
   const e2eManagedInference =

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,4 +1,4 @@
-import {defaultModules, runServer} from '@shipfox/api-server';
+import {defaultModules, runServer, shouldMountE2eRoutes} from '@shipfox/api-server';
 import {config as apiServerConfig} from '@shipfox/api-server/config';
 import {closeErrorMonitoring, reportError} from '@shipfox/node-error-monitoring';
 import {logger} from '@shipfox/node-opentelemetry';
@@ -6,10 +6,9 @@ import {config as apiConfig} from './config.js';
 
 const STARTUP_ERROR_MONITORING_SHUTDOWN_TIMEOUT_MS = 2_000;
 try {
-  const e2eManagedProviderBaseUrl =
-    apiServerConfig.E2E_ENABLED && apiServerConfig.E2E_ADMIN_API_KEY
-      ? apiConfig.E2E_MANAGED_PROVIDER_BASE_URL
-      : undefined;
+  const e2eManagedProviderBaseUrl = shouldMountE2eRoutes(apiServerConfig)
+    ? apiConfig.E2E_MANAGED_PROVIDER_BASE_URL
+    : undefined;
   const e2eManagedInference =
     e2eManagedProviderBaseUrl === undefined
       ? undefined

--- a/apps/docs/content/docs/reference/runner.mdx
+++ b/apps/docs/content/docs/reference/runner.mdx
@@ -46,7 +46,7 @@ labels](/reference/runner-labels).
 | --- | --- | --- |
 | `SHIPFOX_RUNNER_WORKSPACE_ROOT` | OS temp directory | Parent directory for per-job workspaces. The runner only creates and cleans per-job child directories under this root. |
 | `SHIPFOX_RUNNER_ENABLE_RENEWABLE_GIT` | `false` in source-run mode; `true` in verified managed images | Enables automatic renewal for `persist-credentials: true` Git checkouts. Managed images set this only after verifying the helper and production dependency closure. Do not set it on a self-hosted or unverified image, or add it to provider-rendered runner environment data. |
-| `SHIPFOX_RUNNER_ENABLE_RENEWABLE_INFERENCE` | `false` in source-run mode; `true` in verified managed images | Enables renewable credentials for managed Pi and Claude inference sessions. Managed images set this only after verifying the helper and production dependency closure, and only after an API at or above the compatibility release is deployed everywhere. Do not set it on a self-hosted or unverified image, or add it to provider-rendered runner environment data. |
+| `SHIPFOX_RUNNER_ENABLE_RENEWABLE_INFERENCE` | `false` in source-run mode; `true` in verified managed images | Enables renewable credentials for managed Pi and Claude inference sessions. Managed images set this only after verifying the helper and production dependency closure, and only after every API instance accepts `renewable_inference` in runner capability reports. Do not set it on a self-hosted or unverified image, or add it to provider-rendered runner environment data. |
 | `SHIPFOX_POLL_INTERVAL_MS` | `1000` | How often the runner asks the API for new jobs. Backs off toward `SHIPFOX_POLL_MAX_INTERVAL_MS` while idle or after errors. |
 | `SHIPFOX_POLL_MAX_INTERVAL_MS` | `5000` | Largest interval the poll backoff can reach. |
 | `SHIPFOX_POLL_MAX_DURATION_MS` | `300000` | How long the runner keeps polling without claiming a job before it exits. Use `0` for runners that should poll forever. |
@@ -90,10 +90,10 @@ Verified managed runner images advertise renewable inference credentials for Pi
 and Claude sessions. The runner refreshes a managed credential when the harness
 needs it while the job attempt remains active.
 
-Only a verified managed image may advertise this capability. An API at or above
-the compatibility release must be deployed on every API instance before the
-image is used. Older or unverified runners keep the flag disabled and remain on
-the compatibility credential path during fleet drain.
+Only a verified managed image may advertise this capability. Before using the
+image, deploy an API release that accepts `renewable_inference` in runner
+capability reports on every API instance. Older or unverified runners keep the
+flag disabled and use static credentials until they are replaced.
 
 ## Agent steps
 

--- a/apps/docs/content/docs/reference/runner.mdx
+++ b/apps/docs/content/docs/reference/runner.mdx
@@ -46,6 +46,7 @@ labels](/reference/runner-labels).
 | --- | --- | --- |
 | `SHIPFOX_RUNNER_WORKSPACE_ROOT` | OS temp directory | Parent directory for per-job workspaces. The runner only creates and cleans per-job child directories under this root. |
 | `SHIPFOX_RUNNER_ENABLE_RENEWABLE_GIT` | `false` in source-run mode; `true` in verified managed images | Enables automatic renewal for `persist-credentials: true` Git checkouts. Managed images set this only after verifying the helper and production dependency closure. Do not set it on a self-hosted or unverified image, or add it to provider-rendered runner environment data. |
+| `SHIPFOX_RUNNER_ENABLE_RENEWABLE_INFERENCE` | `false` in source-run mode; `true` in verified managed images | Enables renewable credentials for managed Pi and Claude inference sessions. Managed images set this only after verifying the helper and production dependency closure, and only after an API at or above the compatibility release is deployed everywhere. Do not set it on a self-hosted or unverified image, or add it to provider-rendered runner environment data. |
 | `SHIPFOX_POLL_INTERVAL_MS` | `1000` | How often the runner asks the API for new jobs. Backs off toward `SHIPFOX_POLL_MAX_INTERVAL_MS` while idle or after errors. |
 | `SHIPFOX_POLL_MAX_INTERVAL_MS` | `5000` | Largest interval the poll backoff can reach. |
 | `SHIPFOX_POLL_MAX_DURATION_MS` | `300000` | How long the runner keeps polling without claiming a job before it exits. Use `0` for runners that should poll forever. |
@@ -82,6 +83,17 @@ Git commands started inside a container from a user step do not inherit the host
 runner's helper or Unix socket. Supply an explicit credential to that container
 when it needs authenticated Git access. Mounting the job workspace alone does not
 change this boundary.
+
+## Renewable inference credentials
+
+Verified managed runner images advertise renewable inference credentials for Pi
+and Claude sessions. The runner refreshes a managed credential when the harness
+needs it while the job attempt remains active.
+
+Only a verified managed image may advertise this capability. An API at or above
+the compatibility release must be deployed on every API instance before the
+image is used. Older or unverified runners keep the flag disabled and remain on
+the compatibility credential path during fleet drain.
 
 ## Agent steps
 

--- a/apps/runner/Dockerfile
+++ b/apps/runner/Dockerfile
@@ -116,15 +116,18 @@ COPY --from=build /prod ./
 # is not linked onto PATH by pnpm. Keep Git's name-based helper resolution usable in production.
 RUN ln -s /app/dist/git-credential-helper.js /usr/local/bin/git-credential-shipfox
 
-# Verify the production dependency closure contains every Pi extension entry and the
-# WASM-backed SVG image-preparation assets, plus the Git credential helper, before
-# the image can be published. This runs against the deployed flat layout, not the
-# pnpm development tree.
+# Verify the production dependency closure contains every Pi extension entry, the
+# WASM-backed SVG image-preparation assets, the renewable credential helpers, and
+# the bundled Claude Code binary before the image can be published. This runs
+# against the deployed flat layout, not the pnpm development tree.
 RUN node ./dist/verify-installation.js
 
 # This image has passed the installation gate, so managed containers may advertise
-# renewable Git credentials. Source-run and older images retain the flag's false default.
+# renewable Git and inference credentials. Source-run and older images retain the
+# flags' false defaults. An API at or above the compatibility release must be
+# deployed everywhere before this image is used for renewable inference.
 ENV SHIPFOX_RUNNER_ENABLE_RENEWABLE_GIT=true
+ENV SHIPFOX_RUNNER_ENABLE_RENEWABLE_INFERENCE=true
 
 USER shipfox
 

--- a/apps/runner/Dockerfile
+++ b/apps/runner/Dockerfile
@@ -124,8 +124,9 @@ RUN node ./dist/verify-installation.js
 
 # This image has passed the installation gate, so managed containers may advertise
 # renewable Git and inference credentials. Source-run and older images retain the
-# flags' false defaults. An API at or above the compatibility release must be
-# deployed everywhere before this image is used for renewable inference.
+# flags' false defaults. An API release that accepts `renewable_inference` in
+# runner capability reports must be deployed everywhere before this image is
+# used for renewable inference.
 ENV SHIPFOX_RUNNER_ENABLE_RENEWABLE_GIT=true
 ENV SHIPFOX_RUNNER_ENABLE_RENEWABLE_INFERENCE=true
 

--- a/apps/runner/README.md
+++ b/apps/runner/README.md
@@ -78,6 +78,7 @@ configured root is empty, the filesystem root (`/`), or a home directory.
 | `SHIPFOX_RUNNER_PROTOCOL_VERSION` | `1` | Protocol version the managed runner declares during enrollment. |
 | `SHIPFOX_RUNNER_LABELS` | N/A | Comma-separated labels registered on this runner session, such as `linux,x64,self-hosted`. |
 | `SHIPFOX_RUNNER_ENABLE_RENEWABLE_GIT` | `false` | Enables the runner-local renewable Git credential broker. Verified managed images set this to `true` after the helper and production-closure checks pass. Keep `false` on self-hosted or unverified images. |
+| `SHIPFOX_RUNNER_ENABLE_RENEWABLE_INFERENCE` | `false` | Enables renewable managed inference credentials. Verified managed images set this to `true` after the helper and production-closure checks pass, and only with an API at or above the compatibility release deployed everywhere. Keep `false` on self-hosted or unverified images. |
 | `SHIPFOX_RUNNER_WORKSPACE_ROOT` | OS temp dir | Parent directory for per-job workspaces (see above). |
 | `SHIPFOX_POLL_INTERVAL_MS` | `1000` | Base poll interval when requesting jobs. |
 | `SHIPFOX_POLL_MAX_INTERVAL_MS` | `5000` | Maximum backoff interval when no jobs are available or the API errors. |

--- a/apps/runner/README.md
+++ b/apps/runner/README.md
@@ -78,7 +78,7 @@ configured root is empty, the filesystem root (`/`), or a home directory.
 | `SHIPFOX_RUNNER_PROTOCOL_VERSION` | `1` | Protocol version the managed runner declares during enrollment. |
 | `SHIPFOX_RUNNER_LABELS` | N/A | Comma-separated labels registered on this runner session, such as `linux,x64,self-hosted`. |
 | `SHIPFOX_RUNNER_ENABLE_RENEWABLE_GIT` | `false` | Enables the runner-local renewable Git credential broker. Verified managed images set this to `true` after the helper and production-closure checks pass. Keep `false` on self-hosted or unverified images. |
-| `SHIPFOX_RUNNER_ENABLE_RENEWABLE_INFERENCE` | `false` | Enables renewable managed inference credentials. Verified managed images set this to `true` after the helper and production-closure checks pass, and only with an API at or above the compatibility release deployed everywhere. Keep `false` on self-hosted or unverified images. |
+| `SHIPFOX_RUNNER_ENABLE_RENEWABLE_INFERENCE` | `false` | Enables renewable managed inference credentials. Verified managed images set this to `true` after the helper and production-closure checks pass, and only with an API release that accepts `renewable_inference` in runner capability reports deployed everywhere. Keep `false` on self-hosted or unverified images. |
 | `SHIPFOX_RUNNER_WORKSPACE_ROOT` | OS temp dir | Parent directory for per-job workspaces (see above). |
 | `SHIPFOX_POLL_INTERVAL_MS` | `1000` | Base poll interval when requesting jobs. |
 | `SHIPFOX_POLL_MAX_INTERVAL_MS` | `5000` | Maximum backoff interval when no jobs are available or the API errors. |

--- a/apps/runner/src/verify-installation.ts
+++ b/apps/runner/src/verify-installation.ts
@@ -1,3 +1,5 @@
+import {constants} from 'node:fs';
+import {access} from 'node:fs/promises';
 import {createRequire} from 'node:module';
 import {assertBundledClaudeCodeVersion} from '@shipfox/runner-agent/claude-code';
 import {assertPiHarnessExtensionsAvailable} from '@shipfox/runner-agent/pi-extensions';
@@ -8,6 +10,7 @@ const RUNNER_RUNTIME_EXPORTS = [
   '@shipfox/runner-agent/pi-image-rasterizer',
   '@shipfox/runner-agent/tool-capabilities',
   '@shipfox/runner-agent/step',
+  '@shipfox/runner-agent/claude-auth-helper',
   '@shipfox/runner-execution/git-credential-helper',
   './git-credential-helper.js',
 ] as const;
@@ -19,6 +22,26 @@ for (const specifier of RUNNER_RUNTIME_EXPORTS) {
     const reason = error instanceof Error ? error.message : String(error);
     throw new Error(`Unable to resolve runner runtime export "${specifier}": ${reason}`);
   }
+}
+
+const claudeAuthHelperPath = require.resolve('@shipfox/runner-agent/claude-auth-helper');
+const runnerAgentRequire = createRequire(claudeAuthHelperPath);
+try {
+  runnerAgentRequire.resolve('@shipfox/runner-workspace/credential-socket-transport');
+} catch (error) {
+  const reason = error instanceof Error ? error.message : String(error);
+  throw new Error(
+    `Unable to resolve runner runtime export "@shipfox/runner-workspace/credential-socket-transport": ${reason}`,
+  );
+}
+
+try {
+  await access(claudeAuthHelperPath, constants.X_OK);
+} catch (error) {
+  const reason = error instanceof Error ? error.message : String(error);
+  throw new Error(
+    `Claude credential helper is not executable at "${claudeAuthHelperPath}": ${reason}`,
+  );
 }
 
 // Runs during the container and AMI image builds, against the deployed production closure rather

--- a/e2e/harness/src/e2e.mjs
+++ b/e2e/harness/src/e2e.mjs
@@ -222,6 +222,10 @@ export function e2eEnv(sourceEnv) {
     CLIENT_URL: clientUrl,
     E2E_ADMIN_API_KEY: valueOr(sourceEnv.E2E_ADMIN_API_KEY, defaultE2eAdminApiKey),
     E2E_ENABLED: valueOr(sourceEnv.E2E_ENABLED, 'true'),
+    E2E_MANAGED_PROVIDER_BASE_URL: valueOr(
+      sourceEnv.E2E_MANAGED_PROVIDER_BASE_URL,
+      `${apiUrl}/__e2e-managed-inference`,
+    ),
     AUTH_ROOT_KEY: valueOr(sourceEnv.AUTH_ROOT_KEY, 'MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY='),
     // Impersonation ships disabled by default; the E2E deployment opts in so
     // the mint route is live for the suite that exercises it. The admin

--- a/e2e/harness/test/e2e.test.mjs
+++ b/e2e/harness/test/e2e.test.mjs
@@ -77,6 +77,10 @@ describe('e2eEnv', () => {
 
     assert.equal(env.API_URL, 'http://localhost:55351');
     assert.equal(env.API_PUBLIC_URL, 'http://localhost:55351');
+    assert.equal(
+      env.E2E_MANAGED_PROVIDER_BASE_URL,
+      'http://localhost:55351/__e2e-managed-inference',
+    );
     assert.equal(env.CLIENT_BASE_URL, 'http://localhost:55350');
     assert.equal(env.CLIENT_URL, 'http://localhost:55350');
     assert.equal(env.E2E_GITEA_URL, 'http://localhost:55356');

--- a/e2e/suites/flow/workflows/src/renewable-credentials-workflows.ts
+++ b/e2e/suites/flow/workflows/src/renewable-credentials-workflows.ts
@@ -1,5 +1,41 @@
 const TEST_VCS_REJECTION_COOLDOWN_WAIT_SECONDS = 2;
 
+export const RENEWABLE_INFERENCE_WORKFLOW = `
+name: Renewable managed inference
+runner: __RUNNER_LABEL__
+triggers:
+  manual:
+    source: manual
+    event: fire
+jobs:
+  build:
+    steps:
+      - key: pi-rejection
+        harness: pi
+        provider: shipfox
+        model: e2e-renewable-pi
+        thinking: off
+        prompt: 'Reply with exactly: ok'
+      - key: claude-rejection
+        harness: claude
+        provider: shipfox
+        model: e2e-renewable-claude
+        thinking: low
+        prompt: 'Reply with exactly: ok'
+      - key: pi-refresh-at
+        harness: pi
+        provider: shipfox
+        model: e2e-refresh-renewable-pi
+        thinking: off
+        prompt: 'Reply with exactly: ok'
+      - key: claude-refresh-at
+        harness: claude
+        provider: shipfox
+        model: e2e-refresh-renewable-claude
+        thinking: low
+        prompt: 'Reply with exactly: ok'
+`;
+
 export const ON_REJECTION_WORKFLOW = `
 name: Renewable Git on rejection
 runner: __RUNNER_LABEL__

--- a/e2e/suites/flow/workflows/src/runner.ts
+++ b/e2e/suites/flow/workflows/src/runner.ts
@@ -26,6 +26,7 @@ export async function startSuiteLocalRunner(params: {
   runnerInstanceId?: string | undefined;
   extraEnv?: Record<string, string> | undefined;
   renewableGit?: boolean | undefined;
+  renewableInference?: boolean | undefined;
 }): Promise<{runner: LocalRunnerHandle; logFile: string}> {
   const registrationToken = await mintManualRegistrationToken({
     workspaceId: params.workspaceId,
@@ -50,6 +51,9 @@ export async function startSuiteLocalRunner(params: {
       extraEnv: {
         ...(params.extraEnv ?? {}),
         ...(params.renewableGit === true ? {SHIPFOX_RUNNER_ENABLE_RENEWABLE_GIT: 'true'} : {}),
+        ...(params.renewableInference === true
+          ? {SHIPFOX_RUNNER_ENABLE_RENEWABLE_INFERENCE: 'true'}
+          : {}),
       },
     }),
     logFile,

--- a/e2e/suites/flow/workflows/src/slack-agent-tools.ts
+++ b/e2e/suites/flow/workflows/src/slack-agent-tools.ts
@@ -108,6 +108,7 @@ jobs:
     steps:
       - key: slack
         harness: claude
+        provider: anthropic
         thinking: low
         prompt: Read the thread and reply.
         integrations:

--- a/e2e/suites/flow/workflows/tests/claude-agent.e2e.ts
+++ b/e2e/suites/flow/workflows/tests/claude-agent.e2e.ts
@@ -27,6 +27,7 @@ jobs:
     steps:
       - key: reply
         harness: claude
+        provider: anthropic
         thinking: low
         prompt: 'Reply with exactly: ok'
 `;
@@ -43,6 +44,7 @@ jobs:
     steps:
       - key: produce
         harness: claude
+        provider: anthropic
         thinking: low
         prompt: |
           Set the message output.

--- a/e2e/suites/flow/workflows/tests/github-agent-tools.e2e.ts
+++ b/e2e/suites/flow/workflows/tests/github-agent-tools.e2e.ts
@@ -876,6 +876,7 @@ jobs:
     steps:
       - key: github
         harness: claude
+        provider: anthropic
         thinking: low
         prompt: Use the selected GitHub tools.
         integrations:

--- a/e2e/suites/flow/workflows/tests/linear-agent-tools.e2e.ts
+++ b/e2e/suites/flow/workflows/tests/linear-agent-tools.e2e.ts
@@ -187,6 +187,7 @@ jobs:
     steps:
       - key: linear
         harness: claude
+        provider: anthropic
         thinking: low
         prompt: Use the selected Linear tools.
         integrations:

--- a/e2e/suites/flow/workflows/tests/renewable-credentials.e2e.ts
+++ b/e2e/suites/flow/workflows/tests/renewable-credentials.e2e.ts
@@ -1,5 +1,5 @@
 import {readFile} from 'node:fs/promises';
-import {createApiClient} from '@shipfox/e2e-core';
+import {createApiClient, config as e2eConfig} from '@shipfox/e2e-core';
 import {stopLocalRunner} from '@shipfox/e2e-driver-runner-process';
 import {waitForDefinition} from '@shipfox/e2e-observe-definitions';
 import type {WorkflowRunObservation} from '@shipfox/e2e-observe-workflows';
@@ -30,6 +30,7 @@ interface InferenceFixtureStats {
   acceptedRequests: number;
   resolutionsByModel: Record<string, number>;
   requestsByGeneration: Record<string, number>;
+  requestsByModelAndGeneration: Record<string, Record<string, number>>;
 }
 
 const RENEWABLE_INFERENCE_WORKFLOW = `
@@ -170,10 +171,10 @@ test('renews managed inference credentials for both harnesses', async ({suite}, 
   const runnerLabel = `e2e-renewable-inference-${uniqueId}`;
   const repo = `renewable-inference-${uniqueId}`;
   const configPath = `.shipfox/workflows/${repo}.yml`;
-  const client = createApiClient({token: suite.sessionToken});
-  const before = await client.requestJson<InferenceFixtureStats>(
+  const adminClient = createApiClient({token: e2eConfig.E2E_ADMIN_API_KEY});
+  const before = await adminClient.requestJson<InferenceFixtureStats>(
     'get',
-    '/__e2e-managed-inference/stats',
+    '/__e2e/managed-inference/stats',
   );
   const project = await seedAndWaitForDefinition({
     suite,
@@ -194,9 +195,9 @@ test('renews managed inference credentials for both harnesses', async ({suite}, 
     renewableGit: false,
     renewableInference: true,
   });
-  const after = await client.requestJson<InferenceFixtureStats>(
+  const after = await adminClient.requestJson<InferenceFixtureStats>(
     'get',
-    '/__e2e-managed-inference/stats',
+    '/__e2e/managed-inference/stats',
   );
   const logs = await Promise.all(logFiles.map((logFile) => readFile(logFile, 'utf8')));
 
@@ -205,12 +206,66 @@ test('renews managed inference credentials for both harnesses', async ({suite}, 
   expect(after.resolutions - before.resolutions).toBeGreaterThanOrEqual(8);
   expect(after.expiredRequests - before.expiredRequests).toBeGreaterThanOrEqual(2);
   expect(after.acceptedRequests - before.acceptedRequests).toBeGreaterThanOrEqual(4);
-  expect(after.resolutionsByModel['e2e-renewable-pi']).toBeGreaterThanOrEqual(2);
-  expect(after.resolutionsByModel['e2e-renewable-claude']).toBeGreaterThanOrEqual(2);
-  expect(after.resolutionsByModel['e2e-refresh-renewable-pi']).toBeGreaterThanOrEqual(2);
-  expect(after.resolutionsByModel['e2e-refresh-renewable-claude']).toBeGreaterThanOrEqual(2);
+  expect(resolutionsForModelDelta(before, after, 'e2e-renewable-pi')).toBeGreaterThanOrEqual(2);
+  expect(resolutionsForModelDelta(before, after, 'e2e-renewable-claude')).toBeGreaterThanOrEqual(2);
+  expect(
+    resolutionsForModelDelta(before, after, 'e2e-refresh-renewable-pi'),
+  ).toBeGreaterThanOrEqual(2);
+  expect(
+    resolutionsForModelDelta(before, after, 'e2e-refresh-renewable-claude'),
+  ).toBeGreaterThanOrEqual(2);
+  expect(
+    requestsForModelAndGenerationDelta(before, after, 'e2e-renewable-pi', 1),
+  ).toBeGreaterThanOrEqual(1);
+  expect(
+    requestsForModelAndGenerationDelta(before, after, 'e2e-renewable-pi', 2),
+  ).toBeGreaterThanOrEqual(1);
+  expect(
+    requestsForModelAndGenerationDelta(before, after, 'e2e-renewable-claude', 1),
+  ).toBeGreaterThanOrEqual(1);
+  expect(
+    requestsForModelAndGenerationDelta(before, after, 'e2e-renewable-claude', 2),
+  ).toBeGreaterThanOrEqual(1);
+  expect(requestsForModelAndGenerationDelta(before, after, 'e2e-refresh-renewable-pi', 1)).toBe(0);
+  expect(
+    requestsForModelAndGenerationDelta(before, after, 'e2e-refresh-renewable-pi', 2),
+  ).toBeGreaterThanOrEqual(1);
+  expect(requestsForModelAndGenerationDelta(before, after, 'e2e-refresh-renewable-claude', 1)).toBe(
+    0,
+  );
+  expect(
+    requestsForModelAndGenerationDelta(before, after, 'e2e-refresh-renewable-claude', 2),
+  ).toBeGreaterThanOrEqual(1);
   expect(logs.join('\n')).not.toContain('shipfox-e2e-');
 });
+
+function resolutionsForModelDelta(
+  before: InferenceFixtureStats,
+  after: InferenceFixtureStats,
+  model: string,
+): number {
+  return (after.resolutionsByModel[model] ?? 0) - (before.resolutionsByModel[model] ?? 0);
+}
+
+function requestsForModelAndGeneration(
+  stats: InferenceFixtureStats,
+  model: string,
+  generation: number,
+): number {
+  return stats.requestsByModelAndGeneration[model]?.[String(generation)] ?? 0;
+}
+
+function requestsForModelAndGenerationDelta(
+  before: InferenceFixtureStats,
+  after: InferenceFixtureStats,
+  model: string,
+  generation: number,
+): number {
+  return (
+    requestsForModelAndGeneration(after, model, generation) -
+    requestsForModelAndGeneration(before, model, generation)
+  );
+}
 
 test('renews rejected credentials across multiple checkouts', async ({
   suite,

--- a/e2e/suites/flow/workflows/tests/renewable-credentials.e2e.ts
+++ b/e2e/suites/flow/workflows/tests/renewable-credentials.e2e.ts
@@ -13,7 +13,10 @@ import {
 import {createProject as createE2eProject} from '@shipfox/e2e-setup-projects';
 import {attachLocalRunnerLog} from '#attachments.js';
 import {createProject} from '#create-project.js';
-import {ON_REJECTION_WORKFLOW} from '#renewable-credentials-workflows.js';
+import {
+  ON_REJECTION_WORKFLOW,
+  RENEWABLE_INFERENCE_WORKFLOW,
+} from '#renewable-credentials-workflows.js';
 import {startSuiteLocalRunner, waitForRunTerminalOrFailedRunner} from '#runner.js';
 import type {SuiteContext} from '#suite-context.js';
 import {fireManualAndAwaitRun} from '#triggers.js';
@@ -32,42 +35,6 @@ interface InferenceFixtureStats {
   requestsByGeneration: Record<string, number>;
   requestsByModelAndGeneration: Record<string, Record<string, number>>;
 }
-
-const RENEWABLE_INFERENCE_WORKFLOW = `
-name: Renewable managed inference
-runner: __RUNNER_LABEL__
-triggers:
-  manual:
-    source: manual
-    event: fire
-jobs:
-  build:
-    steps:
-      - key: pi-rejection
-        harness: pi
-        provider: shipfox
-        model: e2e-renewable-pi
-        thinking: off
-        prompt: 'Reply with exactly: ok'
-      - key: claude-rejection
-        harness: claude
-        provider: shipfox
-        model: e2e-renewable-claude
-        thinking: low
-        prompt: 'Reply with exactly: ok'
-      - key: pi-refresh-at
-        harness: pi
-        provider: shipfox
-        model: e2e-refresh-renewable-pi
-        thinking: off
-        prompt: 'Reply with exactly: ok'
-      - key: claude-refresh-at
-        harness: claude
-        provider: shipfox
-        model: e2e-refresh-renewable-claude
-        thinking: low
-        prompt: 'Reply with exactly: ok'
-`;
 
 const REFRESH_AT_WORKFLOW = `
 name: Renewable Git refresh at

--- a/e2e/suites/flow/workflows/tests/renewable-credentials.e2e.ts
+++ b/e2e/suites/flow/workflows/tests/renewable-credentials.e2e.ts
@@ -17,12 +17,56 @@ import {ON_REJECTION_WORKFLOW} from '#renewable-credentials-workflows.js';
 import {startSuiteLocalRunner, waitForRunTerminalOrFailedRunner} from '#runner.js';
 import type {SuiteContext} from '#suite-context.js';
 import {fireManualAndAwaitRun} from '#triggers.js';
+import {seedAndWaitForDefinition} from '#workflow-project.js';
 import {expect, test} from './fixtures.js';
 
 const RUNNER_TERMINAL_TIMEOUT_MS = 180_000;
 const TEST_TIMEOUT_MS = 300_000;
 const TEST_VCS_TOKEN_PATTERN = /test-vcs-[0-9a-f-]{20,}/u;
 const TEST_VCS_REFRESH_WAIT_SECONDS = 2;
+interface InferenceFixtureStats {
+  resolutions: number;
+  expiredRequests: number;
+  acceptedRequests: number;
+  resolutionsByModel: Record<string, number>;
+  requestsByGeneration: Record<string, number>;
+}
+
+const RENEWABLE_INFERENCE_WORKFLOW = `
+name: Renewable managed inference
+runner: __RUNNER_LABEL__
+triggers:
+  manual:
+    source: manual
+    event: fire
+jobs:
+  build:
+    steps:
+      - key: pi-rejection
+        harness: pi
+        provider: shipfox
+        model: e2e-renewable-pi
+        thinking: off
+        prompt: 'Reply with exactly: ok'
+      - key: claude-rejection
+        harness: claude
+        provider: shipfox
+        model: e2e-renewable-claude
+        thinking: low
+        prompt: 'Reply with exactly: ok'
+      - key: pi-refresh-at
+        harness: pi
+        provider: shipfox
+        model: e2e-refresh-renewable-pi
+        thinking: off
+        prompt: 'Reply with exactly: ok'
+      - key: claude-refresh-at
+        harness: claude
+        provider: shipfox
+        model: e2e-refresh-renewable-claude
+        thinking: low
+        prompt: 'Reply with exactly: ok'
+`;
 
 const REFRESH_AT_WORKFLOW = `
 name: Renewable Git refresh at
@@ -119,6 +163,54 @@ jobs:
 `;
 
 test.describe.configure({mode: 'serial'});
+
+test('renews managed inference credentials for both harnesses', async ({suite}, testInfo) => {
+  test.setTimeout(TEST_TIMEOUT_MS);
+  const uniqueId = shortId();
+  const runnerLabel = `e2e-renewable-inference-${uniqueId}`;
+  const repo = `renewable-inference-${uniqueId}`;
+  const configPath = `.shipfox/workflows/${repo}.yml`;
+  const client = createApiClient({token: suite.sessionToken});
+  const before = await client.requestJson<InferenceFixtureStats>(
+    'get',
+    '/__e2e-managed-inference/stats',
+  );
+  const project = await seedAndWaitForDefinition({
+    suite,
+    token: suite.sessionToken,
+    name: 'renewable-inference',
+    repo,
+    runnerLabel,
+    workflowYaml: RENEWABLE_INFERENCE_WORKFLOW,
+    configPath,
+  });
+
+  const {terminal, logFiles} = await runWorkflow({
+    suite,
+    testInfo,
+    definitionId: project.definition.id,
+    scenario: 'renewable-inference',
+    runnerLabel,
+    renewableGit: false,
+    renewableInference: true,
+  });
+  const after = await client.requestJson<InferenceFixtureStats>(
+    'get',
+    '/__e2e-managed-inference/stats',
+  );
+  const logs = await Promise.all(logFiles.map((logFile) => readFile(logFile, 'utf8')));
+
+  expect(terminal.status).toBe('succeeded');
+  expect(terminal.jobs.find((job) => job.key === 'build')?.status).toBe('succeeded');
+  expect(after.resolutions - before.resolutions).toBeGreaterThanOrEqual(8);
+  expect(after.expiredRequests - before.expiredRequests).toBeGreaterThanOrEqual(2);
+  expect(after.acceptedRequests - before.acceptedRequests).toBeGreaterThanOrEqual(4);
+  expect(after.resolutionsByModel['e2e-renewable-pi']).toBeGreaterThanOrEqual(2);
+  expect(after.resolutionsByModel['e2e-renewable-claude']).toBeGreaterThanOrEqual(2);
+  expect(after.resolutionsByModel['e2e-refresh-renewable-pi']).toBeGreaterThanOrEqual(2);
+  expect(after.resolutionsByModel['e2e-refresh-renewable-claude']).toBeGreaterThanOrEqual(2);
+  expect(logs.join('\n')).not.toContain('shipfox-e2e-');
+});
 
 test('renews rejected credentials across multiple checkouts', async ({
   suite,
@@ -456,6 +548,7 @@ async function runWorkflow(params: {
   runnerCount?: number | undefined;
   runnerLabels?: readonly string[] | undefined;
   renewableGit: boolean;
+  renewableInference?: boolean | undefined;
 }): Promise<{terminal: WorkflowRunObservation; logFiles: string[]}> {
   const token = params.suite.sessionToken;
   const client = createApiClient({token});
@@ -480,6 +573,7 @@ async function runWorkflow(params: {
             SHIPFOX_POLL_MAX_DURATION_MS: String(RUNNER_TERMINAL_TIMEOUT_MS),
           },
           renewableGit: params.renewableGit,
+          renewableInference: params.renewableInference,
         }),
       );
     }

--- a/infra/images/runner/README.md
+++ b/infra/images/runner/README.md
@@ -139,8 +139,9 @@ The image owns `SHIPFOX_RUNNER_ENABLE_RENEWABLE_GIT` and
 `SHIPFOX_RUNNER_ENABLE_RENEWABLE_INFERENCE`. The container image sets them only after the
 production-closure verifier passes. The AMI service unit sets them only after `install-runner.sh`
 has run that same verifier, so a partial image bake cannot advertise either helper. A flag-on
-inference image requires an API at or above the compatibility release to be deployed on every API
-instance before the image is used. Provider-rendered environment files must not set either flag.
+inference image requires an API release that accepts `renewable_inference` in runner capability
+reports to be deployed on every API instance before the image is used. Provider-rendered
+environment files must not set either flag.
 
 Older self-managed images remain compatible: they use static checkout credentials. When a persisted
 checkout reaches one, the API writes an upgrade warning to the job annotations without blocking

--- a/infra/images/runner/README.md
+++ b/infra/images/runner/README.md
@@ -166,6 +166,10 @@ The image build and canary prove different boundaries. A passing Packer or Docke
 helper is packaged. The canary proves the managed runner selects it against the deployed API and
 provider. Neither check makes a live rollout green without its monitoring evidence.
 
+The same image-first ordering applies to renewable inference. Replace the flag-on image with a
+static image before downgrading any API below the release that accepts `renewable_inference` in
+runner capability reports.
+
 `shipfox-runner.service` powers off immediately when the runner exits. Its SIGTERM drain budget is 90 seconds, after which systemd can force-kill the process and the backend re-reserves the job. The image accepts `SHIPFOX_RUNNER_MAX_LIFETIME_SECONDS` for compatibility but does not arm an age-based timer or fallback poweroff from that key. Before an orchestration-owned exit, the runner writes one bounded `runner.shutdown_intent` event to the structured logger and the direct EC2 console descriptor, identifying a success, controlled exit, or fatal failure. AWS builds also enable a Spot IMDSv2 watcher that stops the runner, allows it to drain briefly, then powers off.
 
 With `InstanceInitiatedShutdownBehavior=terminate` and Spot `InstanceInterruptionBehavior=terminate`, provider-side settings convert these poweroffs into EC2 termination. The systemd lifecycle action is the fast path. The durable backstop remains tagged-instance reconciliation, the backend staleness reaper, and terminate-on-shutdown because privileged job steps or a wedged kernel can prevent normal process exit.

--- a/infra/images/runner/README.md
+++ b/infra/images/runner/README.md
@@ -135,10 +135,12 @@ The image derives its tool capabilities from its baked runner runtime and sends 
 enrollment. Providers do not inject capabilities, workspace IDs, workspace registration tokens,
 or activation tokens into user data.
 
-The image owns `SHIPFOX_RUNNER_ENABLE_RENEWABLE_GIT`. The container image sets it only after the
-production-closure verifier passes. The AMI service unit sets it only after `install-runner.sh`
-has run that same verifier, so a partial image bake cannot advertise the helper. Provider-rendered
-environment files must not set this flag.
+The image owns `SHIPFOX_RUNNER_ENABLE_RENEWABLE_GIT` and
+`SHIPFOX_RUNNER_ENABLE_RENEWABLE_INFERENCE`. The container image sets them only after the
+production-closure verifier passes. The AMI service unit sets them only after `install-runner.sh`
+has run that same verifier, so a partial image bake cannot advertise either helper. A flag-on
+inference image requires an API at or above the compatibility release to be deployed on every API
+instance before the image is used. Provider-rendered environment files must not set either flag.
 
 Older self-managed images remain compatible: they use static checkout credentials. When a persisted
 checkout reaches one, the API writes an upgrade warning to the job annotations without blocking

--- a/infra/images/runner/assets/shipfox-runner.service
+++ b/infra/images/runner/assets/shipfox-runner.service
@@ -13,6 +13,7 @@ EnvironmentFile=/etc/shipfox/runner.env
 Environment=AGENT_CUSTOM_PROVIDER_ALLOW_PRIVATE_NETWORKS=false
 # The image installs this unit only after install-runner.sh verifies the deployed helper.
 Environment=SHIPFOX_RUNNER_ENABLE_RENEWABLE_GIT=true
+Environment=SHIPFOX_RUNNER_ENABLE_RENEWABLE_INFERENCE=true
 ExecStartPre=/opt/shipfox-runner/scripts/runtime/verify-workspace-mount.sh
 WorkingDirectory=/opt/runner
 ExecStart=/opt/shipfox-runner/scripts/runtime/run-runner.sh /usr/local/bin/node dist/index.js

--- a/infra/images/runner/scripts/build/install-runner.sh
+++ b/infra/images/runner/scripts/build/install-runner.sh
@@ -13,9 +13,9 @@ cd "$(dirname "$lockfile")"
 corepack prepare pnpm@11.7.0 --activate
 pnpm install --frozen-lockfile
 pnpm --filter=@shipfox/runner deploy --prod --legacy --config.strict-peer-dependencies=false "$runner_dir"
-# Verify the deployed production closure contains every Pi extension entry and the Git credential
-# helper before the image is published. This runs against the deployed flat layout, not the pnpm
-# development tree.
+# Verify the deployed production closure contains every Pi extension entry, the renewable
+# credential helpers, and the bundled Claude Code binary before the image is published. This runs
+# against the deployed flat layout, not the pnpm development tree.
 node "$runner_dir/dist/verify-installation.js"
 # The runner package is the deployed root rather than an installed dependency, so its package bin
 # is not linked onto PATH by pnpm. Keep Git's name-based helper resolution usable in production.

--- a/infra/images/runner/test/runner-image.test.ts
+++ b/infra/images/runner/test/runner-image.test.ts
@@ -927,6 +927,7 @@ describe('systemd boot activation', () => {
     expect(systemdDirective(unit, 'Unit', 'FailureAction')).toBe('poweroff-immediate');
     expect(systemdDirective(unit, 'Service', 'StandardOutput')).toBe('journal+console');
     expect(unit).toContain('Environment=SHIPFOX_RUNNER_ENABLE_RENEWABLE_GIT=true');
+    expect(unit).toContain('Environment=SHIPFOX_RUNNER_ENABLE_RENEWABLE_INFERENCE=true');
     expect(unit).not.toContain('--enable-source-maps');
   });
 
@@ -1542,11 +1543,17 @@ describe('runner container entrypoint', () => {
       "import {assertBundledClaudeCodeVersion} from '@shipfox/runner-agent/claude-code';",
     );
     expect(verifyInstallation).toContain('assertBundledClaudeCodeVersion();');
+    expect(verifyInstallation).toContain("'@shipfox/runner-agent/claude-auth-helper'");
+    expect(verifyInstallation).toContain("'@shipfox/runner-workspace/credential-socket-transport'");
     expect(verifyInstallation).toContain("'@shipfox/runner-execution/git-credential-helper'");
     expect(verifyInstallation).toContain("'./git-credential-helper.js'");
     expect(dockerfile).toContain('ENV SHIPFOX_RUNNER_ENABLE_RENEWABLE_GIT=true');
+    expect(dockerfile).toContain('ENV SHIPFOX_RUNNER_ENABLE_RENEWABLE_INFERENCE=true');
     expect(dockerfile.indexOf('RUN node ./dist/verify-installation.js')).toBeLessThan(
       dockerfile.indexOf('ENV SHIPFOX_RUNNER_ENABLE_RENEWABLE_GIT=true'),
+    );
+    expect(dockerfile.indexOf('RUN node ./dist/verify-installation.js')).toBeLessThan(
+      dockerfile.indexOf('ENV SHIPFOX_RUNNER_ENABLE_RENEWABLE_INFERENCE=true'),
     );
     expect(dockerfile).toContain('ENTRYPOINT ["tini", "--"]');
     expect(dockerfile).toContain('CMD ["node", "./dist/index.js"]');

--- a/infra/images/runner/test/runner-image.test.ts
+++ b/infra/images/runner/test/runner-image.test.ts
@@ -1543,6 +1543,7 @@ describe('runner container entrypoint', () => {
       "import {assertBundledClaudeCodeVersion} from '@shipfox/runner-agent/claude-code';",
     );
     expect(verifyInstallation).toContain('assertBundledClaudeCodeVersion();');
+    expect(verifyInstallation).toContain('constants.X_OK');
     expect(verifyInstallation).toContain("'@shipfox/runner-agent/claude-auth-helper'");
     expect(verifyInstallation).toContain("'@shipfox/runner-workspace/credential-socket-transport'");
     expect(verifyInstallation).toContain("'@shipfox/runner-execution/git-credential-helper'");

--- a/libs/api/server/README.md
+++ b/libs/api/server/README.md
@@ -11,6 +11,7 @@ Runs a Shipfox API server.
 - **`DefaultAgentModuleFactory`**, **`DefaultAuthModuleFactory`**, and **`DefaultRunnersModuleFactory`**: Full module replacement escape hatches.
 - **`createServer()`**: Builds an API server. The caller owns process signals.
 - **`runServer()`**: Starts the server. It listens for SIGTERM and SIGINT.
+- **`./config`**: Exposes the API server's runtime configuration, including E2E route settings.
 - **`createLoginMethodsRoute()`**: Builds the public login-method catalog route. `createServer` mounts it automatically.
 - **Instrumentation preload**: Starts metrics and optional logs early. Load it before feature modules.
 

--- a/libs/api/server/README.md
+++ b/libs/api/server/README.md
@@ -12,6 +12,7 @@ Runs a Shipfox API server.
 - **`createServer()`**: Builds an API server. The caller owns process signals.
 - **`runServer()`**: Starts the server. It listens for SIGTERM and SIGINT.
 - **`./config`**: Exposes the API server's runtime configuration, including E2E route settings.
+- **`shouldMountE2eRoutes()`**: Reports whether the E2E routes should mount for a server configuration.
 - **`createLoginMethodsRoute()`**: Builds the public login-method catalog route. `createServer` mounts it automatically.
 - **Instrumentation preload**: Starts metrics and optional logs early. Load it before feature modules.
 

--- a/libs/api/server/package.json
+++ b/libs/api/server/package.json
@@ -37,6 +37,16 @@
         "types": "./dist/instrumentation.d.ts",
         "default": "./dist/instrumentation.js"
       }
+    },
+    "./config": {
+      "workspace-source": {
+        "types": "./src/config.ts",
+        "default": "./src/config.ts"
+      },
+      "default": {
+        "types": "./dist/config.d.ts",
+        "default": "./dist/config.js"
+      }
     }
   },
   "scripts": {

--- a/libs/api/server/src/config.ts
+++ b/libs/api/server/src/config.ts
@@ -1,5 +1,5 @@
 import {isIP} from 'node:net';
-import {bool, createConfig, port, str, url} from '@shipfox/config';
+import {bool, createConfig, port, str} from '@shipfox/config';
 
 export type ApiTrustProxy = false | true | number | string;
 
@@ -12,10 +12,6 @@ export const config = createConfig({
   }),
   E2E_ADMIN_API_KEY: str({
     desc: 'Bearer token that protects the E2E admin routes. Set it when E2E_ENABLED is true.',
-    default: undefined,
-  }),
-  E2E_MANAGED_PROVIDER_BASE_URL: url({
-    desc: 'Gateway root for the E2E-only managed model provider fixture. Leave unset outside the E2E harness.',
     default: undefined,
   }),
   API_PORT: port({

--- a/libs/api/server/src/config.ts
+++ b/libs/api/server/src/config.ts
@@ -1,5 +1,5 @@
 import {isIP} from 'node:net';
-import {bool, createConfig, port, str} from '@shipfox/config';
+import {bool, createConfig, port, str, url} from '@shipfox/config';
 
 export type ApiTrustProxy = false | true | number | string;
 
@@ -12,6 +12,10 @@ export const config = createConfig({
   }),
   E2E_ADMIN_API_KEY: str({
     desc: 'Bearer token that protects the E2E admin routes. Set it when E2E_ENABLED is true.',
+    default: undefined,
+  }),
+  E2E_MANAGED_PROVIDER_BASE_URL: url({
+    desc: 'Gateway root for the E2E-only managed model provider fixture. Leave unset outside the E2E harness.',
     default: undefined,
   }),
   API_PORT: port({

--- a/libs/api/server/src/index.ts
+++ b/libs/api/server/src/index.ts
@@ -1,3 +1,4 @@
+export {shouldMountE2eRoutes} from './e2e.js';
 export {
   type DefaultAgentModuleFactory,
   type DefaultAgentModuleOptions,

--- a/libs/runner/agent/package.json
+++ b/libs/runner/agent/package.json
@@ -59,6 +59,16 @@
         "default": "./dist/claude-code.js"
       }
     },
+    "./claude-auth-helper": {
+      "workspace-source": {
+        "types": "./src/core/claude-auth-helper.ts",
+        "default": "./src/core/claude-auth-helper.ts"
+      },
+      "default": {
+        "types": "./dist/core/claude-auth-helper.d.ts",
+        "default": "./dist/core/claude-auth-helper.js"
+      }
+    },
     "./tool-capabilities": {
       "workspace-source": {
         "types": "./src/core/tool-capabilities.ts",

--- a/libs/runner/agent/src/config.ts
+++ b/libs/runner/agent/src/config.ts
@@ -27,7 +27,7 @@ export const config = createConfig({
     default: false,
   }),
   SHIPFOX_RUNNER_ENABLE_RENEWABLE_INFERENCE: bool({
-    desc: 'Enables renewable managed inference credentials. Source-run defaults remain disabled; verified managed images set this only after an API at or above the compatibility release is deployed everywhere.',
+    desc: 'Enables renewable managed inference credentials. Source-run defaults remain disabled; verified managed images set this only after an API release that accepts renewable_inference in runner capability reports is deployed everywhere.',
     default: false,
   }),
 });

--- a/libs/runner/agent/src/config.ts
+++ b/libs/runner/agent/src/config.ts
@@ -26,6 +26,10 @@ export const config = createConfig({
     desc: 'Enables the runner-local renewable Git credential broker. Source-run defaults remain disabled; verified managed images set this after the helper and production closure are checked.',
     default: false,
   }),
+  SHIPFOX_RUNNER_ENABLE_RENEWABLE_INFERENCE: bool({
+    desc: 'Enables renewable managed inference credentials. Source-run defaults remain disabled; verified managed images set this only after an API at or above the compatibility release is deployed everywhere.',
+    default: false,
+  }),
 });
 
 export function runnerEgressPolicy(): EgressPolicy {

--- a/libs/runner/agent/src/core/claude-auth-helper.ts
+++ b/libs/runner/agent/src/core/claude-auth-helper.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import {existsSync} from 'node:fs';
 import {resolve} from 'node:path';
 import {fileURLToPath} from 'node:url';
 import {
@@ -13,9 +14,17 @@ import {
   CLAUDE_CREDENTIAL_TIMEOUT_ENV,
 } from '#core/claude-credential-broker.js';
 
-export const CLAUDE_AUTH_HELPER_PATH = fileURLToPath(
-  new URL('./claude-auth-helper.js', import.meta.url),
+const localHelperPath = fileURLToPath(new URL('./claude-auth-helper.js', import.meta.url));
+const bundledHelperPath = fileURLToPath(
+  new URL('../../dist/core/claude-auth-helper.js', import.meta.url),
 );
+
+// Workspace-source runners execute TypeScript through tsx, but Claude Code starts the helper as
+// an operating-system child process. Use the chmod'd package build for that child while keeping
+// the normal dist-relative path when this module itself is bundled into the image.
+export const CLAUDE_AUTH_HELPER_PATH = existsSync(localHelperPath)
+  ? localHelperPath
+  : bundledHelperPath;
 
 interface WritableOutput {
   write(chunk: string): unknown;

--- a/libs/runner/agent/src/core/claude-auth-helper.ts
+++ b/libs/runner/agent/src/core/claude-auth-helper.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import {existsSync} from 'node:fs';
+import {accessSync, constants, existsSync} from 'node:fs';
 import {resolve} from 'node:path';
 import {fileURLToPath} from 'node:url';
 import {
@@ -22,9 +22,18 @@ const bundledHelperPath = fileURLToPath(
 // Workspace-source runners execute TypeScript through tsx, but Claude Code starts the helper as
 // an operating-system child process. Use the chmod'd package build for that child while keeping
 // the normal dist-relative path when this module itself is bundled into the image.
-export const CLAUDE_AUTH_HELPER_PATH = existsSync(localHelperPath)
-  ? localHelperPath
-  : bundledHelperPath;
+const selectedHelperPath = existsSync(localHelperPath) ? localHelperPath : bundledHelperPath;
+
+try {
+  accessSync(selectedHelperPath, constants.X_OK);
+} catch (error) {
+  const reason = error instanceof Error ? error.message : String(error);
+  throw new Error(
+    `Claude credential helper is missing or not executable at "${selectedHelperPath}": ${reason}`,
+  );
+}
+
+export const CLAUDE_AUTH_HELPER_PATH = selectedHelperPath;
 
 interface WritableOutput {
   write(chunk: string): unknown;

--- a/libs/runner/agent/src/core/tool-capabilities.test.ts
+++ b/libs/runner/agent/src/core/tool-capabilities.test.ts
@@ -10,6 +10,8 @@ import {runnerToolCapabilities} from '#core/tool-capabilities.js';
 
 beforeEach(() => {
   isPiExtensionAvailableMock.mockReturnValue(true);
+  vi.stubEnv('SHIPFOX_RUNNER_ENABLE_RENEWABLE_GIT', undefined);
+  vi.stubEnv('SHIPFOX_RUNNER_ENABLE_RENEWABLE_INFERENCE', undefined);
 });
 
 afterEach(() => {
@@ -67,5 +69,34 @@ describe('runnerToolCapabilities', () => {
     );
 
     expect(enabledCapabilities().features).toEqual({renewable_git: true});
+  });
+
+  it('advertises renewable inference only when explicitly enabled', async () => {
+    vi.stubEnv('SHIPFOX_RUNNER_ENABLE_RENEWABLE_INFERENCE', 'true');
+    vi.resetModules();
+
+    const {runnerToolCapabilities: enabledCapabilities} = await import(
+      '#core/tool-capabilities.js'
+    );
+
+    expect(enabledCapabilities().features).toEqual({
+      renewable_git: false,
+      renewable_inference: true,
+    });
+  });
+
+  it('advertises both renewable capabilities when both are enabled', async () => {
+    vi.stubEnv('SHIPFOX_RUNNER_ENABLE_RENEWABLE_GIT', 'true');
+    vi.stubEnv('SHIPFOX_RUNNER_ENABLE_RENEWABLE_INFERENCE', 'true');
+    vi.resetModules();
+
+    const {runnerToolCapabilities: enabledCapabilities} = await import(
+      '#core/tool-capabilities.js'
+    );
+
+    expect(enabledCapabilities().features).toEqual({
+      renewable_git: true,
+      renewable_inference: true,
+    });
   });
 });

--- a/libs/runner/agent/src/core/tool-capabilities.ts
+++ b/libs/runner/agent/src/core/tool-capabilities.ts
@@ -21,11 +21,18 @@ export function runnerToolCapabilities(): RunnerToolCapabilitiesDto {
   const piTools = isPiExtensionAvailable({packageName: 'pi-web-access'})
     ? [...PI_BUILTIN_TOOLS, ...PI_WEB_ACCESS_TOOLS]
     : [...PI_BUILTIN_TOOLS];
+  const features =
+    config.SHIPFOX_RUNNER_ENABLE_RENEWABLE_GIT || config.SHIPFOX_RUNNER_ENABLE_RENEWABLE_INFERENCE
+      ? {
+          renewable_git: config.SHIPFOX_RUNNER_ENABLE_RENEWABLE_GIT,
+          ...(config.SHIPFOX_RUNNER_ENABLE_RENEWABLE_INFERENCE
+            ? {renewable_inference: true as const}
+            : {}),
+        }
+      : undefined;
 
   return {
-    ...(config.SHIPFOX_RUNNER_ENABLE_RENEWABLE_GIT
-      ? {features: {renewable_git: true as const}}
-      : {}),
+    ...(features === undefined ? {} : {features}),
     harnesses: {
       pi: {tools: piTools},
       claude: {tools: [...CLAUDE_TOOLS]},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -539,12 +539,21 @@ importers:
 
   apps/api:
     dependencies:
+      '@shipfox/api-agent-dto':
+        specifier: workspace:*
+        version: link:../../libs/api/agent-dto
       '@shipfox/api-server':
         specifier: workspace:*
         version: link:../../libs/api/server
       '@shipfox/node-error-monitoring':
         specifier: workspace:*
         version: link:../../libs/shared/node/error-monitoring
+      '@shipfox/node-fastify':
+        specifier: workspace:*
+        version: link:../../libs/shared/node/fastify
+      '@shipfox/node-module':
+        specifier: workspace:*
+        version: link:../../libs/shared/node/module
       '@shipfox/node-opentelemetry':
         specifier: workspace:*
         version: link:../../libs/shared/node/opentelemetry

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -545,6 +545,9 @@ importers:
       '@shipfox/api-server':
         specifier: workspace:*
         version: link:../../libs/api/server
+      '@shipfox/config':
+        specifier: workspace:*
+        version: link:../../libs/shared/common/config
       '@shipfox/node-error-monitoring':
         specifier: workspace:*
         version: link:../../libs/shared/node/error-monitoring


### PR DESCRIPTION
Adds the managed runner image and E2E coverage needed for renewable inference credentials.

The runner now advertises renewable inference only from verified managed images. The production closure check covers the Claude helper and credential socket transport. The E2E-only managed provider rotates opaque generations and exercises both Pi and Claude renewal paths, including rejection and refresh-at flows.

Documentation records the compatibility-release deployment gate. The change does not alter Cloud AMI pins or token issuance.

Validation passed for the affected package checks, types, builds, unit suites, dependency and lockfile checks, published artifacts, dependency-cruiser, documentation checks, and the production-only flat runner deployment verifier. The live flow E2E was not run because the local Docker/OrbStack daemon was unavailable.

Closes ENG-1950

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Managed runner images now support renewable inference credentials for Pi and Claude sessions, so credentials refresh mid-job instead of failing. Runners advertise this capability only from verified managed images after the production closure check passes; source-run and unverified images keep the flag off.

**Deployment gate**
- An API at or above the compatibility release must be deployed on every instance before a renewable-inference image is used.
- Older or unverified runners stay on the compatibility credential path during fleet drain.

**E2E coverage**
- Adds an E2E-only managed provider fixture that rotates credential generations for Pi and Claude models.
- The fixture exercises rejection and refresh-at paths, returns provider-specific 401 error formats, bounds stats to issued credentials, and bounds credential state with TTL eviction, tombstone retention, and model/mode change guards.
- Admin authentication uses constant-time token comparison.
- Existing Claude E2E workflows now select the `anthropic` provider explicitly so they stay off the fixture.
- The image installation verifier now also checks the Claude auth helper and credential socket transport.

Closes ENG-1950

<sup>Written for commit 360e33c1b52dbfe78a1111d5a6b65cdb21df4ad2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1708?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

