### PR TITLE
[docs] Add new Cloud models to the agent reference

### DIFF
--- a/apps/docs/content/docs/reference/cloud-models.mdx
+++ b/apps/docs/content/docs/reference/cloud-models.mdx
@@ -49,6 +49,7 @@ reference](/reference/workflow-schema#agent-step-fields).
 | Claude Sonnet 4.5 | `claude-sonnet-4.5` |
 | Claude Haiku 4.5 | `claude-haiku-4.5` |
 | Gemini 3.8 Flash | `gemini-3.8-flash` |
+| GPT 6 Astra | `gpt-6-astra` |
 | GPT-5.6 Luna | `gpt-5.6-luna` |
 | GPT-5.6 Terra | `gpt-5.6-terra` |
 | GPT-5.6 Sol | `gpt-5.6-sol` |
@@ -61,6 +62,7 @@ reference](/reference/workflow-schema#agent-step-fields).
 | DeepSeek V4 Flash (0731) | `deepseek-v4-flash-0731` |
 | DeepSeek V4 Pro (0813) | `deepseek-v4-pro-0813` |
 | DeepSeek V4 Pro | `deepseek-v4-pro` |
+| GLM 5.3 | `glm-5.3` |
 | GLM-5.3 Flash | `glm-5.3-flash` |
 | GLM-5.2 | `glm-5.2` |
 | GLM-5.1 | `glm-5.1` |


### PR DESCRIPTION
Keep the public Cloud model reference aligned with the managed inference catalog by documenting GPT 6 Astra and GLM 5.3, which were added in [Cloud PR #390](https://github.com/ShipfoxHQ/cloud/pull/390).

Local docs checks, tests, type checks, production build, and diff validation passed. This is documentation-only, so no Changeset is included.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds GPT 6 Astra and GLM 5.3 to the Cloud model reference so the docs match the managed inference catalog.

<sup>Written for commit 02e211a3adb6523a370548d35f7927f879bd43b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1709?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

