### PR TITLE
[client-workflows] Stabilize animated tab screenshots

### DIFF
--- a/libs/client/workflows/vitest.config.ts
+++ b/libs/client/workflows/vitest.config.ts
@@ -58,7 +58,10 @@ export default defineConfig(
             browser: {
               enabled: true,
               headless: true,
-              provider: playwright(),
+              provider: playwright({
+                // Framer Motion honors this preference; Argos CSS alone cannot stop JS animations.
+                contextOptions: {reducedMotion: 'reduce'},
+              }),
               instances: [{browser: 'chromium'}],
             },
           },


### PR DESCRIPTION
Make client-workflows Storybook runs emulate reduced motion. The workflow job cost-tab snapshot could capture Framer Motion's underline between positions because Argos CSS only disables CSS transitions; the browser preference sends the shared tabs component through its zero-duration path while leaving production behavior unchanged.

Validated the JobDetail Storybook file (17 stories) and the client-workflows dependency closure with `turbo check type --filter=@shipfox/client-workflows...`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Emulates reduced motion in client-workflows Storybook runs so animated tab screenshots no longer capture Framer Motion's underline mid-animation. Argos CSS only disables CSS transitions, so the browser preference now sends the shared tabs component through its zero-duration path while leaving production behavior unchanged.

<sup>Written for commit b136a179b92f62f48c69bab94805b21099e9b64c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1732?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

