### PR TITLE
[e2e-flow-workflows] Stabilize listener delivery synchronization

### DIFF
--- a/e2e/suites/flow/workflows/src/listener-helpers.ts
+++ b/e2e/suites/flow/workflows/src/listener-helpers.ts
@@ -226,6 +226,7 @@ export async function waitForListenerStatus(params: {
   listenerStatus: ListenerStatusDto;
   timeoutMs: number;
 }): Promise<WorkflowRunObservation> {
+  const requestSignal = AbortSignal.timeout(params.timeoutMs);
   let diagnostic = `listener job ${params.jobKey} missing`;
   return await pollUntil(
     {
@@ -239,6 +240,7 @@ export async function waitForListenerStatus(params: {
       const observation = await observeRun({
         runId: params.runId,
         selection: {jobs: [{jobKey: params.jobKey}]},
+        signal: requestSignal,
         token: params.token,
       });
       const status = listenerStatusMatches({...params, observation});
@@ -250,7 +252,7 @@ export async function waitForListenerStatus(params: {
       const readiness = await requestJson<{ready: boolean}>(
         'get',
         `/__e2e/triggers/listeners/${encodeURIComponent(job.id)}/readiness`,
-        {},
+        {signal: requestSignal},
       );
       diagnostic = readiness.ready
         ? `${status.diagnostic}, trigger subscriptions ready`

--- a/e2e/suites/flow/workflows/src/listener-jobs.ts
+++ b/e2e/suites/flow/workflows/src/listener-jobs.ts
@@ -14,6 +14,7 @@ import {logText} from './expect.js';
 import {
   batchedListenerExecutionMatches,
   sendWebhookDeliveryUntilObserved,
+  waitForListenerStatus,
 } from './listener-helpers.js';
 import {waitForRunObservationMatching} from './polling.js';
 import {startSuiteLocalRunner} from './runner.js';
@@ -28,6 +29,7 @@ import {
 import {seedProjectWithApiDefinition} from './workflow-project.js';
 
 export const LISTENER_JOB = 'listen';
+const LISTENER_DELIVERY_TIMEOUT_MS = 60_000;
 const FIRE_SOURCE_PLACEHOLDER = '__FIRE_WEBHOOK_SOURCE__';
 const RESOLVE_SOURCE_PLACEHOLDER = '__RESOLVE_WEBHOOK_SOURCE__';
 
@@ -200,6 +202,15 @@ export async function sendFire(
   label: string,
   message: string,
 ) {
+  await waitForListenerStatus({
+    token: testCase.token,
+    runId,
+    jobKey: LISTENER_JOB,
+    listenerStatus: 'listening',
+    timeoutMs: LISTENER_DELIVERY_TIMEOUT_MS,
+  });
+
+  // Retry delivery IDs are distinct listener events and can consume multiple executions.
   const result = await sendWebhookDeliveryUntilObserved({
     client: testCase.client,
     connection: testCase.fireConnection,
@@ -207,7 +218,8 @@ export async function sendFire(
     token: testCase.token,
     jobKey: LISTENER_JOB,
     deliveryIdPrefix: `${testCase.uniqueId}-${label}`,
-    attemptTimeoutMs: 15_000,
+    maxAttempts: 1,
+    attemptTimeoutMs: LISTENER_DELIVERY_TIMEOUT_MS,
     body: (_attempt, deliveryId) => ({message, delivery_id: deliveryId}),
   });
   testCase.fireDiagnostics.deliveryIds.push(...result.deliveryIds);

--- a/e2e/suites/flow/workflows/tests/filter-scenarios.e2e.ts
+++ b/e2e/suites/flow/workflows/tests/filter-scenarios.e2e.ts
@@ -27,6 +27,7 @@ import {
   listenerStatusMatches,
   sendWebhookDeliveryUntilObserved,
   waitForListenerResolution,
+  waitForListenerStatus,
 } from '#listener-helpers.js';
 import {
   cleanupListenerCase,
@@ -36,7 +37,6 @@ import {
   setupListenerCase,
   stopRunner,
 } from '#listener-jobs.js';
-import {waitForRunObservationMatching} from '#polling.js';
 import {startSuiteLocalRunner, waitForRunTerminalOrFailedRunner} from '#runner.js';
 import type {SuiteContext} from '#suite-context.js';
 import {postWebhookDelivery} from '#webhook.js';
@@ -45,6 +45,7 @@ import {expect, test} from './fixtures.js';
 
 const TRIGGER_FILTER_NO_RUN_TIMEOUT_MS = 8_000;
 const LISTENER_NEGATIVE_ASSERTION_MS = 5_000;
+const LISTENER_FILTER_DELIVERY_TIMEOUT_MS = 60_000;
 const MATCHING_PR_NUMBER = '42';
 const NONMATCHING_PR_NUMBER = '41';
 
@@ -355,18 +356,12 @@ test.describe('filter scenarios', () => {
       });
       runId = await fireManualRun(testCase);
 
-      await waitForRunObservationMatching({
+      await waitForListenerStatus({
         token: testCase.token,
         runId,
-        timeoutMs: 90_000,
-        description: 'listener filter job to start listening',
-        selection: {jobs: [{jobKey: LISTENER_JOB}]},
-        matches: (observation) =>
-          listenerStatusMatches({
-            observation,
-            jobKey: LISTENER_JOB,
-            listenerStatus: 'listening',
-          }),
+        jobKey: LISTENER_JOB,
+        listenerStatus: 'listening',
+        timeoutMs: LISTENER_FILTER_DELIVERY_TIMEOUT_MS,
       });
 
       const nonmatchingFireDeliveryId = `${testCase.uniqueId}-fire-filtered`;
@@ -415,7 +410,8 @@ test.describe('filter scenarios', () => {
         token: testCase.token,
         jobKey: LISTENER_JOB,
         deliveryIdPrefix: `${testCase.uniqueId}-fire-matching`,
-        attemptTimeoutMs: 15_000,
+        maxAttempts: 1,
+        attemptTimeoutMs: LISTENER_FILTER_DELIVERY_TIMEOUT_MS,
         body: (_attempt, deliveryId) => ({
           issue: {number: MATCHING_PR_NUMBER},
           delivery_id: deliveryId,


### PR DESCRIPTION
## Summary

Wait for listener trigger subscriptions to become ready before sending fire events, then send one logical delivery per intended execution. This prevents observation lag from creating retry deliveries that consume multiple listener executions, stabilizing the max-executions scenario without increasing its delivery time budget.

## Validation

- Package checks passed: 318 tasks across check, type, test, and depcruise.
- The max-executions E2E scenario passed three concurrent repeats.
- The complete listener-jobs E2E spec passed all four tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes the listener E2E flow by waiting for the listener to be ready before firing and sending a single delivery per intended execution, so observation lag no longer causes retry deliveries that consume extra listener executions.

- Waits for the listener job to report `listening` status before sending each fire event, using a timeout signal so the readiness poll cannot hang.
- Sends at most one delivery attempt with a 60s timeout instead of retrying on a 15s timeout.

<sup>Written for commit 85162d05fecb0d5a782c1e0d3cb0762d27601595. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1734?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

