### PR TITLE
Guide users through connecting Claude and Codex over MCP

### DIFF
--- a/.changeset/calm-shared-tabs.md
+++ b/.changeset/calm-shared-tabs.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/react-ui": patch
+---
+
+Use semantic group spacing between tabs so multiword labels remain distinct.

--- a/.changeset/quiet-mcp-guidance.md
+++ b/.changeset/quiet-mcp-guidance.md
@@ -1,0 +1,7 @@
+---
+"@shipfox/client-agent": patch
+"@shipfox/client-api": minor
+---
+
+Add MCP setup guidance with a copyable endpoint and Claude and Codex connection instructions.
+Expose API URL resolution for links that use the configured API base.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -635,6 +635,8 @@ Navigation never wears a standalone bordered tile. A grid of openable things is
 
 ### Navigation
 
+- **TabsList** uses `gap-group` between triggers so multiword labels read as
+  separate choices. Consumers and stories inherit this spacing from the shared component.
 - **NavBar** `h-56`, sticky, `bg-background-subtle-base`, hairline bottom border,
   holding a theme-aware `Logo`, split-affordance workspace and project crumbs (name
   links to the entity, chevron opens a `Command`+`Popover` switcher), and a

--- a/libs/client/agent/src/agent-access/components/agent-access-settings-page.test.tsx
+++ b/libs/client/agent/src/agent-access/components/agent-access-settings-page.test.tsx
@@ -25,6 +25,26 @@ function renderSettings(element: ReactElement) {
 }
 
 describe('AgentAccessSettingsPage', () => {
+  test('guides setup and copies the selected client commands before any app is connected', async () => {
+    const user = userEvent.setup();
+    configureApiClient({
+      baseUrl: 'https://api.example.test/proxy/',
+      fetchImpl: vi.fn().mockResolvedValue(jsonResponse({grants: []})),
+    });
+    renderSettings(<AgentAccessSettingsPage workspaceId={WORKSPACE_ID} />);
+
+    expect(await screen.findByText('No connected apps')).toBeVisible();
+    expect(screen.getByText('https://api.example.test/proxy/mcp')).toBeVisible();
+    await user.click(screen.getByRole('tab', {name: 'Codex'}));
+    const instructions = screen.getByRole('tabpanel');
+    await user.click(within(instructions).getByRole('button', {name: 'Copy Codex commands'}));
+
+    expect(await navigator.clipboard.readText()).toBe(
+      "codex mcp add shipfox --url 'https://api.example.test/proxy/mcp'\ncodex mcp login shipfox",
+    );
+    expect(within(instructions).queryByText('Claude Code command')).not.toBeInTheDocument();
+  });
+
   test('shows only OAuth apps authorized for the active workspace', async () => {
     const fetchImpl = vi.fn().mockResolvedValue(
       jsonResponse({

--- a/libs/client/agent/src/agent-access/components/agent-access-settings-page.tsx
+++ b/libs/client/agent/src/agent-access/components/agent-access-settings-page.tsx
@@ -31,39 +31,43 @@ import {
 } from '#hooks/api/agent-access/credentials.js';
 import {agentAccessErrorMessage} from './errors.js';
 import {formatAgentAccessDate, formatAgentAccessTimestamp} from './format.js';
+import {McpSetup} from './mcp-setup.js';
 
 export function AgentAccessSettingsPage({workspaceId}: {workspaceId: string}) {
   const grantsQuery = useAgentGrantsQuery();
   const grants = (grantsQuery.data ?? []).filter((grant) => grant.workspaceId === workspaceId);
 
   return (
-    <section className="flex min-w-0 flex-col gap-group" aria-labelledby="connected-apps-title">
-      <div className="flex flex-col gap-tight">
-        <Header id="connected-apps-title" variant="h3">
-          Connected apps
-        </Header>
-        <Text size="sm" className="text-foreground-neutral-muted">
-          Tools connected to this workspace through MCP.
-        </Text>
-      </div>
-      {grantsQuery.isPending ? <GrantListSkeleton /> : null}
-      {grantsQuery.isError && grantsQuery.data === undefined ? (
-        <Panel>
-          <QueryLoadError query={grantsQuery} subject="connected apps" variant="panel" />
-        </Panel>
-      ) : null}
-      {grantsQuery.data !== undefined && grants.length === 0 ? (
-        <Panel>
-          <EmptyState
-            icon="terminalBoxLine"
-            title="No connected apps"
-            description="Apps you connect to this workspace through MCP will appear here."
-            variant="panel"
-          />
-        </Panel>
-      ) : null}
-      {grants.length > 0 ? <AgentGrantList grants={grants} /> : null}
-    </section>
+    <div className="flex min-w-0 flex-col gap-section">
+      <McpSetup />
+      <section className="flex min-w-0 flex-col gap-group" aria-labelledby="connected-apps-title">
+        <div className="flex flex-col gap-tight">
+          <Header id="connected-apps-title" variant="h3">
+            Connected apps
+          </Header>
+          <Text size="sm" className="text-foreground-neutral-muted">
+            Tools connected to this workspace through MCP.
+          </Text>
+        </div>
+        {grantsQuery.isPending ? <GrantListSkeleton /> : null}
+        {grantsQuery.isError && grantsQuery.data === undefined ? (
+          <Panel>
+            <QueryLoadError query={grantsQuery} subject="connected apps" variant="panel" />
+          </Panel>
+        ) : null}
+        {grantsQuery.data !== undefined && grants.length === 0 ? (
+          <Panel>
+            <EmptyState
+              icon="terminalBoxLine"
+              title="No connected apps"
+              description="Follow the setup steps above to connect your first app."
+              variant="panel"
+            />
+          </Panel>
+        ) : null}
+        {grants.length > 0 ? <AgentGrantList grants={grants} /> : null}
+      </section>
+    </div>
   );
 }
 

--- a/libs/client/agent/src/agent-access/components/mcp-setup.tsx
+++ b/libs/client/agent/src/agent-access/components/mcp-setup.tsx
@@ -1,0 +1,124 @@
+import {resolveApiUrl} from '@shipfox/client-api';
+import {Button} from '@shipfox/react-ui/button';
+import {useCopyToClipboard} from '@shipfox/react-ui/hooks';
+import {Panel} from '@shipfox/react-ui/panel';
+import {Tabs, TabsContent, TabsList, TabsTrigger} from '@shipfox/react-ui/tabs';
+import {toast} from '@shipfox/react-ui/toast';
+import {Code, Header, Text} from '@shipfox/react-ui/typography';
+
+export function McpSetup() {
+  const endpoint = new URL(resolveApiUrl('/mcp'), window.location.origin).href;
+  const quotedEndpoint = `'${endpoint.replaceAll("'", "'\\''")}'`;
+
+  return (
+    <section className="flex min-w-0 flex-col gap-group" aria-labelledby="mcp-setup-title">
+      <div className="flex flex-col gap-tight">
+        <Header id="mcp-setup-title" variant="h3">
+          Connect your agent
+        </Header>
+        <Text size="sm" className="text-foreground-neutral-muted">
+          Give Claude, Codex, or another MCP app access to your Shipfox workspace.
+        </Text>
+      </div>
+      <Panel>
+        <div className="border-b border-border-neutral-base p-panel-compact">
+          <SetupCode label="MCP endpoint" code={endpoint} showLabel />
+        </div>
+        <div className="flex flex-col gap-group p-panel-compact">
+          <Tabs defaultValue="claude-code">
+            <TabsList aria-label="Setup instructions">
+              <TabsTrigger value="claude-code">Claude Code</TabsTrigger>
+              <TabsTrigger value="codex">Codex</TabsTrigger>
+              <TabsTrigger value="claude">Claude app</TabsTrigger>
+            </TabsList>
+            <TabsContent value="claude-code" className="flex flex-col gap-inline pt-panel-compact">
+              <Text size="sm">Run this command in your terminal:</Text>
+              <SetupCode
+                label="Claude Code command"
+                code={`claude mcp add --transport http shipfox ${quotedEndpoint}`}
+              />
+              <Text size="sm">
+                Open Claude Code and run{' '}
+                <Code
+                  as="code"
+                  variant="label"
+                  className="rounded-4 bg-background-components-base px-tight"
+                >
+                  /mcp
+                </Code>
+                . Select Shipfox and follow the sign-in steps in your browser.
+              </Text>
+            </TabsContent>
+            <TabsContent value="codex" className="flex flex-col gap-inline pt-panel-compact">
+              <Text size="sm">Run these commands in your terminal to add Shipfox and sign in:</Text>
+              <SetupCode
+                label="Codex commands"
+                code={`codex mcp add shipfox --url ${quotedEndpoint}\ncodex mcp login shipfox`}
+              />
+            </TabsContent>
+            <TabsContent value="claude" className="flex flex-col gap-inline pt-panel-compact">
+              <Text size="sm">
+                In Claude on web or desktop, open Settings → Connectors → Add custom connector. Name
+                it Shipfox, paste the MCP endpoint above as the remote server URL, then connect and
+                sign in.
+              </Text>
+            </TabsContent>
+          </Tabs>
+          <Text size="sm" className="text-foreground-neutral-muted">
+            When Shipfox opens, select this workspace and review the requested access. Once you
+            approve, the app will appear below. Other MCP apps can use the same endpoint with OAuth.
+          </Text>
+        </div>
+      </Panel>
+    </section>
+  );
+}
+
+function SetupCode({
+  label,
+  code,
+  showLabel = false,
+}: {
+  label: string;
+  code: string;
+  showLabel?: boolean;
+}) {
+  const {copy} = useCopyToClipboard({text: code});
+
+  async function handleCopy() {
+    try {
+      await copy();
+      toast.success('Copied to clipboard.');
+    } catch {
+      toast.error('Could not copy. Select and copy the text manually.');
+    }
+  }
+
+  return (
+    <div className="flex min-w-0 flex-col gap-inline">
+      {showLabel ? (
+        <Text size="sm" className="text-foreground-neutral-muted">
+          {label}
+        </Text>
+      ) : null}
+      <div className="flex min-w-0 items-start gap-inline rounded-4 bg-background-components-base p-tight">
+        <Code
+          as="pre"
+          variant="label"
+          className="min-w-0 flex-1 self-center whitespace-pre-wrap break-all"
+        >
+          <code>{code}</code>
+        </Code>
+        <Button
+          type="button"
+          variant="transparentMuted"
+          size="xs"
+          iconLeft="copy"
+          aria-label={`Copy ${label}`}
+          title={`Copy ${label}`}
+          onClick={() => void handleCopy()}
+        />
+      </div>
+    </div>
+  );
+}

--- a/libs/client/api/src/index.test.ts
+++ b/libs/client/api/src/index.test.ts
@@ -12,6 +12,7 @@ import {
   isErrorWithCode,
   isInvalidApiResponseError,
   resetApiClient,
+  resolveApiUrl,
 } from './index.js';
 
 function transportRequest<T>(path: string, options: Parameters<typeof checkedApiRequest>[2] = {}) {
@@ -27,6 +28,15 @@ function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
 }
 
 describe('checked API transport', () => {
+  test.each([
+    ['https://api.example.test', 'https://api.example.test/mcp'],
+    ['https://api.example.test/proxy/', 'https://api.example.test/proxy/mcp'],
+    ['', '/mcp'],
+  ])('resolves MCP URLs with API base %s', (baseUrl, expected) => {
+    configureApiClient({baseUrl});
+
+    expect(resolveApiUrl('/mcp')).toBe(expected);
+  });
   beforeEach(() => {
     configureApiClient({
       baseUrl: 'https://api.example.test',

--- a/libs/client/api/src/index.ts
+++ b/libs/client/api/src/index.ts
@@ -168,6 +168,11 @@ function joinUrl(baseUrl: string, path: string): string {
   return `${baseUrl.replace(TRAILING_SLASH_RE, '')}/${path.replace(LEADING_SLASH_RE, '')}`;
 }
 
+/** Resolves a path against the configured API base. Same-origin URLs remain relative. */
+export function resolveApiUrl(path: string): string {
+  return joinUrl(defaultBaseUrl(), path);
+}
+
 function defaultFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
   return globalThis.fetch(input, init);
 }

--- a/libs/shared/react/ui/src/components/tabs/tabs.stories.tsx
+++ b/libs/shared/react/ui/src/components/tabs/tabs.stories.tsx
@@ -26,7 +26,7 @@ export const Playground: Story = {
   render: () => (
     <div className="bg-background-subtle-base p-24 w-[80vw]">
       <Tabs defaultValue="analytics">
-        <TabsList className="gap-12 border-b border-neutral-strong">
+        <TabsList className="border-b border-neutral-strong">
           <TabsTrigger value="analytics">Analytics</TabsTrigger>
           <TabsTrigger value="jobs">Jobs</TabsTrigger>
         </TabsList>
@@ -46,7 +46,7 @@ export const Controlled: Story = {
     return (
       <div className="bg-background-subtle-base p-24 w-[80vw]">
         <Tabs value={value} onValueChange={setValue}>
-          <TabsList className="gap-12 border-b border-neutral-strong">
+          <TabsList className="border-b border-neutral-strong">
             <TabsTrigger value="analytics">Analytics</TabsTrigger>
             <TabsTrigger value="jobs">Jobs</TabsTrigger>
           </TabsList>
@@ -81,7 +81,7 @@ export const MultipleTabs: Story = {
   render: () => (
     <div className="bg-background-subtle-base p-24 w-[80vw]">
       <Tabs defaultValue="tab1">
-        <TabsList className="gap-12 border-b border-neutral-strong">
+        <TabsList className="border-b border-neutral-strong">
           <TabsTrigger value="tab1">Tab 1</TabsTrigger>
           <TabsTrigger value="tab2">Tab 2</TabsTrigger>
           <TabsTrigger value="tab3">Tab 3</TabsTrigger>

--- a/libs/shared/react/ui/src/components/tabs/tabs.tsx
+++ b/libs/shared/react/ui/src/components/tabs/tabs.tsx
@@ -196,7 +196,7 @@ function TabsList({
       ref={listRef}
       role="tablist"
       data-slot="tabs-list"
-      className={cn('relative inline-flex items-center gap-8', className)}
+      className={cn('relative inline-flex items-center gap-group', className)}
       {...(props as ComponentProps<'div'>)}
     >
       {children}


### PR DESCRIPTION
MCP connection settings previously showed only connected apps, leaving new users without setup instructions. Add a setup panel with the configured MCP endpoint, Claude Code and Codex commands, and separate Claude app instructions. Compact inline code includes embedded copy icons, and the guidance explains browser sign-in and workspace authorization.

Use semantic group spacing as the shared TabsList default and remove local and story overrides so multiword labels remain distinct. Include Changesets for client-agent, client-api, and react-ui.

Validation: 192 scoped lint, type, and build tasks passed; 202 client-agent tests, 23 client-api tests, and 6 shared tabs tests passed. Desktop and mobile layouts were inspected. Live client authorization and hosted Argos approval remain unverified.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Guides users through connecting Claude, Codex, and other MCP apps in connection settings, which previously only showed connected apps with no setup instructions.

**New Features**
- Adds a setup panel with the MCP endpoint, Claude Code and Codex commands, and Claude app instructions, each with copy buttons.
- Exposes `resolveApiUrl` in `@shipfox/client-api` for building the endpoint URL.

**Refactors**
- Makes `gap-group` the shared TabsList default spacing so multiword labels remain distinct.

<sup>Written for commit 883f8d345cd3ef7174d6019fd0e51b28f8d13d0e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1735?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

