### PR TITLE
Document GitHub repository access

### DIFF
--- a/apps/docs/content/docs/how-to/author-workflows/use-integration-tools.mdx
+++ b/apps/docs/content/docs/how-to/author-workflows/use-integration-tools.mdx
@@ -45,8 +45,8 @@ jobs:
           - include: [pull_request_read]
 ```
 
-The workflow omits `connection` and repository scope. It uses the project's
-GitHub source and repository. See [Agent integration
+The workflow omits `connection`, so Shipfox selects the project's source
+integration connection. See [Agent integration
 fields](/reference/workflow-schema#agent-integration-fields) for other choices.
 
 Commit and push the file to the project's default branch. Wait for **Read a new

--- a/apps/docs/content/docs/how-to/set-up-work/index.mdx
+++ b/apps/docs/content/docs/how-to/set-up-work/index.mdx
@@ -17,6 +17,9 @@ needs.
   <Card title="Inspect an integration connection" href="/how-to/set-up-work/manage-integration-connections">
     Find its slug and confirm recent events.
   </Card>
+  <Card title="Manage GitHub repository access" href="/how-to/set-up-work/manage-github-repository-access">
+    Change the GitHub repository list and Shipfox access mode.
+  </Card>
   <Card title="Pause an integration connection" href="/how-to/set-up-work/disable-integration-connection">
     Stop new events for a limited time, then resume them.
   </Card>

--- a/apps/docs/content/docs/how-to/set-up-work/manage-github-repository-access.mdx
+++ b/apps/docs/content/docs/how-to/set-up-work/manage-github-repository-access.mdx
@@ -1,0 +1,73 @@
+---
+title: "Manage GitHub Repository Access"
+sidebarTitle: "Manage GitHub Access"
+description: "Change which repositories Shipfox can access through a GitHub integration connection."
+---
+
+Use this guide to change which repositories Shipfox can access through an
+existing GitHub integration connection.
+
+GitHub controls which repositories Shipfox can access. Shipfox controls which
+of those repositories a workflow can name.
+
+## Before you begin
+
+You need permission to manage workspace integrations and an active GitHub
+integration connection.
+
+To change the GitHub repository list, you also need permission to manage the
+GitHub App installation.
+
+## Open repository access settings
+
+Open **Settings → Integrations**. Open the integration connection's menu. Select
+**Manage repository access**.
+
+## Change the repositories available from GitHub
+
+Skip this section if GitHub already lists the repositories you need.
+
+Select **Change repositories on GitHub**. Select the repositories Shipfox
+needs. Save the GitHub App installation. Return to Shipfox.
+
+Shipfox cannot access any repository outside this selection.
+
+## Choose a Shipfox access mode
+
+By default, a job checks out its project's repository. The access mode applies
+when a workflow explicitly checks out a repository or a GitHub tool names one.
+
+Choose a mode:
+
+| Mode | Repositories a workflow can name |
+| --- | --- |
+| **Only your projects' repositories** | Repositories used by Shipfox projects. [Create a project](/how-to/set-up-work/create-project) to add another repository. |
+| **Every repository this integration can access** | All repositories in the GitHub App selection. |
+
+Select **Save changes**.
+
+## Keep GitHub access narrow
+
+The **Only your projects' repositories** mode cannot check every GitHub action:
+
+- Some tools use an item ID instead of a repository name. The GitHub App
+  selection controls which items those tools can reach.
+- Some tools can affect another repository. The [GitHub tool
+  catalog](/integrations/github/tools) identifies these tools.
+- Shipfox uses saved project repository names. A rename or transfer can make
+  those names outdated.
+- The mode does not check who created an incoming event. Events from other users
+  can still match a workflow trigger.
+
+Use separate GitHub App installations when repository groups must stay
+isolated.
+
+## Verify repository access
+
+Return to **Manage repository access**.
+
+1. Confirm that the saved mode matches your choice.
+2. If you chose **Only your projects' repositories**, confirm that each required
+   project repository appears.
+3. Select **Change repositories on GitHub**. Confirm that GitHub lists only the
+   repositories Shipfox needs.

--- a/apps/docs/content/docs/how-to/set-up-work/meta.json
+++ b/apps/docs/content/docs/how-to/set-up-work/meta.json
@@ -4,6 +4,7 @@
     "index",
     "create-project",
     "manage-integration-connections",
+    "manage-github-repository-access",
     "disable-integration-connection",
     "delete-integration-connection",
     "configure-model-providers",

--- a/apps/docs/content/docs/integrations/github/index.mdx
+++ b/apps/docs/content/docs/integrations/github/index.mdx
@@ -16,6 +16,26 @@ catalog:
 Shipfox connects through a GitHub App. Install the App on the target account or
 organization. Grant it access only to the repositories Shipfox needs.
 
+## Repository access
+
+GitHub controls which repositories an integration connection can access.
+Shipfox cannot access any repository outside that selection.
+
+Shipfox uses one of two modes when a workflow names a repository:
+
+| Mode | Allowed repositories |
+| --- | --- |
+| **Only your projects' repositories** | Repositories used by Shipfox projects. |
+| **Every repository this integration can access** | Repositories selected for the GitHub App installation. |
+
+By default, a job checks out its project's repository. These modes apply when a
+workflow explicitly checks out a repository or a tool names one.
+
+Use [Manage GitHub repository
+access](/how-to/set-up-work/manage-github-repository-access) to change these
+settings. See the [GitHub tool catalog](/integrations/github/tools) for
+tool-specific behavior.
+
 ## Integration connection identity
 
 The slug of a GitHub integration connection defaults to `github_<account>`, such as

--- a/apps/docs/content/docs/integrations/github/setup.mdx
+++ b/apps/docs/content/docs/integrations/github/setup.mdx
@@ -27,10 +27,11 @@ To verify a run, you also need an online runner with the `shipfox` label.
   </Step>
   <Step>
 
-    **Choose repository access**
+    **Set the GitHub repository boundary**
 
-    Select the GitHub account or organization. Grant access only to the
-    repositories Shipfox should use. GitHub returns you to Shipfox.
+    Select the GitHub account or organization. Choose only the repositories
+    Shipfox should reach. This selection is the hard repository boundary.
+    GitHub returns you to Shipfox.
   </Step>
   <Step>
 
@@ -41,6 +42,15 @@ To verify a run, you also need an online runner with the `shipfox` label.
   </Step>
 </Steps>
 
+New GitHub integration connections use **Only your projects' repositories** by
+default.
+This setting applies to explicit checkouts and repositories named by GitHub
+tools.
+
+Use [Manage GitHub repository
+access](/how-to/set-up-work/manage-github-repository-access) to change the
+setting or the repositories selected in GitHub.
+
 ## Check event delivery
 
 Make sure the integration connection is enabled in **Settings → Integrations**. Select
@@ -49,9 +59,10 @@ show the GitHub event.
 
 ## Verify a triggered run
 
-[Create a project](/how-to/set-up-work/create-project) from one allowed
-repository. Add `.shipfox/workflows/check-github-connection.yml` to that
-repository. Replace `github_acme` with the integration connection slug. This is a complete
+[Create a project](/how-to/set-up-work/create-project) from one repository
+selected in GitHub. Add
+`.shipfox/workflows/check-github-connection.yml` to that repository. Replace
+`github_acme` with the integration connection slug. This is a complete
 workflow:
 
 ```yaml

