### PR TITLE
[client-shell] Collapse empty session banner space

### DIFF
--- a/.changeset/calm-banners-collapse.md
+++ b/.changeset/calm-banners-collapse.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/client-shell": patch
+---
+
+Collapses registered session-banner slots when they render no content.

--- a/libs/client/shell/README.md
+++ b/libs/client/shell/README.md
@@ -112,7 +112,8 @@ composition and collision rules.
 - The shared header owns the Docs link, user identity, theme selection, account
   menu slot, and logout action.
 - The shared frame resolves the deepest route's `content`, `data`, or `focused`
-  declaration and accounts for the measured session-banner height.
+  declaration and accounts for the measured session-banner height. A registered
+  session banner that returns `null` reserves no space.
 - Consumers import browser components from `@shipfox/client-shell/runtime`.
   The package root remains safe for build-time feature evaluation.
 

--- a/libs/client/shell/src/components/application-frame.tsx
+++ b/libs/client/shell/src/components/application-frame.tsx
@@ -168,6 +168,25 @@ function SessionBannerStrip({
     return () => observer.disconnect();
   }, [bannerFailed, onHeightChange]);
 
+  // Keep the presence-based fallback current in runtimes without
+  // ResizeObserver. The minimum is the best available height in that case.
+  useEffect(() => {
+    if (
+      bannerFailed ||
+      typeof ResizeObserver !== 'undefined' ||
+      typeof MutationObserver === 'undefined'
+    ) {
+      return;
+    }
+    const strip = stripRef.current;
+    if (!strip) return;
+    const observer = new MutationObserver(() => {
+      onHeightChange(strip.hasChildNodes() ? SESSION_BANNER_HEIGHT_PX : 0);
+    });
+    observer.observe(strip, {childList: true, subtree: true});
+    return () => observer.disconnect();
+  }, [bannerFailed, onHeightChange]);
+
   return (
     <ReportErrorBoundary
       label="Failed to render session banner."
@@ -177,7 +196,8 @@ function SessionBannerStrip({
     >
       <div
         ref={stripRef}
-        className="flex min-h-40 shrink-0 items-center bg-background-subtle-base empty:min-h-0"
+        className="flex min-h-(--session-banner-min-height) shrink-0 items-center bg-background-subtle-base empty:min-h-0"
+        style={{'--session-banner-min-height': `${SESSION_BANNER_HEIGHT_PX}px`} as CSSProperties}
       >
         <SessionBanner />
       </div>

--- a/libs/client/shell/src/components/application-frame.tsx
+++ b/libs/client/shell/src/components/application-frame.tsx
@@ -37,10 +37,10 @@ const frameClassNames: Record<RouteFrame, string> = {
 };
 
 /**
- * Minimum height of the reserved SessionBanner strip, in pixels. The layout
- * reserves this much for the slot and the app-content viewport arithmetic
- * starts from it; the rendered strip height is measured and feeds the
- * arithmetic so taller banners keep the content area consistent.
+ * Minimum height of a rendered SessionBanner strip, in pixels. The layout
+ * reserves this much when the slot renders content; the rendered strip height
+ * is measured and feeds the app-content viewport arithmetic so taller banners
+ * keep the content area consistent.
  */
 const SESSION_BANNER_HEIGHT_PX = 40;
 
@@ -147,9 +147,11 @@ function SessionBannerStrip({
   const stripRef = useRef<HTMLDivElement | null>(null);
   const [bannerFailed, setBannerFailed] = useState(false);
 
-  // Reset stale or failed measurements before paint when the slot state changes.
+  // Reset stale measurements from the committed output before paint. A slot
+  // may remain registered while returning null for the current session.
   useLayoutEffect(() => {
-    onHeightChange(bannerFailed ? 0 : SESSION_BANNER_HEIGHT_PX);
+    const hasBannerContent = stripRef.current?.hasChildNodes() ?? false;
+    onHeightChange(bannerFailed || !hasBannerContent ? 0 : SESSION_BANNER_HEIGHT_PX);
   }, [bannerFailed, onHeightChange]);
 
   // The strip exists only after authentication succeeds, so observation starts
@@ -175,8 +177,7 @@ function SessionBannerStrip({
     >
       <div
         ref={stripRef}
-        className="flex shrink-0 items-center bg-background-subtle-base"
-        style={{minHeight: SESSION_BANNER_HEIGHT_PX}}
+        className="flex min-h-40 shrink-0 items-center bg-background-subtle-base empty:min-h-0"
       >
         <SessionBanner />
       </div>

--- a/libs/client/shell/src/components/main-layout.stories.tsx
+++ b/libs/client/shell/src/components/main-layout.stories.tsx
@@ -187,6 +187,12 @@ export const Playground: Story = {
 
 export const WithoutBanner: Story = {
   args: {
+    withSessionBanner: false,
+  },
+};
+
+export const EmptyBanner: Story = {
+  args: {
     showSessionBanner: false,
   },
 };

--- a/libs/client/shell/src/components/main-layout.stories.tsx
+++ b/libs/client/shell/src/components/main-layout.stories.tsx
@@ -59,6 +59,10 @@ function DemoSessionBanner() {
   );
 }
 
+function EmptySessionBanner() {
+  return null;
+}
+
 function OverviewPage() {
   return (
     <div className="flex flex-col gap-cluster">
@@ -74,9 +78,11 @@ function OverviewPage() {
 
 function MainLayoutStory({
   withSessionBanner,
+  showSessionBanner,
   hideProjectNavigation,
 }: {
   withSessionBanner: boolean;
+  showSessionBanner: boolean;
   hideProjectNavigation: boolean;
 }) {
   const queryClient = useMemo(
@@ -92,9 +98,11 @@ function MainLayoutStory({
     () => ({
       ProjectBreadcrumb: () => null,
       projectSlugResolver: async () => 'project',
-      ...(withSessionBanner ? {SessionBanner: DemoSessionBanner} : {}),
+      ...(withSessionBanner
+        ? {SessionBanner: showSessionBanner ? DemoSessionBanner : EmptySessionBanner}
+        : {}),
     }),
-    [withSessionBanner],
+    [showSessionBanner, withSessionBanner],
   );
   const [router, setRouter] = useState<AnyRouter | null>(null);
 
@@ -151,6 +159,7 @@ const meta = {
   },
   args: {
     withSessionBanner: true,
+    showSessionBanner: true,
     hideProjectNavigation: false,
   },
 } satisfies Meta<typeof MainLayoutStory>;
@@ -178,7 +187,7 @@ export const Playground: Story = {
 
 export const WithoutBanner: Story = {
   args: {
-    withSessionBanner: false,
+    showSessionBanner: false,
   },
 };
 

--- a/libs/client/shell/src/components/main-layout.test.tsx
+++ b/libs/client/shell/src/components/main-layout.test.tsx
@@ -1,5 +1,5 @@
 import type {AnyRouter} from '@tanstack/react-router';
-import {fireEvent, screen, waitFor, within} from '@testing-library/react';
+import {act, fireEvent, screen, waitFor, within} from '@testing-library/react';
 import {atom, useAtomValue} from 'jotai';
 import {defineClientFeature} from '#contract.js';
 import type {ChromeSlots} from '#runtime/chrome-context.js';
@@ -113,6 +113,68 @@ describe('MainLayout session banner', () => {
 
     expect(screen.queryByText('Session banner')).not.toBeInTheDocument();
     expect(await screen.findByRole('main')).toHaveStyle('--app-content-h: calc(100dvh - 96px)');
+  });
+
+  test('collapses a registered session banner that renders nothing', async () => {
+    vi.stubGlobal('ResizeObserver', undefined);
+
+    try {
+      await renderMainLayout({SessionBanner: () => null});
+
+      const bannerStrip = (await screen.findByRole('banner')).previousElementSibling;
+      expect(bannerStrip).toBeEmptyDOMElement();
+      expect(bannerStrip).toHaveClass('min-h-40', 'empty:min-h-0');
+      expect(screen.getByRole('main')).toHaveStyle('--app-content-h: calc(100dvh - 96px)');
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  test('tracks when a registered session banner starts and stops rendering content', async () => {
+    let resize: ResizeObserverCallback | undefined;
+    class ResizeObserverProbe {
+      constructor(callback: ResizeObserverCallback) {
+        resize = callback;
+      }
+      observe(): void {
+        // The test invokes the captured callback directly.
+      }
+      unobserve(): void {
+        // The test invokes the captured callback directly.
+      }
+      disconnect(): void {
+        // The test invokes the captured callback directly.
+      }
+    }
+    vi.stubGlobal('ResizeObserver', ResizeObserverProbe);
+    const bannerVisibleAtom = atom(false);
+    function ConditionalSessionBanner() {
+      return useAtomValue(bannerVisibleAtom) ? <div>Session banner</div> : null;
+    }
+
+    try {
+      const {store} = await renderMainLayout({SessionBanner: ConditionalSessionBanner});
+
+      const main = await screen.findByRole('main');
+      expect(main).toHaveStyle('--app-content-h: calc(100dvh - 96px)');
+      await waitFor(() => expect(resize).toBeTypeOf('function'));
+
+      act(() => store.set(bannerVisibleAtom, true));
+      expect(await screen.findByText('Session banner')).toBeVisible();
+      act(() => {
+        resize?.([{contentRect: {height: 40}} as ResizeObserverEntry], {} as ResizeObserver);
+      });
+      expect(main).toHaveStyle('--app-content-h: calc(100dvh - 136px)');
+
+      act(() => store.set(bannerVisibleAtom, false));
+      expect(screen.queryByText('Session banner')).not.toBeInTheDocument();
+      act(() => {
+        resize?.([{contentRect: {height: 0}} as ResizeObserverEntry], {} as ResizeObserver);
+      });
+      expect(main).toHaveStyle('--app-content-h: calc(100dvh - 96px)');
+    } finally {
+      vi.unstubAllGlobals();
+    }
   });
 
   test('renders a composed session banner above the navigation bar', async () => {

--- a/libs/client/shell/src/components/main-layout.test.tsx
+++ b/libs/client/shell/src/components/main-layout.test.tsx
@@ -121,10 +121,7 @@ describe('MainLayout session banner', () => {
     try {
       await renderMainLayout({SessionBanner: () => null});
 
-      const bannerStrip = (await screen.findByRole('banner')).previousElementSibling;
-      expect(bannerStrip).toBeEmptyDOMElement();
-      expect(bannerStrip).toHaveClass('min-h-40', 'empty:min-h-0');
-      expect(screen.getByRole('main')).toHaveStyle('--app-content-h: calc(100dvh - 96px)');
+      expect(await screen.findByRole('main')).toHaveStyle('--app-content-h: calc(100dvh - 96px)');
     } finally {
       vi.unstubAllGlobals();
     }

--- a/libs/client/shell/src/components/main-layout.test.tsx
+++ b/libs/client/shell/src/components/main-layout.test.tsx
@@ -174,6 +174,31 @@ describe('MainLayout session banner', () => {
     }
   });
 
+  test('tracks banner presence when ResizeObserver is unavailable', async () => {
+    vi.stubGlobal('ResizeObserver', undefined);
+    const bannerVisibleAtom = atom(false);
+    function ConditionalSessionBanner() {
+      return useAtomValue(bannerVisibleAtom) ? <div>Session banner</div> : null;
+    }
+
+    try {
+      const {store} = await renderMainLayout({SessionBanner: ConditionalSessionBanner});
+
+      const main = await screen.findByRole('main');
+      expect(main).toHaveStyle('--app-content-h: calc(100dvh - 96px)');
+
+      act(() => store.set(bannerVisibleAtom, true));
+      expect(await screen.findByText('Session banner')).toBeVisible();
+      await waitFor(() => expect(main).toHaveStyle('--app-content-h: calc(100dvh - 136px)'));
+
+      act(() => store.set(bannerVisibleAtom, false));
+      expect(screen.queryByText('Session banner')).not.toBeInTheDocument();
+      await waitFor(() => expect(main).toHaveStyle('--app-content-h: calc(100dvh - 96px)'));
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
   test('renders a composed session banner above the navigation bar', async () => {
     await renderMainLayout({SessionBanner: () => <div>Session banner</div>});
 

--- a/libs/client/shell/src/runtime/chrome-context.tsx
+++ b/libs/client/shell/src/runtime/chrome-context.tsx
@@ -25,12 +25,11 @@ export interface ChromeSlots {
   WorkspaceSetupIndicator?: ComponentType;
   /**
    * Optional component the main layout renders above the navigation bar, inside
-   * an error boundary. The layout reserves a minimum-height strip for the slot,
-   * measures its rendered height, and accounts for it in the app-content
-   * viewport arithmetic, so a composing component taller than the minimum is
-   * still fully visible and the content area stays consistent. The layout
-   * renders nothing when the slot is absent, so a consumer that composes
-   * without the session banner is unaffected.
+   * an error boundary. The component may return null for the current session.
+   * The layout collapses an empty slot, otherwise reserves a minimum-height
+   * strip, measures its rendered height, and accounts for it in the app-content
+   * viewport arithmetic. A composing component taller than the minimum stays
+   * fully visible and the content area stays consistent.
    */
   SessionBanner?: ComponentType;
 }


### PR DESCRIPTION
## Summary

The shared application frame reserved a 40px session-banner strip whenever a banner component was registered, even when it returned `null` outside impersonation. This left an empty bar above the header and reduced the available content height.

Empty banner output now collapses before paint. Visible banners retain their 40px minimum and continue using `ResizeObserver` for runtime transitions and taller content.

## Validation

- `mise exec -- turbo check type test build --filter=@shipfox/client-shell...`
- `mise exec -- pnpm check:client-architecture`
- `mise exec -- pnpm --filter @shipfox/client-shell storybook:build`
- Browser measurement confirmed an empty height of 0px and a visible height of 40px.
- `mise exec -- pnpm exec changeset status`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the shared application frame reserving a 40px session-banner strip when the registered banner renders nothing, so empty banner output collapses before paint and no longer shrinks the content area. Visible banners keep their 40px minimum; runtime height changes continue through `ResizeObserver`, with a `MutationObserver` fallback when `ResizeObserver` is unavailable.

<sup>Written for commit 0bb6e9f4362be6c710c807f50eae3b36b36024a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1730?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

