### PR TITLE
[E2E] Stabilize GitHub tool failure assertions

### DIFF
--- a/e2e/observe/logs/src/index.test.ts
+++ b/e2e/observe/logs/src/index.test.ts
@@ -1,4 +1,5 @@
 import type {LogRecord, ReadLogsResponseDto} from '@shipfox/api-logs-dto';
+import {PollTimeoutError} from '@shipfox/e2e-core';
 import {fetchStepLogs, waitForStepLogsContaining} from './index.js';
 
 const stepId = '11111111-1111-4111-8111-111111111111';
@@ -195,7 +196,7 @@ describe('waitForStepLogsContaining', () => {
           Response.json(inline({ndjson: records.map((record) => line(record)).join('')})),
         );
       },
-      pollIntervalMs: 0,
+      pollIntervalMs: 1,
       stepId,
       timeoutMs: 100,
       token: 'user-token',
@@ -203,5 +204,35 @@ describe('waitForStepLogsContaining', () => {
 
     expect(result.records).toEqual([argumentRecord, resultRecord]);
     expect(requests).toBe(2);
+  });
+
+  test('aborts an in-flight log request when the timeout expires', async () => {
+    let requestSignal: AbortSignal | undefined;
+    const result = waitForStepLogsContaining({
+      attempt: 1,
+      expectedText: 'eventual result',
+      fetch: (_url, init) => {
+        const signal = init?.signal;
+        requestSignal = signal ?? undefined;
+        return new Promise<Response>((_resolve, reject) => {
+          if (signal == null) {
+            reject(new Error('Expected the log request to carry a timeout signal'));
+            return;
+          }
+          signal.addEventListener('abort', () => reject(signal.reason), {once: true});
+        });
+      },
+      pollIntervalMs: 1,
+      stepId,
+      timeoutMs: 20,
+      token: 'user-token',
+    });
+
+    await expect(result).rejects.toBeInstanceOf(PollTimeoutError);
+    await expect(result).rejects.toMatchObject({
+      description: `step ${stepId} attempt 1 logs to contain "eventual result"`,
+      timeoutMs: 20,
+    });
+    expect(requestSignal?.aborted).toBe(true);
   });
 });

--- a/e2e/observe/logs/src/index.test.ts
+++ b/e2e/observe/logs/src/index.test.ts
@@ -1,5 +1,5 @@
 import type {LogRecord, ReadLogsResponseDto} from '@shipfox/api-logs-dto';
-import {fetchStepLogs} from './index.js';
+import {fetchStepLogs, waitForStepLogsContaining} from './index.js';
 
 const stepId = '11111111-1111-4111-8111-111111111111';
 
@@ -173,5 +173,35 @@ describe('fetchStepLogs', () => {
     });
 
     await expect(result).rejects.toMatchObject({name: 'AbortError'});
+  });
+});
+
+describe('waitForStepLogsContaining', () => {
+  test('polls past partial logs and stops when the expected output arrives', async () => {
+    const argumentRecord = output('{"query":"is:open"}\n');
+    const resultRecord = output(
+      'Selected repository access requires owner and repo parameters\n',
+      2,
+    );
+    let requests = 0;
+
+    const result = await waitForStepLogsContaining({
+      attempt: 1,
+      expectedText: 'Selected repository access requires owner and repo parameters',
+      fetch: () => {
+        requests += 1;
+        const records = requests === 1 ? [argumentRecord] : [argumentRecord, resultRecord];
+        return Promise.resolve(
+          Response.json(inline({ndjson: records.map((record) => line(record)).join('')})),
+        );
+      },
+      pollIntervalMs: 0,
+      stepId,
+      timeoutMs: 100,
+      token: 'user-token',
+    });
+
+    expect(result.records).toEqual([argumentRecord, resultRecord]);
+    expect(requests).toBe(2);
   });
 });