--- a/apps/docs/content/docs/integrations/github/tools.mdx
+++ b/apps/docs/content/docs/integrations/github/tools.mdx
@@ -23,4 +23,15 @@ permissions. Write tools (for example `create_branch` and `merge_pull_request`)
 require the workflow step's `integrations` entry to set `allow_write: true`;
 without it, Shipfox rejects the step at validation.
 
+The generated catalog also states each operation's repository classification:
+
+- **Declared targets:** Shipfox can check repository coordinates from the tool
+  input against the integration connection's repository-access mode.
+- **Integration connection:** The input does not identify a complete repository
+  target that Shipfox can check locally.
+
+An **indirect target** note identifies a GitHub-side effect that can reach beyond
+the declared target. See [GitHub repository
+access](/integrations/github#repository-access) for the boundary and its limits.
+
 <GithubTools />

--- a/apps/docs/content/docs/understand/integrations-connections-and-tools.mdx
+++ b/apps/docs/content/docs/understand/integrations-connections-and-tools.mdx
@@ -83,6 +83,20 @@ checkout credential. An agent can therefore have this mix:
 
 These separate paths mean that "GitHub access" is never one broad permission.
 
+## Repository access adds two boundaries
+
+The provider sets the outer repository boundary. For GitHub, this is the
+repository selection on the GitHub App installation.
+
+Shipfox can add a direct-target guardrail inside that boundary. In `selected`
+mode, explicit checkouts and direct tool targets must match repositories used by
+Shipfox projects. In `all` mode, Shipfox skips that project check.
+
+This guardrail does not resolve opaque IDs or every indirect provider effect.
+The provider installation remains the boundary for those operations. The
+[GitHub tool catalog](/integrations/github/tools) marks each classification and
+indirect target.
+
 ## The workflow never receives the credential
 
 The workflow names an integration connection and the selected operations. It
@@ -106,8 +120,8 @@ Start with no integration tool. Add a read operation when the agent needs
 external context. Add a write operation only when the workflow intends an
 external change.
 
-Keep the repository scope as narrow as the work. When the task concerns one
-repository, the project source default is safer than broad account access.
+Keep the repository boundary as narrow as the work. For GitHub, use `selected`
+mode and a narrow App installation when the task concerns one repository.
 
 A general credential supports many operations but hides the real reach of the
 step. A small tool selection makes that reach visible in the workflow and at
@@ -117,4 +131,6 @@ Use [Agent access](/how-to/author-workflows/use-integration-tools) for the
 authoring task. The reference for [agent integration
 fields](/reference/workflow-schema#agent-integration-fields) lists the exact
 selection and write fields. [Agents](/understand/agents) explains how this
-access fits with the harness, model, and native tools.
+access fits with the harness, model, and native tools. [Manage GitHub repository
+access](/how-to/set-up-work/manage-github-repository-access) explains how to
+change both repository boundaries.

--- a/apps/docs/scripts/check-catalog.mjs
+++ b/apps/docs/scripts/check-catalog.mjs
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import {readFileSync} from 'node:fs';
 import {githubAgentToolCatalog} from '@shipfox/api-integration-github/agent-tools';
 import {githubEventCatalog} from '@shipfox/api-integration-github-dto';
 import {validateIntegrationCatalog} from '@/lib/integration-catalog-validation';
@@ -74,3 +75,34 @@ assert.throws(
   () => validateIntegrationCatalog(providers, {unknown: ['events']}),
   /Generated DTO catalog.*no matching provider page/,
 );
+
+const generatedGithubTools = readFileSync(
+  'content/generated/integrations/github/tools.mdx',
+  'utf8',
+);
+const classifiedGithubOperations = githubAgentToolCatalog.reduce(
+  (count, tool) =>
+    count +
+    (typeof tool.repositoryScope === 'function' ? 1 : 0) +
+    (tool.methods?.filter((method) => typeof method.repositoryScope === 'function').length ?? 0),
+  0,
+);
+assert.equal(
+  generatedGithubTools.split('**Repository classification:**').length - 1,
+  classifiedGithubOperations,
+);
+
+const indirectTargetNotes = new Set(
+  githubAgentToolCatalog.flatMap((tool) => [
+    tool.indirectTargetNote,
+    tool.repositoryScope({}).indirectTargetNote,
+    ...(tool.methods ?? []).flatMap((method) => [
+      method.indirectTargetNote,
+      method.repositoryScope({}).indirectTargetNote,
+    ]),
+  ]),
+);
+indirectTargetNotes.delete(undefined);
+for (const note of indirectTargetNotes) {
+  assert.ok(generatedGithubTools.includes(`**Indirect target:** ${note}`));
+}

--- a/apps/docs/scripts/generate.mjs
+++ b/apps/docs/scripts/generate.mjs
@@ -240,6 +240,7 @@ function renderToolMethod(tool, method) {
     '',
     `**Required permissions:** ${formatScope(method.requiredScope)}`,
     ...alternativeScopeLines(method),
+    ...repositoryClassificationLines(tool.inputSchema, method),
     '',
     methodRequirements(tool.inputSchema, method.id),
   ];
@@ -262,6 +263,7 @@ function renderTool(tool, selectionCatalog) {
     `**Sensitive:** ${tool.sensitive ? 'Yes.' : 'No.'}`,
     '',
     `**Required permissions:** ${formatScope(tool.requiredScope)}`,
+    ...repositoryClassificationLines(tool.inputSchema, tool),
     '',
     `**Selector tokens:** ${formatSelectors(tool.id, selectionCatalog)}`,
     '',
@@ -286,6 +288,51 @@ function renderToolCatalog(catalog, selectionCatalog) {
     }
   }
   return lines.join('\n').trimEnd();
+}
+
+const repositoryCoordinateSamples = {
+  owner: 'example-owner',
+  repo: 'example-repository',
+  base_owner: 'example-base-owner',
+  base_repo: 'example-base-repository',
+  head_owner: 'example-head-owner',
+  head_repo: 'example-head-repository',
+  repository_owner: 'example-owner',
+  repository_name: 'example-repository',
+  repository: 'example-owner/example-repository',
+};
+
+function repositoryClassificationLines(inputSchema, catalogEntry) {
+  if (typeof catalogEntry.repositoryScope !== 'function') return [];
+
+  const directScope = catalogEntry.repositoryScope(repositoryArguments(inputSchema));
+  const connectionScope = catalogEntry.repositoryScope({});
+  const classification = formatRepositoryClassification(directScope, connectionScope);
+  const indirectTargetNote =
+    catalogEntry.indirectTargetNote ??
+    directScope.indirectTargetNote ??
+    connectionScope.indirectTargetNote;
+
+  return [
+    '',
+    `**Repository classification:** ${classification}`,
+    ...(indirectTargetNote ? ['', `**Indirect target:** ${indirectTargetNote}`] : []),
+  ];
+}
+
+function repositoryArguments(inputSchema) {
+  const properties = object(inputSchema.properties);
+  return Object.fromEntries(
+    Object.entries(repositoryCoordinateSamples).filter(([name]) => name in properties),
+  );
+}
+
+function formatRepositoryClassification(directScope, connectionScope) {
+  if (directScope.kind === 'connection') return 'Integration connection.';
+  if (connectionScope.kind !== 'connection' || !connectionScope.requiresExplicitRepository) {
+    return 'Declared targets.';
+  }
+  return 'Declared targets with `owner` and `repo`. Selected mode requires both. Without them, all mode uses the integration connection.';
 }
 
 function unwrapNullableProperty(property) {


### PR DESCRIPTION
## Summary

Document how GitHub App repository selection and Shipfox repository access modes work, with a focused guide for changing both settings.

Derive GitHub tool repository classifications and indirect-target notes from live tool catalog metadata so the generated reference stays aligned with authorization behavior.

## Validation

`mise exec -- turbo check type test --filter=@shipfox/docs... --output-logs=errors-only` passes with 190 of 190 tasks. `mise exec -- git diff --check origin/main...HEAD` also passes.

Closes ENG-1973


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents how GitHub App repository selection and Shipfox repository access modes work, and adds a focused guide for changing both settings. The generated GitHub tool catalog now derives repository classifications and indirect-target notes from live tool metadata so the reference stays aligned with authorization behavior.

**Key changes**
- New guide `manage-github-repository-access.mdx` covers changing the GitHub App installation selection and the Shipfox access mode.
- Clarifies that the GitHub App selection is the hard repository boundary, and `selected` mode is a direct-target guardrail using only project repositories.
- Generation script emits repository classification and indirect-target notes for each GitHub tool, and the check script verifies they match the live catalog.
- Closes ENG-1973.

<sup>Written for commit f32849ef7077827b411ea31e54825c56b5f9cf48. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1736?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

