### PR TITLE
[e2e-flow-workflows] Stabilize readiness under CI contention

### DIFF
--- a/e2e/suites/flow/workflows/playwright.config.ts
+++ b/e2e/suites/flow/workflows/playwright.config.ts
@@ -10,7 +10,8 @@ export default defineConfig({
   globalTeardown: './tests/global-teardown.ts',
   reporter: process.env.CI ? 'github' : 'list',
   fullyParallel: true,
-  workers: 4,
+  // CI shares one API, dispatcher, and Temporal stack with other E2E packages.
+  workers: process.env.CI ? 2 : 4,
   // A scenario waits on real provisioning and execution; its own poll budgets
   // (expect.yaml timeout_seconds, plus the helper defaults) are the real deadlines,
   // so keep the Playwright per-test timeout comfortably above them.

--- a/e2e/suites/flow/workflows/src/listener-helpers.ts
+++ b/e2e/suites/flow/workflows/src/listener-helpers.ts
@@ -16,7 +16,7 @@ import {observeRun} from '@shipfox/e2e-observe-workflows';
 import {waitForRunObservationMatching} from './polling.js';
 import {postWebhookDelivery} from './webhook.js';
 
-const RUNNER_SESSION_ID_PATTERN = /"runnerSessionId":"([^"]+)"/u;
+const RUNNER_SESSION_ID_PATTERN = /"runnerSessionId":"([^"]+)"/gu;
 
 export interface ListenerPredicateResult {
   matched: boolean;
@@ -80,10 +80,11 @@ function runnerReadinessDiagnostic(
   const logTail = localRunnerLogTail(runner.logFile);
   let runnerSessionId = 'not-observed';
   try {
-    runnerSessionId =
-      RUNNER_SESSION_ID_PATTERN.exec(readFileSync(runner.logFile, 'utf8'))?.[1] ?? runnerSessionId;
+    for (const match of readFileSync(runner.logFile, 'utf8').matchAll(RUNNER_SESSION_ID_PATTERN)) {
+      runnerSessionId = match[1] ?? runnerSessionId;
+    }
   } catch {
-    // The timeout still includes process metadata when the runner never created its log.
+    // Keep the original readiness timeout when its best-effort log diagnostic cannot be read.
   }
   return `; runnerPid=${runner.pid}, runnerLabels=[${runner.labels.join(', ')}], runnerSessionId=${runnerSessionId}${logTail}`;
 }

--- a/e2e/suites/flow/workflows/src/listener-helpers.ts
+++ b/e2e/suites/flow/workflows/src/listener-helpers.ts
@@ -1,3 +1,4 @@
+import {readFileSync} from 'node:fs';
 import type {WebhookConnectionDto} from '@shipfox/api-integration-webhook-dto';
 import type {
   JobStatusDto,
@@ -5,6 +6,7 @@ import type {
   ResolutionReasonDto,
 } from '@shipfox/api-workflows-dto';
 import {type createApiClient, pollUntil, requestJson} from '@shipfox/e2e-core';
+import {type LocalRunnerHandle, localRunnerLogTail} from '@shipfox/e2e-driver-runner-process';
 import type {
   WorkflowExecutionObservation,
   WorkflowJobObservation,
@@ -13,6 +15,8 @@ import type {
 import {observeRun} from '@shipfox/e2e-observe-workflows';
 import {waitForRunObservationMatching} from './polling.js';
 import {postWebhookDelivery} from './webhook.js';
+
+const RUNNER_SESSION_ID_PATTERN = /"runnerSessionId":"([^"]+)"/u;
 
 export interface ListenerPredicateResult {
   matched: boolean;
@@ -56,6 +60,32 @@ export function listenerStatusMatches(params: {
     matched: job.listener_status === params.listenerStatus,
     diagnostic: `listener job ${params.jobKey} listenerStatus=${job.listener_status}, expected=${params.listenerStatus}`,
   };
+}
+
+function workflowDispatchState(observation: WorkflowRunObservation): string {
+  const jobs = observation.jobs.map((job) => {
+    const execution = job.default_execution;
+    const executionState = execution
+      ? `executionStatus=${execution.status}, queuedAt=${execution.queued_at}, startedAt=${execution.started_at}`
+      : 'execution=null';
+    return `${job.key}{status=${job.status}, listenerStatus=${job.listener_status}, ${executionState}}`;
+  });
+  return `runStatus=${observation.status}, attemptStatus=${observation.attempt.status}, hasStartedJobExecution=${observation.has_started_job_execution}, jobs=[${jobs.join('; ')}]`;
+}
+
+function runnerReadinessDiagnostic(
+  runner: Pick<LocalRunnerHandle, 'labels' | 'logFile' | 'pid'> | undefined,
+): string {
+  if (runner === undefined) return '';
+  const logTail = localRunnerLogTail(runner.logFile);
+  let runnerSessionId = 'not-observed';
+  try {
+    runnerSessionId =
+      RUNNER_SESSION_ID_PATTERN.exec(readFileSync(runner.logFile, 'utf8'))?.[1] ?? runnerSessionId;
+  } catch {
+    // The timeout still includes process metadata when the runner never created its log.
+  }
+  return `; runnerPid=${runner.pid}, runnerLabels=[${runner.labels.join(', ')}], runnerSessionId=${runnerSessionId}${logTail}`;
 }
 
 export function listenerResolutionMatches(params: {
@@ -225,16 +255,19 @@ export async function waitForListenerStatus(params: {
   jobKey: string;
   listenerStatus: ListenerStatusDto;
   timeoutMs: number;
+  runner?: Pick<LocalRunnerHandle, 'labels' | 'logFile' | 'pid'> | undefined;
 }): Promise<WorkflowRunObservation> {
   const requestSignal = AbortSignal.timeout(params.timeoutMs);
   let diagnostic = `listener job ${params.jobKey} missing`;
+  const transitions: string[] = [];
+  let lastDispatchState: string | undefined;
   return await pollUntil(
     {
       timeoutMs: params.timeoutMs,
       intervalMs: 250,
       maxIntervalMs: 250,
       describe: () =>
-        `listener job ${params.jobKey} status ${params.listenerStatus}: ${diagnostic}`,
+        `listener job ${params.jobKey} status ${params.listenerStatus}: runId=${params.runId}; ${diagnostic}; dispatchTransitions=[${transitions.join(' -> ')}]${runnerReadinessDiagnostic(params.runner)}`,
     },
     async () => {
       const observation = await observeRun({
@@ -243,6 +276,11 @@ export async function waitForListenerStatus(params: {
         signal: requestSignal,
         token: params.token,
       });
+      const dispatchState = workflowDispatchState(observation);
+      if (dispatchState !== lastDispatchState) {
+        transitions.push(dispatchState);
+        lastDispatchState = dispatchState;
+      }
       const status = listenerStatusMatches({...params, observation});
       diagnostic = status.diagnostic;
       if (!status.matched) return null;

--- a/e2e/suites/flow/workflows/src/listener-jobs.ts
+++ b/e2e/suites/flow/workflows/src/listener-jobs.ts
@@ -208,6 +208,7 @@ export async function sendFire(
     jobKey: LISTENER_JOB,
     listenerStatus: 'listening',
     timeoutMs: LISTENER_DELIVERY_TIMEOUT_MS,
+    runner: testCase.runner,
   });
 
   // Retry delivery IDs are distinct listener events and can consume multiple executions.

--- a/e2e/suites/flow/workflows/src/polling.test.ts
+++ b/e2e/suites/flow/workflows/src/polling.test.ts
@@ -1,4 +1,4 @@
-import {waitForRunObservationMatching} from './polling.js';
+import {waitForDefinitionSyncTerminal, waitForRunObservationMatching} from './polling.js';
 
 const runId = '33333333-3333-4333-8333-333333333333';
 const timestamp = '2026-07-04T10:00:00.000Z';
@@ -86,5 +86,21 @@ describe('waitForRunObservationMatching', () => {
       name: 'E2eApiError',
       status: 500,
     });
+  });
+});
+
+describe('waitForDefinitionSyncTerminal', () => {
+  test('reports the project and last response when sync never becomes observable', async () => {
+    const projectId = '11111111-1111-4111-8111-111111111111';
+    const result = waitForDefinitionSyncTerminal({
+      fetch: () => response({definitions: [], sync: null, next_cursor: null}),
+      projectId,
+      timeoutMs: 5,
+      token: 'user-token',
+    });
+
+    await expect(result).rejects.toThrow(
+      `projectId=${projectId}, syncStatus=null, lastResponse={"definitions":[],"sync":null,"next_cursor":null}`,
+    );
   });
 });

--- a/e2e/suites/flow/workflows/src/polling.ts
+++ b/e2e/suites/flow/workflows/src/polling.ts
@@ -81,11 +81,15 @@ export async function waitForDefinitionSyncTerminal(
     const status = lastResponse.sync?.status;
     if (status === 'failed' || status === 'succeeded') return lastResponse;
 
-    await delay(250, undefined, {signal: options.signal});
+    const remainingMs = deadline - Date.now();
+    if (remainingMs <= 0) break;
+    await delay(Math.min(250, remainingMs), undefined, {signal: options.signal});
   }
 
   const status = lastResponse?.sync?.status ?? 'null';
-  throw new Error(`Timed out waiting for definition sync to settle: syncStatus=${status}`);
+  throw new Error(
+    `Timed out waiting for definition sync to settle: projectId=${options.projectId}, syncStatus=${status}, lastResponse=${JSON.stringify(lastResponse)}`,
+  );
 }
 
 export async function waitForNoWorkflowRuns(

--- a/e2e/suites/flow/workflows/tests/github-agent-tools.e2e.ts
+++ b/e2e/suites/flow/workflows/tests/github-agent-tools.e2e.ts
@@ -83,10 +83,11 @@ for (const tokenCase of GITHUB_TOKEN_CASES) {
         sourceDefaultBranch: 'main',
       });
       await activateGithubConnection(suite, connection.id);
-      await waitForDefinitionSyncTerminal({
+      await waitForGithubDefinitionSync({
+        connectionId: connection.id,
+        githubApi,
         projectId: project.id,
-        token: suite.sessionToken,
-        timeoutMs: TERMINAL_TIMEOUT_MS,
+        suite,
       });
       githubApi.calls.length = 0;
       const issueReadTool = `mcp__shipfox_integration_tools__${connection.slug}__issue_read`;
@@ -554,10 +555,11 @@ async function createGithubFixture(suite: SuiteContext, uniqueId: string): Promi
       sourceDefaultBranch: 'main',
     });
     await activateGithubConnection(suite, connection.id);
-    await waitForDefinitionSyncTerminal({
+    await waitForGithubDefinitionSync({
+      connectionId: connection.id,
+      githubApi,
       projectId: project.id,
-      token: suite.sessionToken,
-      timeoutMs: TERMINAL_TIMEOUT_MS,
+      suite,
     });
     githubApi.calls.length = 0;
     return {connection, githubApi, installationId, installationToken, project};
@@ -573,6 +575,28 @@ interface GithubFixture {
   installationId: number;
   installationToken: string;
   project: ProjectResponseDto;
+}
+
+async function waitForGithubDefinitionSync(params: {
+  connectionId: string;
+  githubApi: GithubApiMock;
+  projectId: string;
+  suite: SuiteContext;
+}): Promise<void> {
+  try {
+    await waitForDefinitionSyncTerminal({
+      projectId: params.projectId,
+      token: params.suite.sessionToken,
+      timeoutMs: TERMINAL_TIMEOUT_MS,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    const providerCallKinds = params.githubApi.calls.map((call) => call.kind);
+    throw new Error(
+      `GitHub definition sync readiness failed: connectionId=${params.connectionId}, projectId=${params.projectId}, expectedWorkflowIdPrefix=definition-sync:${params.projectId}:integration:, providerCallKinds=[${providerCallKinds.join(', ')}]; ${message}`,
+      {cause: error},
+    );
+  }
 }
 
 async function activateGithubConnection(suite: SuiteContext, connectionId: string): Promise<void> {

--- a/e2e/suites/flow/workflows/tests/session-continuation.e2e.ts
+++ b/e2e/suites/flow/workflows/tests/session-continuation.e2e.ts
@@ -106,6 +106,7 @@ test('resumes one Pi session across jobs and listening event batches', async ({
       jobKey: LISTENER_JOB,
       listenerStatus: 'listening',
       timeoutMs: SESSION_FLOW_OBSERVATION_TIMEOUT_MS,
+      runner: testCase.runner,
     });
 
     const firstBatch = await sendBatchAndAwaitMaterialization({


### PR DESCRIPTION
## Summary

Reduce Flow suite CI concurrency against the shared API, dispatcher, and Temporal stack while keeping the existing readiness deadlines.

When readiness still expires, surface the identifiers and state needed to distinguish missing definition-sync dispatch from delayed workflow job queueing. Definition failures now include project, connection, workflow-prefix, provider-call, and last-response context. Listener failures include run and attempt state, dispatch transitions, queue timestamps, and runner session and log context.

## Motivation

The failed PR #1720 attempt showed two independent delayed orchestration paths: one integration activation never produced an observable definition sync, while one workflow run did not queue its first job until after teardown despite a registered, polling runner. The identical rerun passed and completed substantially faster, pointing to shared-service contention rather than assertion regressions.

This keeps the 60-second contracts intact instead of masking missing transitions with larger timeouts.

## Validation

- `mise exec -- pnpm turbo test type check depcruise --filter=@shipfox/e2e-flow-workflows`
  - 318/318 Turbo tasks passed
  - 74/74 package tests passed
  - no dependency violations across 325 modules

The live Flow E2E suite is left to hosted CI because this change specifically adjusts its CI concurrency.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduces Flow E2E CI concurrency from 4 to 2 workers against the shared orchestration stack while keeping local runs at 4 and existing readiness deadlines. Readiness timeouts now distinguish delayed definition sync from delayed workflow job queueing.

**Diagnostics**
- Definition sync failures include project, connection, workflow-prefix, provider-call, and last-response context.
- Listener failures include run and attempt state, dispatch transitions, queue timestamps, and the latest runner session, labels, PID, and log tail.
- `waitForGithubDefinitionSync` adds connection and provider-call details to sync polling failures.

<sup>Written for commit b4b45badd36a054768b46c375b265fb0b61f30e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1743?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

