### PR TITLE
[api-workflows] Restore session claims after gate retries

### DIFF
--- a/.changeset/fresh-session-claims.md
+++ b/.changeset/fresh-session-claims.md
@@ -2,4 +2,4 @@
 "@shipfox/api-workflows": patch
 ---
 
-Continue named agent resume sessions from the latest session segment when workflows retry a step.
+Continue named agent sessions from the latest session segment when workflows retry a step.

--- a/.changeset/fresh-session-claims.md
+++ b/.changeset/fresh-session-claims.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-workflows": patch
+---
+
+Restore named agent session claims when gates retry workflow steps.

--- a/.changeset/fresh-session-claims.md
+++ b/.changeset/fresh-session-claims.md
@@ -2,4 +2,4 @@
 "@shipfox/api-workflows": patch
 ---
 
-Restore named agent session claims when gates retry workflow steps.
+Continue named agent resume sessions from the latest session segment when workflows retry a step.

--- a/libs/api/workflows/src/core/job-execution.test.ts
+++ b/libs/api/workflows/src/core/job-execution.test.ts
@@ -2090,6 +2090,62 @@ describe('durable gate restart', () => {
     return (await restartEvents(jobId)).length;
   }
 
+  async function arrangeGatedAgentJob(): Promise<{
+    jobId: string;
+    producer: string;
+    reviewer: string;
+  }> {
+    const model = workflowModel({
+      jobs: {
+        build: {
+          steps: [
+            {
+              key: 'producer',
+              prompt: 'Implement the change.',
+              session: {key: 'main', mode: 'resume'},
+            },
+            {
+              key: 'reviewer',
+              run: 'review',
+              gate: {
+                success: createWorkflowExpression({
+                  source: 'step.exit_code == 0',
+                  check: {mode: 'syntax'},
+                }),
+                onFailure: {restartFrom: 'producer'},
+              },
+            },
+          ],
+        },
+      },
+    });
+    const run = await createWorkflowRun({
+      workspaceId: crypto.randomUUID(),
+      projectId: crypto.randomUUID(),
+      definitionId: crypto.randomUUID(),
+      model,
+      triggerPayload: {
+        source: 'manual',
+        event: 'fire',
+        subscriptionId: crypto.randomUUID(),
+        userId: crypto.randomUUID(),
+      },
+      resolveAgentDefaults: resolveTestAgentDefaults,
+    });
+    const jobs = await getJobsByWorkflowRunId(run.id);
+    const jobId = jobs[0]?.id as string;
+
+    await stripSetupStep(jobId);
+
+    const steps = await getStepsByJobId(jobId);
+    const producer = steps.find((step) => step.key === 'producer')?.id;
+    const reviewer = steps.find((step) => step.key === 'reviewer')?.id;
+    if (producer === undefined || reviewer === undefined) {
+      throw new Error('Expected gated agent steps');
+    }
+    return {jobId, producer, reviewer};
+  }
+
   // producer (named) → reviewer (gated `success: step.exit_code == 0`, on_failure restart_from producer)
   async function arrangeGatedJob(params: {
     source: string;
@@ -2227,6 +2283,63 @@ describe('durable gate restart', () => {
       {stepId: reviewer, attempt: 1, executionOrder: 2},
       {stepId: producer, attempt: 2, executionOrder: 3},
       {stepId: reviewer, attempt: 2, executionOrder: 4},
+    ]);
+  });
+
+  test('reclaims a named resume session after every gate restart', async () => {
+    const {jobId, producer, reviewer} = await arrangeGatedAgentJob();
+    const sessionId = crypto.randomUUID();
+    const claimSession = vi.mocked(agentTestClient.claimSession);
+    claimSession.mockReset();
+    let nextSegment = 3;
+    claimSession.mockImplementation(() => {
+      const segment = nextSegment;
+      nextSegment += 1;
+      return Promise.resolve({
+        descriptor: {id: sessionId, key: 'main', mode: 'resume', segment},
+        harness: 'pi',
+      });
+    });
+
+    const first = await nextStepForJob(jobId, agentTestClient);
+    await recordStepResult({jobId, stepId: producer, status: 'succeeded'});
+    await runStep(jobId, reviewer, 1);
+    const second = await nextStepForJob(jobId, agentTestClient);
+    await recordStepResult({jobId, stepId: producer, status: 'succeeded'});
+    await runStep(jobId, reviewer, 1);
+    const third = await nextStepForJob(jobId, agentTestClient);
+
+    expect(claimSession).toHaveBeenCalledTimes(3);
+    expect(
+      claimSession.mock.calls.map(([claim]) => ({
+        key: claim.key,
+        mode: claim.mode,
+        stepAttemptId: claim.stepAttemptId,
+      })),
+    ).toEqual([
+      {key: 'main', mode: 'resume', stepAttemptId: expect.any(String)},
+      {key: 'main', mode: 'resume', stepAttemptId: expect.any(String)},
+      {key: 'main', mode: 'resume', stepAttemptId: expect.any(String)},
+    ]);
+    expect(new Set(claimSession.mock.calls.map(([claim]) => claim.stepAttemptId)).size).toBe(3);
+    expect(
+      [first, second, third].map((result) =>
+        result.kind === 'step' ? result.step.config.session : undefined,
+      ),
+    ).toEqual([
+      {id: sessionId, key: 'main', mode: 'resume', segment: 3},
+      {id: sessionId, key: 'main', mode: 'resume', segment: 4},
+      {id: sessionId, key: 'main', mode: 'resume', segment: 5},
+    ]);
+    const attempts = await getStepAttempts(jobId);
+    expect(
+      attempts
+        .filter((attempt) => attempt.stepId === producer)
+        .map((attempt) => ({attempt: attempt.attempt, session: attempt.config?.session})),
+    ).toEqual([
+      {attempt: 1, session: {id: sessionId, key: 'main', mode: 'resume', segment: 3}},
+      {attempt: 2, session: {id: sessionId, key: 'main', mode: 'resume', segment: 4}},
+      {attempt: 3, session: {id: sessionId, key: 'main', mode: 'resume', segment: 5}},
     ]);
   });
 

--- a/libs/api/workflows/src/core/job-execution.test.ts
+++ b/libs/api/workflows/src/core/job-execution.test.ts
@@ -2090,7 +2090,12 @@ describe('durable gate restart', () => {
     return (await restartEvents(jobId)).length;
   }
 
-  async function arrangeGatedAgentJob(): Promise<{
+  async function arrangeGatedAgentJob(
+    params: {
+      session?: string | {key: string; mode?: 'resume' | 'fork'};
+      inputs?: Record<string, unknown>;
+    } = {},
+  ): Promise<{
     jobId: string;
     producer: string;
     reviewer: string;
@@ -2102,7 +2107,7 @@ describe('durable gate restart', () => {
             {
               key: 'producer',
               prompt: 'Implement the change.',
-              session: {key: 'main', mode: 'resume'},
+              session: params.session ?? {key: 'main', mode: 'resume'},
             },
             {
               key: 'reviewer',
@@ -2130,6 +2135,7 @@ describe('durable gate restart', () => {
         subscriptionId: crypto.randomUUID(),
         userId: crypto.randomUUID(),
       },
+      ...(params.inputs === undefined ? {} : {inputs: params.inputs}),
       resolveAgentDefaults: resolveTestAgentDefaults,
     });
     const jobs = await getJobsByWorkflowRunId(run.id);
@@ -2340,6 +2346,87 @@ describe('durable gate restart', () => {
       {attempt: 1, session: {id: sessionId, key: 'main', mode: 'resume', segment: 3}},
       {attempt: 2, session: {id: sessionId, key: 'main', mode: 'resume', segment: 4}},
       {attempt: 3, session: {id: sessionId, key: 'main', mode: 'resume', segment: 5}},
+    ]);
+  });
+
+  test('reclaims the materialized key of a templated resume session after a gate restart', async () => {
+    const {jobId, producer, reviewer} = await arrangeGatedAgentJob({
+      session: {key: `triage-\${{ inputs.ticket }}`, mode: 'resume'},
+      inputs: {ticket: 'abc123'},
+    });
+    const sessionId = crypto.randomUUID();
+    const claimSession = vi.mocked(agentTestClient.claimSession);
+    claimSession.mockReset();
+    claimSession.mockImplementation(() =>
+      Promise.resolve({
+        descriptor: {
+          id: sessionId,
+          key: 'triage-abc123',
+          mode: 'resume',
+          segment: claimSession.mock.calls.length + 2,
+        },
+        harness: 'pi',
+      }),
+    );
+
+    await nextStepForJob(jobId, agentTestClient);
+    await recordStepResult({jobId, stepId: producer, status: 'succeeded'});
+    await runStep(jobId, reviewer, 1);
+    await nextStepForJob(jobId, agentTestClient);
+
+    expect(claimSession).toHaveBeenCalledTimes(2);
+    expect(claimSession.mock.calls.map(([claim]) => claim.key)).toEqual([
+      'triage-abc123',
+      'triage-abc123',
+    ]);
+  });
+
+  test('reclaims a templated fork session after a claim without a descriptor', async () => {
+    const {jobId, producer, reviewer} = await arrangeGatedAgentJob({
+      session: {key: `triage-\${{ inputs.ticket }}`, mode: 'fork'},
+      inputs: {ticket: 'abc123'},
+    });
+    const sessionId = crypto.randomUUID();
+    const claimSession = vi.mocked(agentTestClient.claimSession);
+    claimSession.mockReset();
+    claimSession.mockImplementation(() => {
+      const claimNumber = claimSession.mock.calls.length;
+      return Promise.resolve({
+        descriptor:
+          claimNumber === 2
+            ? null
+            : {
+                id: sessionId,
+                key: 'triage-abc123',
+                mode: 'fork',
+                segment: claimNumber + 2,
+              },
+        harness: 'pi',
+      });
+    });
+
+    const first = await nextStepForJob(jobId, agentTestClient);
+    await recordStepResult({jobId, stepId: producer, status: 'succeeded'});
+    await runStep(jobId, reviewer, 1);
+    const second = await nextStepForJob(jobId, agentTestClient);
+    await recordStepResult({jobId, stepId: producer, status: 'succeeded'});
+    await runStep(jobId, reviewer, 1);
+    const third = await nextStepForJob(jobId, agentTestClient);
+
+    expect(claimSession).toHaveBeenCalledTimes(3);
+    expect(claimSession.mock.calls.map(([claim]) => ({key: claim.key, mode: claim.mode}))).toEqual([
+      {key: 'triage-abc123', mode: 'fork'},
+      {key: 'triage-abc123', mode: 'fork'},
+      {key: 'triage-abc123', mode: 'fork'},
+    ]);
+    expect(
+      [first, second, third].map((result) =>
+        result.kind === 'step' ? result.step.config.session : undefined,
+      ),
+    ).toEqual([
+      {id: sessionId, key: 'triage-abc123', mode: 'fork', segment: 3},
+      undefined,
+      {id: sessionId, key: 'triage-abc123', mode: 'fork', segment: 5},
     ]);
   });
 

--- a/libs/api/workflows/src/core/job-execution.ts
+++ b/libs/api/workflows/src/core/job-execution.ts
@@ -57,7 +57,11 @@ import {
   WorkflowExecutionPayloadTooLargeError,
   WorkflowStepResultTooLargeError,
 } from './errors.js';
-import {completeAgentDefaults, readAgentStepSessionIntent} from './step-config/agent.js';
+import {
+  completeAgentDefaults,
+  readAgentStepSessionIntent,
+  restoreAgentSessionIntentForRedispatch,
+} from './step-config/agent.js';
 import {assembleStepDispatchContext} from './step-config/assemble-run-context.js';
 import {completeStepDispatchConfig} from './step-config/complete-step-dispatch-config.js';
 import type {WorkflowEvaluationContext} from './step-config/workflow-evaluation-context.js';
@@ -341,14 +345,10 @@ async function dispatchPendingStep(params: PendingStepDispatchParams): Promise<N
 function pendingStepForDispatch(step: Step): Step {
   if (step.type !== 'agent' || step.currentAttempt === 1) return step;
 
-  // A successful claim replaces the intent with a descriptor. Gate rewinds
-  // preserve step config, so every retried dispatch must restore the authored
-  // intent before it can acquire a claim for the new attempt.
-  const config = {...step.config};
-  const session = step.authoredConfig?.session;
-  if (session === undefined) delete config.session;
-  else config.session = session;
-  return {...step, config};
+  return {
+    ...step,
+    config: restoreAgentSessionIntentForRedispatch(step),
+  };
 }
 
 async function dispatchPendingStepWithConfigPlan({

--- a/libs/api/workflows/src/core/job-execution.ts
+++ b/libs/api/workflows/src/core/job-execution.ts
@@ -320,21 +320,35 @@ async function resolveNextPendingStep({
 }
 
 async function dispatchPendingStep(params: PendingStepDispatchParams): Promise<NextStepResolution> {
-  const hasConfigPlan = params.pending.configPlan !== null || params.pending.type === 'tool';
-  if (hasConfigPlan) return dispatchPendingStepWithConfigPlan(params);
+  const pending = pendingStepForDispatch(params.pending);
+  const dispatchParams = pending === params.pending ? params : {...params, pending};
+  const hasConfigPlan = pending.configPlan !== null || pending.type === 'tool';
+  if (hasConfigPlan) return dispatchPendingStepWithConfigPlan(dispatchParams);
 
   // A fully resolved agent step still carries a session intent in its config.
   // Route it through the claim path even though no other field needs dispatch
   // completion.
-  const hasSessionIntent =
-    params.pending.type === 'agent' && params.pending.config.session !== undefined;
-  if (hasSessionIntent) return dispatchPendingStepWithConfigPlan(params);
+  const hasSessionIntent = pending.type === 'agent' && pending.config.session !== undefined;
+  if (hasSessionIntent) return dispatchPendingStepWithConfigPlan(dispatchParams);
 
   const marked = await markStepRunning(
-    {jobExecutionId: params.jobExecutionId, stepId: params.pending.id},
+    {jobExecutionId: params.jobExecutionId, stepId: pending.id},
     params.tx,
   );
-  return {kind: 'step', step: marked ?? params.pending, dispatched: true};
+  return {kind: 'step', step: marked ?? pending, dispatched: true};
+}
+
+function pendingStepForDispatch(step: Step): Step {
+  if (step.type !== 'agent' || step.currentAttempt === 1) return step;
+
+  // A successful claim replaces the intent with a descriptor. Gate rewinds
+  // preserve step config, so every retried dispatch must restore the authored
+  // intent before it can acquire a claim for the new attempt.
+  const config = {...step.config};
+  const session = step.authoredConfig?.session;
+  if (session === undefined) delete config.session;
+  else config.session = session;
+  return {...step, config};
 }
 
 async function dispatchPendingStepWithConfigPlan({

--- a/libs/api/workflows/src/core/step-config/agent.ts
+++ b/libs/api/workflows/src/core/step-config/agent.ts
@@ -10,6 +10,7 @@ import {agentInterModuleContract} from '@shipfox/api-agent-dto/inter-module';
 import type {WorkflowModel} from '@shipfox/api-definitions-dto';
 import {
   type AgentStepSessionIntentDto,
+  agentStepSessionDescriptorSchema,
   agentStepSessionIntentSchema,
 } from '@shipfox/api-workflows-dto';
 import type {ResolvedField, SiteResolvedField} from '@shipfox/expression';
@@ -123,22 +124,21 @@ export async function completeAgentConfig(params: {
           template: agent.provider,
           params,
         });
-
-  const defaults = await completeAgentDefaults({
-    harness: agent.harness ?? readConfigHarness(params.config),
+  const thinking =
+    agent.thinking === undefined
+      ? readConfigThinking(params.config)
+      : completeAgentField({field: 'agent.thinking', template: agent.thinking, params});
+  const harness = agent.harness ?? readConfigHarness(params.config);
+  await applyAgentDefaultsForDispatch({
+    agent,
+    config: params.config,
+    harness,
     provider,
     model,
-    thinking:
-      agent.thinking === undefined
-        ? readConfigThinking(params.config)
-        : completeAgentField({field: 'agent.thinking', template: agent.thinking, params}),
+    thinking,
     resolveAgentDefaults: params.resolveAgentDefaults,
     definitionId: params.definitionId,
   });
-  params.config.harness = defaults.harness;
-  params.config.provider = defaults.provider;
-  params.config.model = defaults.model;
-  params.config.thinking = defaults.thinking;
   params.config.prompt = prompt;
   let sessionIntent: AgentStepSessionIntentDto | undefined;
   if (agent.session !== undefined) {
@@ -163,6 +163,42 @@ export async function completeAgentConfig(params: {
   return sessionIntent;
 }
 
+async function applyAgentDefaultsForDispatch(params: {
+  readonly agent: NonNullable<StepConfigDispatchPlan['agent']>;
+  readonly config: Record<string, unknown>;
+  readonly harness: WorkflowModelAgentStep['harness'] | undefined;
+  readonly provider: string | undefined;
+  readonly model: string | undefined;
+  readonly thinking: string | undefined;
+  readonly resolveAgentDefaults: AgentDefaultsResolver | undefined;
+  readonly definitionId: string;
+}): Promise<void> {
+  const hasDefaultsPlan =
+    params.agent.harness !== undefined ||
+    params.agent.provider !== undefined ||
+    params.agent.model !== undefined ||
+    params.agent.thinking !== undefined;
+  const hasMaterializedDefaults =
+    params.harness !== undefined &&
+    params.provider !== undefined &&
+    params.model !== undefined &&
+    params.thinking !== undefined;
+  if (!hasDefaultsPlan && hasMaterializedDefaults) return;
+
+  const defaults = await completeAgentDefaults({
+    harness: params.harness,
+    provider: params.provider,
+    model: params.model,
+    thinking: params.thinking,
+    resolveAgentDefaults: params.resolveAgentDefaults,
+    definitionId: params.definitionId,
+  });
+  params.config.harness = defaults.harness;
+  params.config.provider = defaults.provider;
+  params.config.model = defaults.model;
+  params.config.thinking = defaults.thinking;
+}
+
 /**
  * Decodes the intent retained in a running step after the dispatch transaction
  * has committed. The shared schema is the single source of truth for this
@@ -174,6 +210,36 @@ export function readAgentStepSessionIntent(
 ): AgentStepSessionIntentDto | undefined {
   const parsed = agentStepSessionIntentSchema.safeParse(config.session);
   return parsed.success ? parsed.data : undefined;
+}
+
+/** Restore the materialized session intent before redispatch replaces it with a new claim. */
+export function restoreAgentSessionIntentForRedispatch(params: {
+  readonly config: Record<string, unknown>;
+  readonly configPlan: StepConfigDispatchPlan | null;
+  readonly authoredConfig: Record<string, unknown> | null;
+}): Record<string, unknown> {
+  const config = {...params.config};
+
+  // New materializations preserve the resolved intent in the plan. Removing
+  // the prior descriptor lets normal dispatch completion restore that value.
+  if (params.configPlan?.agent?.session !== undefined) {
+    delete config.session;
+    return config;
+  }
+
+  // Older materializations have no session plan. A descriptor still contains
+  // the resolved key, so prefer it over the authored template source.
+  const descriptor = agentStepSessionDescriptorSchema.safeParse(config.session);
+  if (descriptor.success) {
+    config.session = {key: descriptor.data.key, mode: descriptor.data.mode};
+    return config;
+  }
+  if (readAgentStepSessionIntent(config) !== undefined) return config;
+
+  const authored = agentStepSessionIntentSchema.safeParse(params.authoredConfig?.session);
+  if (authored.success) config.session = authored.data;
+  else delete config.session;
+  return config;
 }
 
 function completeAgentField(args: {
@@ -388,6 +454,14 @@ async function agentStepConfigWithDefaults(
       configPlan: {
         agent: {
           prompt: dispatchPlanField(fields.prompt),
+          ...(fields.session === undefined
+            ? {}
+            : {
+                session: {
+                  key: dispatchPlanField(fields.session.key),
+                  mode: fields.session.mode,
+                },
+              }),
           ...agentToolsConfig(step),
           ...agentToolSurfaceConfig(step),
           ...materializedAgentIntegrationsConfig(params),
@@ -414,7 +488,17 @@ async function agentStepConfigWithDefaults(
       ...materializedAgentIntegrationsConfig(params),
       prompt: promptValue,
     },
-    configPlan: null,
+    configPlan:
+      fields.session === undefined
+        ? null
+        : {
+            agent: {
+              session: {
+                key: dispatchPlanField(fields.session.key),
+                mode: fields.session.mode,
+              },
+            },
+          },
     diagnostics: fields.diagnostics,
     trace: fields.trace,
     hasTemplates: fields.hasTemplates,

--- a/libs/api/workflows/src/db/workflow-runs/run-rerun.test.ts
+++ b/libs/api/workflows/src/db/workflow-runs/run-rerun.test.ts
@@ -4,6 +4,7 @@ import type {AgentToolMaterializationSnapshot} from '#core/agent-tools.js';
 import {NoFailedJobsError, RunNotTerminalError, SourceRunNotFoundError} from '#core/errors.js';
 import {nextStepForJob, recordStepResult} from '#core/job-execution.js';
 import {assembleWorkflowRunContext} from '#core/step-config/assemble-run-context.js';
+import {literalField} from '#core/step-config/fields.js';
 import {stripSetupStep} from '#test/fixtures/strip-setup-step.js';
 import {listTestRunAttempts} from '#test/helpers/run-attempts.js';
 import {
@@ -592,6 +593,56 @@ describe('workflow run queries', () => {
         expect(jobSteps.every((step) => step.status === 'pending')).toBe(true);
         expect(jobSteps.every((step) => step.error === null)).toBe(true);
       }
+    });
+
+    test('failed mode preserves the claimed session on a carried-over agent step', async () => {
+      const source = await createTerminalSourceRun();
+      const sourceJobs = await getJobsByWorkflowRunId(source.id);
+      const sourceBuild = sourceJobs.find((job) => job.key === 'build');
+      if (!sourceBuild) throw new Error('Missing source build job');
+      const sourceBuildSteps = await getStepsByJobId(sourceBuild.id);
+      const sourceAgentStep = sourceBuildSteps.find((step) => step.type === 'run');
+      if (!sourceAgentStep) throw new Error('Missing source build step');
+      const session = {
+        id: crypto.randomUUID(),
+        key: 'main',
+        mode: 'resume' as const,
+        segment: 3,
+      };
+      await db()
+        .update(stepsTable)
+        .set({
+          type: 'agent',
+          config: {
+            harness: 'pi',
+            provider: 'openai',
+            model: 'gpt-5.5-pro',
+            thinking: 'medium',
+            prompt: 'Continue.',
+            session,
+          },
+          configPlan: {
+            agent: {session: {key: literalField('main'), mode: 'resume'}},
+          },
+          authoredConfig: {prompt: 'Continue.', session: {key: 'main', mode: 'resume'}},
+        })
+        .where(eq(stepsTable.id, sourceAgentStep.id));
+
+      const rerun = await createRerunWorkflowRun({
+        workflowRunId: source.id,
+        mode: 'failed',
+        actorUserId: crypto.randomUUID(),
+      });
+      const rerunJobs = await getJobsByWorkflowRunId(rerun.id);
+      const rerunBuild = rerunJobs.find((job) => job.key === 'build');
+      if (!rerunBuild) throw new Error('Missing rerun build job');
+      const rerunBuildSteps = await getStepsByJobId(rerunBuild.id);
+
+      expect(rerunBuild).toMatchObject({status: 'succeeded', carriedOver: true});
+      expect(rerunBuildSteps.find((step) => step.type === 'agent')).toMatchObject({
+        status: 'succeeded',
+        config: expect.objectContaining({session}),
+      });
     });
 
     test('increments attempts across a lineage', async () => {

--- a/libs/api/workflows/src/db/workflow-runs/run-rerun.ts
+++ b/libs/api/workflows/src/db/workflow-runs/run-rerun.ts
@@ -271,7 +271,7 @@ function materializeRerunGraphJob(
         status: carriedOver ? step.status : 'pending',
         statusReason: carriedOver ? step.statusReason : null,
         type: step.type,
-        config: rerunStepConfig(step),
+        config: carriedOver ? {...step.config} : rerunStepConfig(step),
         condition: step.condition ?? null,
         configPlan: step.configPlan,
         authoredConfig: step.authoredConfig,

--- a/libs/api/workflows/src/db/workflow-runs/run-rerun.ts
+++ b/libs/api/workflows/src/db/workflow-runs/run-rerun.ts
@@ -2,6 +2,7 @@ import {readPersistedWorkflowModel} from '@shipfox/api-definitions-dto';
 import {and, asc, eq, inArray, sql} from 'drizzle-orm';
 import {isWorkflowRunTerminal, type WorkflowRun} from '#core/entities/workflow-run.js';
 import {NoFailedJobsError, RunNotTerminalError, SourceRunNotFoundError} from '#core/errors.js';
+import {restoreAgentSessionIntentForRedispatch} from '#core/step-config/agent.js';
 import {deriveJobExecutionRunner} from '#core/workflow-run-creation.js';
 import {recordWorkflowRunCreated} from '#metrics/instance.js';
 import {db, type Tx} from '../db.js';
@@ -177,11 +178,9 @@ async function loadRerunSourceGraph(
 }
 
 function rerunStepConfig(step: StepDb): Record<string, unknown> {
-  const config = {...step.config};
+  const config =
+    step.type === 'agent' ? restoreAgentSessionIntentForRedispatch(step) : {...step.config};
   const authoredConfig = step.authoredConfig;
-  const session = authoredConfig?.session;
-  if (session === undefined) delete config.session;
-  else config.session = session;
   if (authoredConfig?.harness !== undefined) config.harness = authoredConfig.harness;
   return config;
 }


### PR DESCRIPTION
## Summary

Restore each retried agent step's authored session intent before dispatch. This lets every gate restart acquire a new claim and use the latest session segment.

Add regression coverage for two consecutive gate restarts of a named resume session. Publish the fix as a patch to `@shipfox/api-workflows`.

## Motivation

Gate rewinds retain the materialized config from the prior attempt. After the first retry replaced the session intent with a descriptor, a later retry treated that descriptor as resolved and skipped the new claim. Its transcript commit then conflicted with the current session head.

## Validation

- `mise exec -- turbo check type test --filter=@shipfox/api-workflows...`
- `mise exec -- pnpm --filter @shipfox/api-workflows test src/core/job-execution.test.ts`
- `mise exec -- vale .changeset/fresh-session-claims.md`
- `mise exec -- pnpm exec changeset status --since origin/main`
- `git diff --check origin/main...HEAD`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes gate retries for agent steps by restoring the authored session intent each time a step is redispatched, so every retry acquires a fresh claim and uses the latest session segment. Previously, a retry could skip the new claim and treat the old descriptor as resolved, causing transcript conflicts.

**Bug Fixes**
- Covers named, templated, and fork resume sessions on gate restarts, manual reruns, and carried-over steps in failed-mode reruns.
- Adds regression tests and publishes as a patch to `@shipfox/api-workflows`.

<sup>Written for commit 7fd21575430d53ae375e10d5ad2dbc989e655846. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1729?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