--- a/e2e/observe/logs/src/index.ts
+++ b/e2e/observe/logs/src/index.ts
@@ -114,20 +114,25 @@ export async function fetchStepLogs(options: FetchStepLogsOptions): Promise<Step
 export async function waitForStepLogsContaining(
   options: WaitForStepLogsContainingOptions,
 ): Promise<StepLogs> {
-  const {expectedText, pollIntervalMs, timeoutMs, ...fetchOptions} = options;
+  const {expectedText, pollIntervalMs, signal, timeoutMs, ...fetchOptions} = options;
+  const intervalMs = pollIntervalMs === undefined ? undefined : Math.max(1, pollIntervalMs);
+  const timeoutSignal = AbortSignal.timeout(timeoutMs);
+  const probeSignal =
+    signal === undefined ? timeoutSignal : AbortSignal.any([signal, timeoutSignal]);
 
   return await pollUntil(
     {
       describe: () =>
         `step ${options.stepId} attempt ${options.attempt} logs to contain ${JSON.stringify(expectedText)}`,
-      ...(pollIntervalMs === undefined ? {} : {intervalMs: pollIntervalMs}),
-      ...(options.signal === undefined ? {} : {signal: options.signal}),
+      ...(intervalMs === undefined ? {} : {intervalMs}),
+      ...(signal === undefined ? {} : {signal}),
       timeoutMs,
     },
     async () => {
       const logs = await fetchStepLogs({
         ...fetchOptions,
         missingStreamRetryTimeoutMs: 0,
+        signal: probeSignal,
       });
       const outputText = logs.records
         .filter(

--- a/e2e/observe/logs/src/index.ts
+++ b/e2e/observe/logs/src/index.ts
@@ -1,5 +1,5 @@
 import {type LogRecord, parseLogRecordLine, type ReadLogsResponseDto} from '@shipfox/api-logs-dto';
-import {type ApiFetch, createApiClient, E2eApiError} from '@shipfox/e2e-core';
+import {type ApiFetch, createApiClient, E2eApiError, pollUntil} from '@shipfox/e2e-core';
 
 const NDJSON_LINE_SPLIT_RE = /\r?\n/u;
 const MISSING_STREAM_RETRY_DELAY_MS = 750;
@@ -20,6 +20,13 @@ export interface StepLogs {
   ndjson: string;
   records: LogRecord[];
   truncated: boolean;
+}
+
+export interface WaitForStepLogsContainingOptions
+  extends Omit<FetchStepLogsOptions, 'missingStreamRetryDelayMs' | 'missingStreamRetryTimeoutMs'> {
+  expectedText: string;
+  pollIntervalMs?: number | undefined;
+  timeoutMs: number;
 }
 
 function parseLogNdjson(ndjson: string): LogRecord[] {
@@ -101,6 +108,36 @@ export async function fetchStepLogs(options: FetchStepLogsOptions): Promise<Step
     records: parseLogNdjson(ndjson),
     truncated,
   };
+}
+
+/** Waits for an output fragment that may be appended after the observed step settles. */
+export async function waitForStepLogsContaining(
+  options: WaitForStepLogsContainingOptions,
+): Promise<StepLogs> {
+  const {expectedText, pollIntervalMs, timeoutMs, ...fetchOptions} = options;
+
+  return await pollUntil(
+    {
+      describe: () =>
+        `step ${options.stepId} attempt ${options.attempt} logs to contain ${JSON.stringify(expectedText)}`,
+      ...(pollIntervalMs === undefined ? {} : {intervalMs: pollIntervalMs}),
+      ...(options.signal === undefined ? {} : {signal: options.signal}),
+      timeoutMs,
+    },
+    async () => {
+      const logs = await fetchStepLogs({
+        ...fetchOptions,
+        missingStreamRetryTimeoutMs: 0,
+      });
+      const outputText = logs.records
+        .filter(
+          (record): record is Extract<LogRecord, {type: 'output'}> => record.type === 'output',
+        )
+        .map((record) => record.data)
+        .join('');
+      return outputText.includes(expectedText) ? logs : null;
+    },
+  );
 }
 
 function isMissingStreamError(error: unknown): boolean {

--- a/e2e/suites/flow/workflows/tests/github-agent-tools.e2e.ts
+++ b/e2e/suites/flow/workflows/tests/github-agent-tools.e2e.ts
@@ -3,6 +3,7 @@ import type {ProjectResponseDto} from '@shipfox/api-projects-dto';
 import {createApiClient} from '@shipfox/e2e-core';
 import {message, startFakeOpenAiModelProvider, toolCall} from '@shipfox/e2e-driver-model-provider';
 import {stopLocalRunner} from '@shipfox/e2e-driver-runner-process';
+import {waitForStepLogsContaining} from '@shipfox/e2e-observe-logs';
 import type {WorkflowRunObservationSelection} from '@shipfox/e2e-observe-workflows';
 import {createAnthropicFakeModelProviderConfig} from '@shipfox/e2e-setup-agent';
 import {createGithubConnection} from '@shipfox/e2e-setup-integrations';
@@ -30,11 +31,16 @@ import {renderWorkflowYaml, seedAndWaitForDefinition} from '#workflow-project.js
 import {expect, test} from './fixtures.js';
 
 const CLAUDE_AGENT_MODEL = 'deterministic-github-tools-agent';
+const FAILURE_LOG_SETTLE_TIMEOUT_MS = 10_000;
 const TERMINAL_TIMEOUT_MS = 60_000;
 const GITHUB_REPOSITORY_ID = 42;
 const GITHUB_REPOSITORY_EXTERNAL_ID = `github:${GITHUB_REPOSITORY_ID}`;
 const GITHUB_OUTSIDE_REPOSITORY_NAME = 'shipfox/outside';
 const BEARER_AUTHORIZATION = /^bearer /iu;
+const REPOSITORY_NOT_AUTHORIZED_MESSAGE =
+  'Repository is not authorized for this integration connection';
+const REPOSITORY_REQUIRED_MESSAGE = 'Selected repository access requires owner and repo parameters';
+const SEARCH_QUALIFIER_MESSAGE = 'Search query cannot contain repo:, org:, or user: qualifiers';
 const GITHUB_TOKEN_CASES = [
   {
     format: 'stateless',
@@ -282,6 +288,7 @@ test('denies a selected GitHub tool target outside Shipfox projects', async ({su
 
   try {
     const result = await runGithubWorkflow({
+      expectedFailureLogText: REPOSITORY_NOT_AUTHORIZED_MESSAGE,
       suite,
       testInfo,
       uniqueId,
@@ -295,9 +302,7 @@ test('denies a selected GitHub tool target outside Shipfox projects', async ({su
 
     expect(result.terminal.status).toBe('failed');
     expect(result.terminal.jobs.find((job) => job.key === 'tools')?.status).toBe('failed');
-    expect(result.failureLogs).toContain(
-      'Repository is not authorized for this integration connection',
-    );
+    expect(result.failureLogs).toContain(REPOSITORY_NOT_AUTHORIZED_MESSAGE);
     expect(result.failureLogs).not.toContain(fixture.installationToken);
     expect(githubAgentToolCalls(fixture.githubApi)).toEqual([]);
   } finally {
@@ -311,6 +316,7 @@ test('requires an explicit repository for selected GitHub search', async ({suite
 
   try {
     const result = await runGithubWorkflow({
+      expectedFailureLogText: REPOSITORY_REQUIRED_MESSAGE,
       suite,
       testInfo,
       uniqueId,
@@ -323,9 +329,7 @@ test('requires an explicit repository for selected GitHub search', async ({suite
     });
 
     expect(result.terminal.status).toBe('failed');
-    expect(result.failureLogs).toContain(
-      'Selected repository access requires owner and repo parameters',
-    );
+    expect(result.failureLogs).toContain(REPOSITORY_REQUIRED_MESSAGE);
     expect(result.failureLogs).not.toContain(fixture.installationToken);
     expect(githubAgentToolCalls(fixture.githubApi)).toEqual([]);
   } finally {
@@ -339,6 +343,7 @@ test('rejects GitHub search qualifiers before provider dispatch', async ({suite}
 
   try {
     const result = await runGithubWorkflow({
+      expectedFailureLogText: SEARCH_QUALIFIER_MESSAGE,
       suite,
       testInfo,
       uniqueId,
@@ -351,9 +356,7 @@ test('rejects GitHub search qualifiers before provider dispatch', async ({suite}
     });
 
     expect(result.terminal.status).toBe('failed');
-    expect(result.failureLogs).toContain(
-      'Search query cannot contain repo:, org:, or user: qualifiers',
-    );
+    expect(result.failureLogs).toContain(SEARCH_QUALIFIER_MESSAGE);
     expect(result.failureLogs).not.toContain(fixture.installationToken);
     expect(githubAgentToolCalls(fixture.githubApi)).toEqual([]);
   } finally {
@@ -593,7 +596,67 @@ async function setRepositoryAccessMode(
   });
 }
 
+async function waitForExpectedFailureLog(params: {
+  expectedText: string | undefined;
+  requests: ReturnType<typeof collectStepLogAttachmentRequests>;
+  scenario: string;
+  token: string;
+}): Promise<void> {
+  if (params.expectedText === undefined) return;
+  if (params.requests.length !== 1) {
+    throw new Error(
+      `Expected one selected step log for ${params.scenario}, received ${params.requests.length}`,
+    );
+  }
+
+  const request = params.requests[0];
+  if (request === undefined) throw new Error('Selected step log request is missing');
+  await waitForStepLogsContaining({
+    attempt: request.attempt,
+    expectedText: params.expectedText,
+    stepId: request.stepId,
+    timeoutMs: FAILURE_LOG_SETTLE_TIMEOUT_MS,
+    token: params.token,
+  });
+}
+
+async function collectGithubFailureLogs(params: {
+  expectedText: string | undefined;
+  scenario: string;
+  terminal: Awaited<ReturnType<typeof waitForRunTerminalOrFailedRunner>>;
+  testInfo: {
+    attach: (name: string, options: {body: Buffer | string; contentType: string}) => Promise<void>;
+  };
+  token: string;
+}): Promise<string> {
+  const requests = collectStepLogAttachmentRequests(params.terminal);
+  let logWaitError: unknown;
+  try {
+    await waitForExpectedFailureLog({
+      expectedText: params.expectedText,
+      requests,
+      scenario: params.scenario,
+      token: params.token,
+    });
+  } catch (error) {
+    logWaitError = error;
+  }
+
+  let failureLogs = '';
+  for (const request of requests) {
+    const attachment = await fetchLogAttachment(request, params.token);
+    failureLogs += `\n${attachment.body}`;
+    await params.testInfo.attach(attachment.name, {
+      body: attachment.body,
+      contentType: attachment.contentType,
+    });
+  }
+  if (logWaitError !== undefined) throw logWaitError;
+  return failureLogs;
+}
+
 async function runGithubWorkflow(params: {
+  expectedFailureLogText?: string | undefined;
   suite: SuiteContext;
   testInfo: {
     attach: (name: string, options: {body: Buffer | string; contentType: string}) => Promise<void>;
@@ -620,7 +683,6 @@ async function runGithubWorkflow(params: {
     extraEnv: {SHIPFOX_POLL_MAX_DURATION_MS: String(TERMINAL_TIMEOUT_MS)},
   });
 
-  let failureLogs = '';
   try {
     const definition =
       params.project === undefined
@@ -663,16 +725,16 @@ async function runGithubWorkflow(params: {
       },
     });
 
-    if (terminal.status !== 'succeeded') {
-      for (const request of collectStepLogAttachmentRequests(terminal)) {
-        const attachment = await fetchLogAttachment(request, token);
-        failureLogs += `\n${attachment.body}`;
-        await params.testInfo.attach(attachment.name, {
-          body: attachment.body,
-          contentType: attachment.contentType,
-        });
-      }
-    }
+    const failureLogs =
+      terminal.status === 'succeeded'
+        ? ''
+        : await collectGithubFailureLogs({
+            expectedText: params.expectedFailureLogText,
+            scenario: params.scenario,
+            terminal,
+            testInfo: params.testInfo,
+            token,
+          });
     return {terminal, failureLogs};
   } finally {
     await attachLocalRunnerLog(


### PR DESCRIPTION
## Summary

GitHub tool failure scenarios could observe a terminal workflow before the server-appended failure record was visible in the step log stream. That made the assertion race the behavior it was meant to verify.

This change adds a reusable log observer that polls for the expected output fragment, uses it only for the three server-generated GitHub failure messages, and still attaches the latest logs on timeout. It does not add Playwright retries, fixed sleeps, or production retry changes.

## Validation

- `mise exec -- turbo check type test --filter=@shipfox/e2e-observe-logs --filter=@shipfox/e2e-flow-workflows` (319 tasks passed; 81 tests passed)
- `mise exec -- turbo depcruise --filter=@shipfox/e2e-observe-logs...`
- `mise exec -- turbo depcruise --filter=@shipfox/e2e-flow-workflows`
- `mise run e2e -- --filter=@shipfox/e2e-flow-workflows -- --grep "requires an explicit repository for selected GitHub search"` (1 passed)
- The targeted scenario also passed 5/5 serial repetitions before the final rebase onto `main`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes flaky E2E assertions on GitHub tool failure scenarios where the terminal workflow could settle before the server-appended failure record appeared in the step log stream, so the assertion raced the behavior it was meant to verify.

- Adds `waitForStepLogsContaining` to `@shipfox/e2e-observe-logs` that polls for an expected output fragment until timeout.
- Uses the poller for the three server-generated GitHub failure messages and still attaches the latest logs when it times out.
- Requires exactly one selected step log request per scenario before polling, so the poll cannot drift across unrelated logs.
- Introduces no Playwright retries, fixed sleeps, or production retry changes.

<sup>Written for commit da3fe8e184cfff91a5d7baeeafe257ff7f2b6bc6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1744?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

