### PR TITLE
[api-auth] Default public API URL to API URL

### DIFF
--- a/.changeset/gentle-public-fallback.md
+++ b/.changeset/gentle-public-fallback.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-auth": patch
+---
+
+Defaults API_PUBLIC_URL to API_URL when an explicit public URL is not set.

--- a/libs/api/auth/README.md
+++ b/libs/api/auth/README.md
@@ -68,12 +68,13 @@ Required environment:
 | `AUTH_SIGNUP_ALLOWED_EMAIL_DOMAINS` | none | Comma-separated email domains allowed to create accounts, such as `shipfox.io,acme.com`. |
 | `AUTH_SIGNUP_ALLOWED_EMAILS` | none | Comma-separated exact email addresses allowed to create accounts. |
 | `AUTH_SIGNUP_NOT_ALLOWED_MESSAGE` | none | Markdown message returned when the signup gate blocks an account. Accepts at most 500 characters. Defaults to "This Shipfox deployment does not accept new accounts right now." |
-| `API_PUBLIC_URL` | none | Required public API origin used by Agent Access OAuth metadata and redirect flows. Local development may use `http://localhost:16101`; use HTTPS elsewhere. |
+| `API_PUBLIC_URL` | `API_URL` | Public API origin used by Agent Access OAuth metadata and redirect flows. Local development may use `http://localhost:16101`; use HTTPS elsewhere. |
 | `CLIENT_BASE_URL` | `http://localhost:5173` | Base URL used in email verification and password reset links. |
 | `ADMIN_BOOTSTRAP_TOKEN` | none | Deployment secret accepted once to create the first administrator owner. Set it before bootstrap and remove or rotate it after successful bootstrap. |
 
-`API_PUBLIC_URL` has no default. Set it before startup. OAuth route construction
-rejects non-loopback HTTP origins.
+`API_PUBLIC_URL` defaults to `API_URL`. Set it when the externally reachable
+origin differs from `API_URL`. OAuth route construction rejects non-loopback
+HTTP origins.
 
 The recommended access-token lifetime is 15 minutes. Because user JWTs are
 verified from their claims, a token issued before logout, password changes,

--- a/libs/api/auth/src/config.test.ts
+++ b/libs/api/auth/src/config.test.ts
@@ -15,15 +15,35 @@ describe('signup gate configuration', () => {
     expect(config.AUTH_SIGNUP_NOT_ALLOWED_MESSAGE).toBeUndefined();
   });
 
-  test('requires the public API URL', async () => {
+  test('requires API_PUBLIC_URL or API_URL', async () => {
     vi.stubEnv('API_PUBLIC_URL', undefined);
+    vi.stubEnv('API_URL', undefined);
     vi.resetModules();
 
     await expect(import('#config.js')).rejects.toThrow('process.exit unexpectedly called with "1"');
   });
 
-  test('accepts an HTTPS public API URL', async () => {
+  test('defaults the public API URL to API_URL', async () => {
+    vi.stubEnv('API_PUBLIC_URL', undefined);
+    vi.stubEnv('API_URL', 'https://internal-api.example.test');
+    vi.resetModules();
+
+    const {config} = await import('#config.js');
+
+    expect(config.API_PUBLIC_URL).toBe('https://internal-api.example.test');
+  });
+
+  test('rejects an invalid API_URL fallback', async () => {
+    vi.stubEnv('API_PUBLIC_URL', undefined);
+    vi.stubEnv('API_URL', 'internal-api.example.test');
+    vi.resetModules();
+
+    await expect(import('#config.js')).rejects.toThrow('process.exit unexpectedly called with "1"');
+  });
+
+  test('prefers API_PUBLIC_URL to API_URL', async () => {
     vi.stubEnv('API_PUBLIC_URL', 'https://api.example.test');
+    vi.stubEnv('API_URL', 'https://internal-api.example.test');
     vi.resetModules();
 
     const {config} = await import('#config.js');

--- a/libs/api/auth/src/config.ts
+++ b/libs/api/auth/src/config.ts
@@ -1,13 +1,13 @@
 import {bool, createConfig, num, str, url} from '@shipfox/config';
 import {SIGNUP_DENIAL_MESSAGE_MAX_LENGTH} from '#core/ports.js';
 
-export const config = createConfig({
+const configSchema = {
   ADMIN_BOOTSTRAP_TOKEN: str({
     desc: 'Deployment secret accepted once to create the first administrator owner. Set it before bootstrap and remove or rotate it after successful bootstrap.',
     default: undefined,
   }),
   API_PUBLIC_URL: url({
-    desc: 'Public origin of the API used by Agent Access OAuth metadata and redirect flows. Required. Set an externally reachable URL including the scheme. Use HTTPS outside localhost.',
+    desc: 'Public origin of the API used by Agent Access OAuth metadata and redirect flows. Defaults to API_URL. Set an externally reachable URL including the scheme. Use HTTPS outside localhost.',
   }),
   AUTH_JWT_EXPIRES_IN: str({
     desc: 'How long an access token stays valid. Accepts a duration string such as 15m, 1h, or 7d.',
@@ -61,6 +61,10 @@ export const config = createConfig({
     desc: 'Base URL of the client app. Used to build links in emails such as password resets.',
     default: 'http://localhost:5173',
   }),
+};
+
+export const config = createConfig(configSchema, {
+  API_PUBLIC_URL: process.env.API_PUBLIC_URL ?? process.env.API_URL,
 });
 
 if (

--- a/libs/api/server/README.md
+++ b/libs/api/server/README.md
@@ -96,7 +96,7 @@ node --import @shipfox/api-server/instrumentation ./dist/index.js
 | --- | --- | --- |
 | `E2E_ENABLED` | `false` | Enables routes under `/__e2e` when `E2E_ADMIN_API_KEY` is set. |
 | `E2E_ADMIN_API_KEY` | none | Required to enable and protect E2E routes. |
-| `API_PUBLIC_URL` | none | Required public API origin used by MCP OAuth metadata and redirect flows. Local development may use `http://localhost:16101`; use HTTPS elsewhere. |
+| `API_PUBLIC_URL` | `API_URL` | Public API origin used by MCP OAuth metadata and redirect flows. Set it when the public origin differs from `API_URL`. Local development may use `http://localhost:16101`; use HTTPS elsewhere. |
 | `API_PORT` | shared `PORT` | Sets the listener port. |
 | `API_TRUST_PROXY` | `false` | Sets proxy IP checks. |
 


### PR DESCRIPTION
Defaults `API_PUBLIC_URL` to `API_URL` when no explicit public origin is configured. This removes duplicate configuration where both addresses match while preserving the override for private networking, reverse proxies, and split DNS.

The selected fallback still passes through URL validation, so startup fails when neither value exists or when the selected value is invalid. The package and server environment docs describe the precedence, with a patch Changeset for `@shipfox/api-auth`.

Validation: `mise exec -- turbo test type check --filter=@shipfox/api-auth...`; focused configuration tests; Changeset status; prose verification; `git diff --check`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defaults `API_PUBLIC_URL` to `API_URL` when no explicit public origin is set, so deployments with matching addresses no longer need duplicate configuration. An explicit `API_PUBLIC_URL` still takes precedence, and the selected value still passes URL validation at startup.

- Updates the `@shipfox/api-auth` and `@shipfox/api-server` docs to describe the fallback and precedence.
- Adds a patch Changeset for `@shipfox/api-auth`.

<sup>Written for commit 2593a045319bca8ab4f86b5ac8a045ec00f64905. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1727?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

