### PR TITLE
[docs] Clarify workflow authoring and integration tools

### DIFF
--- a/apps/docs/WRITING.md
+++ b/apps/docs/WRITING.md
@@ -317,7 +317,7 @@ these provider-specific homes:
 | Shipfox event names, emission conditions, and fields Shipfox normalizes or exposes on `event` | Provider events page (`events.mdx`) | `libs/api/integration/core-dto/src/events.ts`, each provider's `src/core/webhook.ts`, and its webhook DTO schemas. |
 | Raw pass-through webhook payload fields | The provider's upstream webhook reference | The provider owns and versions this schema. Link to it from `events.mdx`; do not reproduce it. |
 | Tool selectors, methods, sensitivity, sensitive status, required provider permissions, scope, inputs, and outputs | Provider tools page (`tools.mdx`) | The provider's `src/core/agent-tools.ts` catalog and its schemas. |
-| Trigger `source`, `event`, `filter`, and `with` fields, plus the agent `integrations:` block | [Workflow schema reference](/reference/workflow-schema) | The workflow schema. Link to it instead of restating the contract. |
+| Trigger `source`, `event`, `filter`, and `with` fields, tool step fields, and the agent `integrations:` block | [Workflow schema reference](/reference/workflow-schema) | The workflow schema. Link to it instead of restating the contract. |
 | Inspecting, pausing, or deleting an integration connection | The matching `how-to/set-up-work/manage-*` guide | The connection lifecycle implementation. |
 
 Shipfox owns the event name, emission condition, and any payload shape it
@@ -358,7 +358,7 @@ triggers:
 | --- | --- |
 | Source control | <Link to the relevant reference.> |
 | Events | [View events](/integrations/<provider>/events). |
-| Agent tools | [View agent tools](/integrations/<provider>/tools). |
+| Tools | [View tools](/integrations/<provider>/tools). |
 
 <If `setup.mdx` exists, link to [Set up this integration](/integrations/<provider>/setup).
 Otherwise, omit this line.>
@@ -469,7 +469,7 @@ the overview and to the workflow schema reference.
 
 ```mdx
 ---
-title: "<Provider> agent tools"
+title: "<Provider> tools"
 sidebarTitle: "Tools"
 description: "<State the provider tools this reference describes.>"
 ---
@@ -478,8 +478,11 @@ description: "<State the provider tools this reference describes.>"
 
 ## Selectors
 
-Use `family`, `family.method`, `family.*`, or a standalone selector. For the
-agent `integrations:` contract, see the [workflow schema reference](/reference/workflow-schema#agent-integration-fields).
+<State which tokens a tool step accepts in `tool` (a standalone id or
+`family.method`) and which selectors an agent step accepts in `integrations:`
+(`family`, `family.method`, `family.*`, or a standalone selector).> For the
+contracts, see [Tool step fields](/reference/workflow-schema#tool-step-fields)
+and [Agent integration fields](/reference/workflow-schema#agent-integration-fields).
 
 ## Tool catalog
 
@@ -520,10 +523,14 @@ tool needs sensitive handling; it is not a separate approval policy.
 4. Write `events.mdx` only when the provider emits Shipfox-named events.
    Otherwise, omit Events from the overview capability table.
 5. Write `tools.mdx` only when `capabilities[]` includes `agent_tools`.
-   Otherwise, omit Agent tools from the overview capability table.
+   Otherwise, omit Tools from the overview capability table.
 6. Add the provider `meta.json`, list only the existing pages in order, and
    register the provider directory in `integrations/meta.json`.
-7. Run the docs checks before review.
+7. Register the provider for generation: add it to
+   `src/lib/registered-integration-providers.ts`, map its DTO catalogs in
+   `scripts/generate.mjs`, add its icon to `src/lib/integration-catalog.ts`
+   and the catalog component, and extend the completeness test fixture.
+8. Run the docs checks before review.
 
 ### Authored and generated reference
 

--- a/apps/docs/content/docs/how-to/author-workflows/add-agent-steps.mdx
+++ b/apps/docs/content/docs/how-to/author-workflows/add-agent-steps.mdx
@@ -1,20 +1,11 @@
 ---
-title: "Add and Test an Agent Step"
+title: "Add an Agent Step"
 sidebarTitle: "Agent Steps"
-description: "Add one agent step that reads project files. Check its result in a manual run."
+description: "Add an agent step that reads project files and summarizes the repository."
 ---
 
 Use this guide to add an agent step to a project. The agent reads the code and
 describes what it finds. It does not change any files.
-
-## Before you begin
-
-You need:
-
-- A project that can sync workflow files.
-- An online runner with the `shipfox` label.
-- [Configured agent
-  defaults](/how-to/set-up-work/configure-model-providers).
 
 ## Add the workflow
 

--- a/apps/docs/content/docs/how-to/author-workflows/bound-listening-job.mdx
+++ b/apps/docs/content/docs/how-to/author-workflows/bound-listening-job.mdx
@@ -12,10 +12,8 @@ missed close event from leaving the run open.
 
 You need:
 
-- A project [connected to GitHub](/integrations/github/setup).
-- Its integration connection slug. This guide uses `github_acme` as a placeholder.
-- An online runner with the `shipfox` label.
-- Configured agent defaults.
+- An integration connection for GitHub and its slug. This guide uses
+  `github_acme` as a placeholder.
 - A test branch that is ready to open as a pull request. Do not open the pull
   request until the workflow has synced.
 

--- a/apps/docs/content/docs/how-to/author-workflows/build-feedback-loop.mdx
+++ b/apps/docs/content/docs/how-to/author-workflows/build-feedback-loop.mdx
@@ -9,9 +9,8 @@ decides whether another attempt is needed.
 
 ## Before you begin
 
-You need a test project that can sync workflows, an online runner with the
-`shipfox` label, configured agent defaults, and an `npm test` command with
-a safe failure that the agent can repair.
+The repository needs a safe failure in its `npm test` command that the agent can
+repair.
 
 ## Add the workflow
 

--- a/apps/docs/content/docs/how-to/author-workflows/call-integration-tool.mdx
+++ b/apps/docs/content/docs/how-to/author-workflows/call-integration-tool.mdx
@@ -1,0 +1,125 @@
+---
+title: "Call an Integration Tool from a Workflow"
+sidebarTitle: "Call a Tool"
+description: "Call one integration operation with values already available in a workflow run."
+---
+
+**Use a tool step when the workflow already knows which integration operation
+to call and which values to send.** Shipfox calls the tool and saves its
+response as step outputs. An agent does not choose the operation.
+
+This guide posts a Slack message. For another tool, replace the tool id, the
+slug of the integration connection, inputs, and output mapping.
+
+## Before you begin
+
+You need:
+
+- An integration connection for a provider with tools. Find a provider in the
+  [integrations catalog](/integrations).
+- The slug of the integration connection. This guide uses `slack_acme`.
+- Values for each required input. Open the provider in the [integrations
+  catalog](/integrations), then select **Tools** to find the input names and
+  descriptions.
+- A Slack channel ID for this example. Invite the Shipfox app to the channel.
+
+## Call the tool
+
+<Steps>
+  <Step>
+
+    **Choose the operation**
+
+    Open the provider's tools page from the [integrations
+    catalog](/integrations). Choose an operation and copy its id. Record its
+    required inputs and whether it reads or writes data.
+
+    This guide uses `send_message` from the [Slack
+    tools](/integrations/slack/tools) page.
+
+  </Step>
+  <Step>
+
+    **Create the workflow**
+
+    Create `.shipfox/workflows/call-a-tool.yml`. Replace the slug of the
+    integration connection, tool id, and inputs. This is a complete workflow:
+
+    ```yaml
+    # yaml-language-server: $schema=https://www.shipfox.io/docs/workflow.schema.json
+    name: Call a tool
+    runner: shipfox
+
+    triggers:
+      manual:
+        source: manual
+
+    jobs:
+      call:
+        steps:
+          - key: call_tool
+            tool: send_message # Replace with an id from the provider's tools page.
+            connection: slack_acme # Replace with the slug of your integration connection.
+            with: # Replace with the tool's inputs.
+              channel_id: C0ABC12345
+              message: "Run #${{ run.number }} of ${{ workflow.name }} started."
+            outputs:
+              ts: ${{ result.ts }} # Replace with a field from the tool result.
+          - env:
+              TOOL_RESULT: ${{ steps.call_tool.outputs.ts }}
+            run: printf 'Tool result field: %s\n' "$TOOL_RESULT"
+    ```
+
+    Adapt these fields:
+
+    | Field | Value |
+    | --- | --- |
+    | `tool` | The id from the provider's tools page. GitHub tools use `family.method`. |
+    | `connection` | The slug of the integration connection. Omit this field only when the tool uses the project's source integration connection. |
+    | `with` | The tool inputs, using the names from the provider's tools page. String values can include `${{ }}` expressions. |
+    | `outputs` | Fields from the tool result that later steps need. The complete response remains available as `steps.<key>.outputs.result`. |
+
+    See [Tool step fields](/reference/workflow-schema#tool-step-fields) for the
+    complete contract.
+  </Step>
+</Steps>
+
+## Verify the result
+
+<Steps>
+  <Step>
+
+    **Start the workflow**
+
+    Select **Run**, then open the new run.
+  </Step>
+  <Step>
+
+    **Inspect the tool call**
+
+    Open the tool step. Confirm that **Arguments** shows the resolved inputs.
+    Confirm that **Result** shows the provider response.
+  </Step>
+  <Step>
+
+    **Inspect the mapped output**
+
+    Open the run step. Confirm that its log contains the mapped result field.
+  </Step>
+  <Step>
+
+    **Check Slack**
+
+    Open the Slack channel. Confirm that the message appears once.
+  </Step>
+</Steps>
+
+## If Shipfox denies the tool call
+
+Check the provider permissions for the integration connection.
+For this example, confirm that the Shipfox app is in the Slack channel.
+Then inspect the integration connection in **Settings → Integrations**.
+
+To pass a tool result to a later step, read it as `steps.<key>.outputs`. To
+let an agent choose operations, [post a pull-request
+review](/how-to/author-workflows/post-pull-request-review).

--- a/apps/docs/content/docs/how-to/author-workflows/choose-runners.mdx
+++ b/apps/docs/content/docs/how-to/author-workflows/choose-runners.mdx
@@ -9,9 +9,9 @@ job needs.
 
 ## Before you begin
 
-You need a project that can sync workflows. Use the [hosted runner
-reference](/reference/runner-labels) for Shipfox Cloud. For a runner you manage,
-you also need access to its process or provisioner template.
+Use the [hosted runner reference](/reference/runner-labels) for Shipfox Cloud.
+For a runner you manage, you also need access to its process or provisioner
+template.
 
 ## Match a workflow to a runner
 

--- a/apps/docs/content/docs/how-to/author-workflows/define-listener-success.mdx
+++ b/apps/docs/content/docs/how-to/author-workflows/define-listener-success.mdx
@@ -16,8 +16,6 @@ You need:
 
 - A [custom webhook](/integrations/webhooks) integration connection and its ingest URL.
 - The integration connection slug. This guide uses `task_hook` as a placeholder.
-- A project that can sync workflow files.
-- An online runner with the `shipfox` label.
 
 ## Add the workflow
 

--- a/apps/docs/content/docs/how-to/author-workflows/group-command-logs.mdx
+++ b/apps/docs/content/docs/how-to/author-workflows/group-command-logs.mdx
@@ -1,23 +1,20 @@
 ---
 title: "Group Long Command Logs"
 sidebarTitle: "Group Command Logs"
-description: "Print log markers around install and test output so the run view renders two collapsible groups."
+description: "Print log markers around command output so the run view renders collapsible groups."
 ---
 
 Use groups when one command step produces a long stream that is hard to scan.
 
-## Before you begin
-
-You need a project that can sync workflows, an online runner with the
-`shipfox` label, and a Node.js repository with a lockfile and tests.
-
 ## Add the workflow
 
-Create `.shipfox/workflows/grouped-checks.yml`. This is a complete workflow:
+Create `.shipfox/workflows/grouped-logs.yml`. This complete workflow groups
+output from two example commands. Replace the commands between the markers with
+your own.
 
 ```yaml
 # yaml-language-server: $schema=https://www.shipfox.io/docs/workflow.schema.json
-name: Run grouped checks
+name: Group command logs
 runner: shipfox
 
 triggers:
@@ -25,35 +22,30 @@ triggers:
     source: manual
 
 jobs:
-  checks:
+  example:
     steps:
       - run: |
-          echo "::group::Install dependencies"
-          if ! npm ci; then
-            echo "::endgroup::"
-            exit 1
-          fi
+          echo "::group::First command"
+          echo "First line"
+          echo "Second line"
           echo "::endgroup::"
 
-          echo "::group::Run tests"
-          if ! npm test; then
-            echo "::endgroup::"
-            exit 1
-          fi
+          echo "::group::Second command"
+          echo "Third line"
+          echo "Fourth line"
           echo "::endgroup::"
 ```
 
-Commit and push the file to the project's default branch. Wait for **Run grouped
-checks** to sync.
+Commit and push the file to the project's default branch. Wait for **Group
+command logs** to sync.
 
 ## Verify the groups
 
 Start the workflow and open the command step.
 
-1. Confirm that **Install dependencies** and **Run tests** appear as separate
+1. Confirm that **First command** and **Second command** appear as separate
    collapsible groups.
 2. Open each group and confirm that it contains only its command's output.
-3. Confirm that the step status still follows the command exit status.
 
 Use [Inspect logs](/how-to/run-and-troubleshoot/inspect-logs) when output is
 missing, delayed, or truncated. Exact group and log limits live in

--- a/apps/docs/content/docs/how-to/author-workflows/index.mdx
+++ b/apps/docs/content/docs/how-to/author-workflows/index.mdx
@@ -4,9 +4,8 @@ sidebarTitle: "Author Workflows"
 description: "Start workflows, run commands and agents, pass results, and check the work."
 ---
 
-Use these guides to change a workflow file and get a clear result. Most tasks
-need a project that can sync workflow files. Each guide also lists the runner,
-provider, integration connection, or repository access it needs.
+Use these guides to change a workflow file and get a clear result. Each guide
+also lists the provider, integration connection, or repository access it needs.
 
 Use the [integrations catalog](/integrations) to find and connect a provider
 when a guide needs one.
@@ -42,6 +41,9 @@ when a guide needs one.
   </Card>
   <Card title="Add an agent step" href="/how-to/author-workflows/add-agent-steps">
     Run work that needs investigation or judgment.
+  </Card>
+  <Card title="Call an integration tool" href="/how-to/author-workflows/call-integration-tool">
+    Call one integration operation with known inputs and no agent.
   </Card>
   <Card title="Read a pull request with an agent" href="/how-to/author-workflows/use-integration-tools">
     Give an agent read-only GitHub context.

--- a/apps/docs/content/docs/how-to/author-workflows/meta.json
+++ b/apps/docs/content/docs/how-to/author-workflows/meta.json
@@ -10,6 +10,7 @@
     "trigger-ready-pull-requests",
     "choose-runners",
     "add-agent-steps",
+    "call-integration-tool",
     "use-integration-tools",
     "post-pull-request-review",
     "push-repository-changes",

--- a/apps/docs/content/docs/how-to/author-workflows/pass-outputs.mdx
+++ b/apps/docs/content/docs/how-to/author-workflows/pass-outputs.mdx
@@ -1,24 +1,17 @@
 ---
-title: "Pass a Computed Version to a Later Job"
-sidebarTitle: "Pass Outputs"
-description: "Publish a version from one job and use it in a later release-preview job."
+title: "Pass Output Between Jobs"
+sidebarTitle: "Pass Output Between Jobs"
+description: "Pass output from one job to another job in the same workflow."
 ---
 
-Use this guide when one job computes a small value that another isolated job
-needs. The workflow derives a version from Git and prints it in a later job.
+Use a job output to pass output between jobs. The first job publishes a step
+output. A dependent job reads it.
 
-## Before you begin
-
-You need a project that can sync workflows and an online runner with the
-`shipfox` label. The repository must contain at least one Git commit.
-
-## Add the workflow
-
-Create `.shipfox/workflows/release-version.yml`. This is a complete workflow:
+## Pass output between jobs
 
 ```yaml
 # yaml-language-server: $schema=https://www.shipfox.io/docs/workflow.schema.json
-name: Preview a release version
+name: Pass output between jobs
 runner: shipfox
 
 triggers:
@@ -26,76 +19,44 @@ triggers:
     source: manual
 
 jobs:
-  package:
+  prepare:
     outputs:
-      version: ${{ steps.read_version.outputs.version }}
+      message: ${{ steps.create_message.outputs.message }}
     steps:
-      - key: read_version
-        run: echo "version=$(git describe --tags --always)" >> "$SHIPFOX_OUTPUT"
+      - key: create_message
+        run: echo "message=Hello from the prepare job" >> "$SHIPFOX_OUTPUT"
         outputs:
-          version: string
+          message: string
 
-  preview:
-    needs: package
+  consume:
+    needs: prepare
     steps:
-      - run: |
-          printf 'Release version: %s\n' "${{ jobs.package.outputs.version }}"
+      - env:
+          MESSAGE: ${{ jobs.prepare.outputs.message }}
+        run: echo "$MESSAGE"
 ```
 
-The `read_version` step declares and writes `version`. The `package` job
-publishes it. The `preview` job declares the dependency, reads the job output,
-and places it in the command.
+The `prepare` job publishes the `message` step output. The `consume` job
+depends on `prepare` and reads the job output.
 
-A job output mapped from one expression preserves an inferred non-string source
-type. This lets a later job read a field from a structured JSON output:
+## Verify the output
 
-```yaml
-# yaml-language-server: $schema=https://www.shipfox.io/docs/workflow.schema.json
-jobs:
-  review:
-    outputs:
-      findings: ${{ steps.inspect.outputs.findings }}
-    steps:
-      - key: inspect
-        run: printf 'findings=%s\n' '[{"severity":"high"}]' >> "$SHIPFOX_OUTPUT"
-        outputs:
-          findings:
-            type: json
-            schema:
-              type: array
-              items:
-                type: object
-                additionalProperties: false
-                required:
-                  - severity
-                properties:
-                  severity:
-                    type: string
+<Steps>
+  <Step>
 
-  summarize:
-    needs: review
-    steps:
-      - run: printf 'Severity: %s\n' "${{ jobs.review.outputs.findings[0].severity }}"
-```
+    **Start the workflow**
 
-Mixed templates such as `Finding: ${{ steps.inspect.outputs.findings }}`
-remain strings. Sources without an inferred type also resolve to strings. See
-[Job outputs](/reference/limits#job-outputs) for size limits.
+    Select **Run**, then open the new run.
+  </Step>
+  <Step>
 
-Commit and push the file to the project's default branch. Wait for **Preview a
-release version** to sync.
+    **Compare the output**
 
-## Verify the value
+    Open `prepare` and confirm that its outputs include `message`. Open
+    `consume` and confirm that its log contains `Hello from the prepare job`.
+  </Step>
+</Steps>
 
-Start the workflow from the **Workflows** tab.
-
-1. Open `package` and confirm that its outputs include `version`.
-2. Open `preview` and confirm that the printed version matches the package
-   output.
-3. Confirm that `preview` ran in a separate job execution and did not rely on
-   files from `package`.
-
-Use [Step outputs](/reference/workflow-schema#step-outputs) for declaration
-types and encoding. Use [structured agent
-outputs](/how-to/author-workflows/use-structured-agent-outputs) when an agent,
-rather than a command, must produce the value.
+See [Step outputs](/reference/workflow-schema#step-outputs) for declaration
+types and encoding. See [Job outputs](/reference/limits#job-outputs) for size
+limits.

--- a/apps/docs/content/docs/how-to/author-workflows/pass-trigger-inputs.mdx
+++ b/apps/docs/content/docs/how-to/author-workflows/pass-trigger-inputs.mdx
@@ -12,8 +12,6 @@ trigger to the full test suite.
 
 You need:
 
-- A project that can sync workflow files.
-- An online runner with the `shipfox` label.
 - A Node.js repository with `test:smoke` and `test` scripts.
 
 ## Add the workflow

--- a/apps/docs/content/docs/how-to/author-workflows/post-pull-request-review.mdx
+++ b/apps/docs/content/docs/how-to/author-workflows/post-pull-request-review.mdx
@@ -12,11 +12,9 @@ review-write family.
 
 You need:
 
-- A project connected to GitHub.
-- Its integration connection slug. This guide uses `github_acme` as a placeholder.
+- The slug of an integration connection for GitHub. This guide uses
+  `github_acme` as a placeholder.
 - A GitHub integration connection that can read and write pull-request reviews.
-- An online runner with the `shipfox` label.
-- Configured agent defaults.
 - A test branch that is ready to open as a pull request. Do not open it until
   the workflow has synced.
 

--- a/apps/docs/content/docs/how-to/author-workflows/push-repository-changes.mdx
+++ b/apps/docs/content/docs/how-to/author-workflows/push-repository-changes.mdx
@@ -12,9 +12,8 @@ any integration tool.
 
 You need:
 
-- A GitHub-backed project whose source integration connection can write repository contents.
-- An online runner with the `shipfox` label.
-- Configured agent defaults.
+- The workflow repository must use an integration connection for GitHub that
+  can write repository contents.
 - A repository with `README.md`.
 - A repository where a temporary `shipfox/docs-*` branch is safe.
 

--- a/apps/docs/content/docs/how-to/author-workflows/run-manually.mdx
+++ b/apps/docs/content/docs/how-to/author-workflows/run-manually.mdx
@@ -7,11 +7,6 @@ description: "Add a manual trigger, start the workflow from the Shipfox dashboar
 A manual trigger adds a **Run** action to a workflow. Use it for on-demand work,
 testing a new workflow, or repeating a task without waiting for an outside event.
 
-## Before you begin
-
-You need a project that can sync workflows and an online runner with the
-`shipfox` label.
-
 ## Add and use a manual trigger
 
 <Steps>

--- a/apps/docs/content/docs/how-to/author-workflows/run-shell-commands.mdx
+++ b/apps/docs/content/docs/how-to/author-workflows/run-shell-commands.mdx
@@ -1,27 +1,18 @@
 ---
-title: "Run Repository Checks on Demand"
-sidebarTitle: "Run Project Checks"
-description: "Add a manual workflow that installs dependencies and runs repository tests."
+title: "Run Shell Commands in a Workflow"
+sidebarTitle: "Run Shell Commands"
+description: "Add a run step that executes shell commands on a runner."
 ---
 
-Use this guide when a repository check should run on demand in a clean Shipfox
-job. The workflow uses fixed shell commands, not an agent.
+**Use a run step to execute a shell command on a runner.** This guide prints a
+message from a manually started workflow. Replace the example with the command
+your workflow needs.
 
-## Before you begin
-
-You need:
-
-- A project that can sync workflows.
-- An online runner with the `shipfox` label.
-- A Node.js repository with a lockfile and an `npm test` command.
-
-## Add the workflow
-
-Create `.shipfox/workflows/project-checks.yml`. This is a complete workflow:
+## Add the commands
 
 ```yaml
 # yaml-language-server: $schema=https://www.shipfox.io/docs/workflow.schema.json
-name: Run project checks
+name: Run shell commands
 runner: shipfox
 
 triggers:
@@ -29,27 +20,35 @@ triggers:
     source: manual
 
 jobs:
-  checks:
+    command:
     steps:
-      - run: npm ci
-      - run: npm test
+      - run: echo "Single-line command"
+      - run: |
+          echo "First line of a multiline command"
+          echo "Second line of a multiline command"
 ```
 
-Commit and push the file to the project's default branch. Wait for **Run project
-checks** to appear in the project's **Workflows** tab.
+## Verify the command
 
-## Verify the checks
+<Steps>
+  <Step>
 
-Select **Run** and open the new run.
+    **Start the workflow**
 
-1. Confirm that `npm ci` finishes successfully.
-2. Open the `npm test` step. Check that its output matches a local test run.
-3. In a test repository, push a safe failing test to the default branch and
-   start another run. Check that the test step fails. Revert the test change
-   afterward.
+    Select **Run**, then open the new run.
+  </Step>
+  <Step>
+
+    **Inspect the output**
+
+    Open both run steps. Confirm that their logs contain the three messages
+    from the example. After adapting the example, confirm that each command
+    produced its expected result.
+  </Step>
+</Steps>
 
 Use [Inspect logs](/how-to/run-and-troubleshoot/inspect-logs) when output is
 missing. See [Run step
-fields](/reference/workflow-schema#run-step-fields) for all fields. See
+fields](/reference/workflow-schema#run-step-fields) for command options. See
 [Environment variables](/reference/workflow-schema#environment-variables) for
 workflow, job, and step order.

--- a/apps/docs/content/docs/how-to/author-workflows/schedule-workflows.mdx
+++ b/apps/docs/content/docs/how-to/author-workflows/schedule-workflows.mdx
@@ -9,8 +9,7 @@ need an integration connection.
 
 ## Before you begin
 
-You need a project that can sync workflows, an online runner with the
-`shipfox` label, and a command or script for the scheduled task.
+You need a command or script for the scheduled task.
 
 ## Add a scheduled trigger
 

--- a/apps/docs/content/docs/how-to/author-workflows/share-agent-sessions.mdx
+++ b/apps/docs/content/docs/how-to/author-workflows/share-agent-sessions.mdx
@@ -13,12 +13,9 @@ run.
 
 You need:
 
-- A project that can sync workflow files.
-- An online runner with the `shipfox` label.
-- [Configured agent defaults](/how-to/set-up-work/configure-model-providers).
-- For the listening example, a project [connected to
-  GitHub](/integrations/github/setup) and the slug of its GitHub
-  integration connection. This guide uses `github_acme` as a placeholder.
+- For the listening example, an [integration connection for
+  GitHub](/integrations/github/setup) and its slug. This guide uses
+  `github_acme` as a placeholder.
 
 ## Continue a plan in a later job
 

--- a/apps/docs/content/docs/how-to/author-workflows/trigger-ready-pull-requests.mdx
+++ b/apps/docs/content/docs/how-to/author-workflows/trigger-ready-pull-requests.mdx
@@ -12,9 +12,8 @@ drafts or other base branches.
 
 You need:
 
-- A project connected to GitHub.
-- The slug of its GitHub integration connection. This guide uses `github_acme` as a placeholder.
-- An online runner with the `shipfox` label.
+- The slug of an integration connection for GitHub. This guide uses
+  `github_acme` as a placeholder.
 - A Node.js repository with a lockfile and an `npm test` command.
 
 Replace `main` below if the repository uses another default branch.

--- a/apps/docs/content/docs/how-to/author-workflows/use-integration-tools.mdx
+++ b/apps/docs/content/docs/how-to/author-workflows/use-integration-tools.mdx
@@ -11,11 +11,9 @@ receives no write operation.
 
 You need:
 
-- A project [connected to GitHub](/integrations/github/setup).
-- Its integration connection slug. This guide uses `github_acme` as a placeholder.
+- The slug of an integration connection for GitHub. This guide uses
+  `github_acme` as a placeholder.
 - A GitHub integration connection that supports agent tools.
-- An online runner with the `shipfox` label.
-- Configured agent defaults.
 - A test branch that is ready to open as a pull request. Do not open it until
   the workflow has synced.
 

--- a/apps/docs/content/docs/how-to/author-workflows/use-structured-agent-outputs.mdx
+++ b/apps/docs/content/docs/how-to/author-workflows/use-structured-agent-outputs.mdx
@@ -8,11 +8,6 @@ Use structured outputs when later workflow logic needs a value from an agent.
 This guide records a summary and a boolean review decision instead of parsing
 the agent's final response.
 
-## Before you begin
-
-You need a project that can sync workflows, an online runner with the
-`shipfox` label, and configured agent defaults.
-
 ## Add the workflow
 
 Create `.shipfox/workflows/classify-release-risk.yml`. This is a complete

--- a/apps/docs/content/docs/how-to/recipes/checks-on-push.mdx
+++ b/apps/docs/content/docs/how-to/recipes/checks-on-push.mdx
@@ -11,10 +11,8 @@ an agent to review the repository only after the test job succeeds.
 
 You need:
 
-- A Shipfox project [connected to GitHub](/integrations/github/setup).
-- The slug of the GitHub integration connection. This recipe uses `github_acme` as a placeholder.
-- An online runner with the `shipfox` label.
-- A configured model provider and workspace agent defaults.
+- The slug of an integration connection for GitHub. This recipe uses
+  `github_acme` as a placeholder.
 - A Node.js repository with a lockfile and an `npm test` command.
 
 ## Add the workflow

--- a/apps/docs/content/docs/how-to/recipes/event-to-verified-pull-request.mdx
+++ b/apps/docs/content/docs/how-to/recipes/event-to-verified-pull-request.mdx
@@ -12,14 +12,11 @@ workflow pushes and opens a pull request only after the tests pass.
 
 You need:
 
-- A Shipfox project connected to the GitHub repository that will receive the
-  branch and pull request.
 - A Sentry integration connection and its slug. This recipe uses `sentry_acme` as a
   placeholder.
-- A GitHub integration connection used as the project source. It must be able
-  to push repository contents and use the `create_pull_request` agent tool.
-- An online runner with the `shipfox` label.
-- A configured model provider and workspace agent defaults.
+- The repository source must use an integration connection for GitHub. That
+  integration connection must be able to push repository contents and use the
+  `create_pull_request` agent tool.
 - A Node.js repository with a lockfile and an `npm test` command.
 - A safe Sentry project and repository where an automated test branch is
   acceptable.

--- a/apps/docs/content/docs/how-to/recipes/parallel-ci-agent-review.mdx
+++ b/apps/docs/content/docs/how-to/recipes/parallel-ci-agent-review.mdx
@@ -11,9 +11,8 @@ should start only after both checks pass.
 
 You need:
 
-- A project [connected to GitHub](/integrations/github/setup). Find its integration connection slug in **Settings → Integrations**.
-- An online runner with the `shipfox` label.
-- A configured model provider and workspace agent defaults.
+- An integration connection for GitHub and its slug. Find the slug in
+  **Settings → Integrations**.
 - A Node.js repository with `lint` and `test` scripts.
 
 ## Add the workflow

--- a/apps/docs/content/docs/how-to/recipes/triage-sentry-issues.mdx
+++ b/apps/docs/content/docs/how-to/recipes/triage-sentry-issues.mdx
@@ -12,11 +12,9 @@ supporting code, and the first check to run.
 
 You need:
 
-- A Shipfox project whose repository contains the affected code.
+- A repository that contains the affected code.
 - A Sentry integration connection in the workspace.
 - The slug of the Sentry integration connection. This recipe uses `sentry_acme` as a placeholder.
-- An online runner with the `shipfox` label.
-- A configured model provider and workspace agent defaults.
 
 ## Add the workflow
 

--- a/apps/docs/content/docs/how-to/run-and-troubleshoot/agent-provider-failures.mdx
+++ b/apps/docs/content/docs/how-to/run-and-troubleshoot/agent-provider-failures.mdx
@@ -10,8 +10,7 @@ Sync, setup, and provider errors need different fixes.
 ## Before you begin
 
 You need the failed run and access to workspace agent settings. A tool failure
-may also require integration settings. A network failure may require runner
-logs.
+may also require integration settings.
 
 ## Check whether the workflow synced
 

--- a/apps/docs/content/docs/how-to/run-and-troubleshoot/inspect-runs-and-attempts.mdx
+++ b/apps/docs/content/docs/how-to/run-and-troubleshoot/inspect-runs-and-attempts.mdx
@@ -10,8 +10,7 @@ next action.
 
 ## Before you begin
 
-You need access to the project and the run ID or trigger that identifies the
-affected work.
+You need the run ID or trigger that identifies the affected work.
 
 ## Select the right run attempt
 

--- a/apps/docs/content/docs/how-to/run-and-troubleshoot/workflow-sync.mdx
+++ b/apps/docs/content/docs/how-to/run-and-troubleshoot/workflow-sync.mdx
@@ -9,7 +9,7 @@ when the project reports **Workflow sync failed**.
 
 ## Before you begin
 
-You need access to the project, its source integration connection, and the repository's
+You need access to the source integration connection and the repository's
 default branch.
 
 ## Inspect the sync result

--- a/apps/docs/content/docs/how-to/set-up-work/add-custom-model-provider.mdx
+++ b/apps/docs/content/docs/how-to/set-up-work/add-custom-model-provider.mdx
@@ -11,8 +11,7 @@ the setup form.
 ## Before you begin
 
 You need access to workspace agent settings, the endpoint base URL, any required
-API key or headers, and the model IDs the endpoint serves. To verify it in a
-workflow, you also need a project and an online runner.
+API key or headers, and the model IDs the endpoint serves.
 
 ## Connect the provider
 

--- a/apps/docs/content/docs/how-to/set-up-work/configure-model-providers.mdx
+++ b/apps/docs/content/docs/how-to/set-up-work/configure-model-providers.mdx
@@ -13,8 +13,6 @@ manual agent run.
 You need:
 
 - The provider's API key. The form asks for any other provider values.
-- A project that can sync workflow files.
-- An online runner with the `shipfox` label.
 
 ## Configure the agent runtime
 

--- a/apps/docs/content/docs/how-to/set-up-work/create-project.mdx
+++ b/apps/docs/content/docs/how-to/set-up-work/create-project.mdx
@@ -74,6 +74,3 @@ Commit the file to the default branch. Push it, then open the project's
 
 A successful sync lists the workflow. If the sync badge reports a failure, use
 [Troubleshoot workflow sync](/how-to/run-and-troubleshoot/workflow-sync).
-
-You only need an online `shipfox` runner to start the workflow. Shipfox
-can find the workflow without a runner.

--- a/apps/docs/content/docs/how-to/set-up-work/delete-integration-connection.mdx
+++ b/apps/docs/content/docs/how-to/set-up-work/delete-integration-connection.mdx
@@ -18,7 +18,7 @@ must continue.
 Before deletion:
 
 1. Search `.shipfox/workflows/` in each project repository for the slug. Check
-   trigger `source` values. Check agent-tool `connection` values too.
+   trigger `source` values. Check tool step and agent `connection` values too.
 2. Open each project's settings. Check whether this is its source integration connection.
 3. Identify active runs whose listening jobs still expect events from it.
 4. Point workflow files and project settings to a replacement where needed.

--- a/apps/docs/content/docs/how-to/set-up-work/delete-model-provider.mdx
+++ b/apps/docs/content/docs/how-to/set-up-work/delete-model-provider.mdx
@@ -10,8 +10,7 @@ also removes its saved keys from the workspace.
 ## Before you begin
 
 You need access to agent settings and a working replacement. It must support the
-harnesses and models used by your workflows. You also need a representative
-project and an online runner.
+harnesses and models used by your workflows.
 
 ## Move every dependency
 

--- a/apps/docs/content/docs/how-to/set-up-work/delete-workspace-value.mdx
+++ b/apps/docs/content/docs/how-to/set-up-work/delete-workspace-value.mdx
@@ -9,8 +9,7 @@ reference can stop run creation or fail a step.
 
 ## Before you begin
 
-You need workspace value-settings access and the exact key to remove. You also
-need the runners required by affected workflows for the final checks.
+You need workspace value-settings access and the exact key to remove.
 
 ## Remove every dependency
 

--- a/apps/docs/content/docs/how-to/set-up-work/index.mdx
+++ b/apps/docs/content/docs/how-to/set-up-work/index.mdx
@@ -4,9 +4,8 @@ sidebarTitle: "Set Up Work"
 description: "Connect other systems, create projects, set up agents, and manage workspace access."
 ---
 
-These guides get a workspace ready to run work. You do not need a runner or
-model provider for every task. Each guide tells you which account and access it
-needs.
+These guides get a workspace ready to run work. You do not need a model provider
+for every task. Each guide tells you which account and access it needs.
 
 ## Connect external systems
 

--- a/apps/docs/content/docs/how-to/set-up-work/manage-integration-connections.mdx
+++ b/apps/docs/content/docs/how-to/set-up-work/manage-integration-connections.mdx
@@ -18,7 +18,8 @@ Open **Settings → Integrations**. Open the integration connection's menu and s
 this integration**.
 
 Copy the slug from the trigger example. Use the full value as a trigger
-`source`. The same value works as an agent-tool `connection`.
+`source`. The same value works as `connection` on a tool step or an agent
+integration entry.
 
 ## Inspect recent events
 

--- a/apps/docs/content/docs/how-to/set-up-work/rotate-model-provider-credentials.mdx
+++ b/apps/docs/content/docs/how-to/set-up-work/rotate-model-provider-credentials.mdx
@@ -9,8 +9,7 @@ before saving it.
 
 ## Before you begin
 
-You need access to agent settings and a new provider key. You also need a test
-project with an online runner.
+You need access to agent settings and a new provider key.
 
 Keep the old key active until the test run succeeds.
 

--- a/apps/docs/content/docs/how-to/set-up-work/secrets-and-variables.mdx
+++ b/apps/docs/content/docs/how-to/set-up-work/secrets-and-variables.mdx
@@ -9,8 +9,7 @@ are available to projects in the workspace.
 
 ## Before you begin
 
-You need access to workspace secret and variable settings. To verify a value in
-a workflow, you also need a project and an online runner.
+You need access to workspace secret and variable settings.
 
 ## Create the values
 

--- a/apps/docs/content/docs/how-to/set-up-work/update-custom-model-provider.mdx
+++ b/apps/docs/content/docs/how-to/set-up-work/update-custom-model-provider.mdx
@@ -11,8 +11,7 @@ not need a rename.
 ## Before you begin
 
 You need workspace agent-settings access and the new endpoint configuration.
-You also need a representative project and an online runner. Keep the old
-endpoint or credential active until verification succeeds.
+Keep the old endpoint or credential active until verification succeeds.
 
 ## Find affected workflows
 

--- a/apps/docs/content/docs/how-to/set-up-work/update-workspace-value.mdx
+++ b/apps/docs/content/docs/how-to/set-up-work/update-workspace-value.mdx
@@ -9,8 +9,7 @@ external credential active until workflows succeed with the new secret.
 
 ## Before you begin
 
-You need workspace value-settings access and the replacement value. You also
-need a representative project and runner for verification.
+You need workspace value-settings access and the replacement value.
 
 ## Find affected workflows
 

--- a/apps/docs/content/docs/integrations/github/index.mdx
+++ b/apps/docs/content/docs/integrations/github/index.mdx
@@ -1,10 +1,10 @@
 ---
 title: "GitHub integration"
 sidebarTitle: "Overview"
-description: "Connect GitHub repositories for project code, event triggers, and agent tools."
+description: "Connect GitHub repositories for project code, event triggers, and workflow tools."
 catalog:
   name: "GitHub"
-  summary: "Connect repositories, receive events, and give agents scoped GitHub tools."
+  summary: "Connect repositories, receive events, and call scoped GitHub tools from workflows."
   capabilities: ["source_control", "events", "agent_tools"]
   categories: ["source-control"]
   aliases: ["git", "vcs", "ci"]
@@ -57,6 +57,6 @@ For trigger field rules, see the [workflow schema reference](/reference/workflow
 | --- | --- |
 | Source control | Use the integration connection when you [create a project](/how-to/set-up-work/create-project). |
 | Events | [View GitHub events](/integrations/github/events). |
-| Agent tools | [View GitHub agent tools](/integrations/github/tools). |
+| Tools | [View GitHub tools](/integrations/github/tools). |
 
 [Connect GitHub](/integrations/github/setup) to create an integration connection.

--- a/apps/docs/content/docs/integrations/github/setup.mdx
+++ b/apps/docs/content/docs/integrations/github/setup.mdx
@@ -5,7 +5,7 @@ description: "Install the GitHub App, limit repository scope, and prove that a p
 ---
 
 Connect GitHub so Shipfox can read a repository and receive events. The same
-integration connection can give selected GitHub tools to an agent. See the
+integration connection lets a workflow call selected GitHub tools. See the
 [GitHub overview](/integrations/github) for its capabilities.
 
 ## Before you begin
@@ -91,5 +91,5 @@ Open the second push event and its linked run. Check the Git ref in the log.
 Check that the job uses the same allowed repository.
 
 The [GitHub events reference](/integrations/github/events) lists the shipped
-event names and payload behavior. The [reference for GitHub agent tools](/integrations/github/tools)
-lists the tools an agent can use.
+event names and payload behavior. The [reference for GitHub
+tools](/integrations/github/tools) lists the tools a workflow can call.

--- a/apps/docs/content/docs/integrations/github/tools.mdx
+++ b/apps/docs/content/docs/integrations/github/tools.mdx
@@ -1,27 +1,33 @@
 ---
-title: "GitHub agent tools"
+title: "GitHub tools"
 sidebarTitle: "Tools"
-description: "Look up the GitHub tools, selectors, permissions, inputs, and outputs available to agent steps."
+description: "Look up the GitHub tools, selectors, permissions, inputs, and outputs available to tool steps and agent steps."
 ---
 
 import GithubTools from '../../../generated/integrations/github/tools.mdx';
 
-This reference lists the shipped GitHub agent-tool catalog. See the [GitHub
+This reference lists the shipped GitHub tool catalog. See the [GitHub
 overview](/integrations/github) for authentication and setup.
 
 ## Selectors
 
-Use a tool family, `family.method`, or `family.*` in an agent step's
-`integrations:` block. For the agent integration contract, see the [workflow
-schema reference](/reference/workflow-schema#agent-integration-fields).
+A tool step names one method as `family.method`, such as `issue_write.update`,
+in its `tool` field. A family name alone or `family.*` is rejected on a tool
+step, because a tool step calls exactly one operation.
+
+An agent step accepts a family, `family.method`, or `family.*` in its
+`integrations:` block. For the field contracts, see [Tool step
+fields](/reference/workflow-schema#tool-step-fields) and [Agent integration
+fields](/reference/workflow-schema#agent-integration-fields).
 
 ## Tool catalog
 
 Grant the GitHub App only the repository permissions required by selected tools.
 The catalog states each tool's read or write sensitivity and its required GitHub
-permissions. Write tools (for example `create_branch` and `merge_pull_request`)
-require the workflow step's `integrations` entry to set `allow_write: true`;
-without it, Shipfox rejects the step at validation.
+permissions. An agent step's `integrations` entry must set `allow_write: true`
+to include a write tool such as `merge_pull_request`, or Shipfox rejects the
+step at validation. A tool step needs no flag: naming the write tool is the
+choice.
 
 The generated catalog also states each operation's repository classification:
 

--- a/apps/docs/content/docs/integrations/jira/index.mdx
+++ b/apps/docs/content/docs/integrations/jira/index.mdx
@@ -1,10 +1,10 @@
 ---
 title: "Jira integration"
 sidebarTitle: "Overview"
-description: "Connect Jira Cloud to trigger workflows from issue and comment events, and give agents Jira tools."
+description: "Connect Jira Cloud to trigger workflows from issue and comment events, and call Jira tools from workflows."
 catalog:
   name: "Jira"
-  summary: "Connect a Jira site, receive issue events, and give agents scoped Jira tools."
+  summary: "Connect a Jira site, receive issue events, and call scoped Jira tools from workflows."
   capabilities: ["events", "agent_tools"]
   categories: ["issue-tracking"]
   aliases: ["issues", "tickets"]
@@ -40,6 +40,6 @@ For trigger field rules, see the [workflow schema reference](/reference/workflow
 | Capability | Details |
 | --- | --- |
 | Events | [View Jira events](/integrations/jira/events). |
-| Agent tools | [View Jira agent tools](/integrations/jira/tools). |
+| Tools | [View Jira tools](/integrations/jira/tools). |
 
 [Connect Jira](/integrations/jira/setup) to create an integration connection.

--- a/apps/docs/content/docs/integrations/jira/setup.mdx
+++ b/apps/docs/content/docs/integrations/jira/setup.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Connect Jira to a Shipfox workspace"
 sidebarTitle: "Setup"
-description: "Authorize a Jira site, copy the integration connection slug, and verify event and agent-tool access."
+description: "Authorize a Jira site, copy the integration connection slug, and verify event and tool access."
 ---
 
 Connect Jira when a workflow needs Jira events or an agent step needs Jira
@@ -38,7 +38,7 @@ the workspace should use.
 
     Open the new integration connection's menu. Select **Use this integration**.
     Copy the slug from the event or tool-selection example. Workflows use the
-    slug as `source`, and agent steps use it as `connection`.
+    slug as `source`. Tool steps and agent steps use it as `connection`.
   </Step>
 </Steps>
 

--- a/apps/docs/content/docs/integrations/jira/tools.mdx
+++ b/apps/docs/content/docs/integrations/jira/tools.mdx
@@ -1,23 +1,28 @@
 ---
-title: "Jira agent tools"
+title: "Jira tools"
 sidebarTitle: "Tools"
-description: "Look up the Jira tools, selectors, permissions, inputs, and outputs available to agent steps."
+description: "Look up the Jira tools, selectors, permissions, inputs, and outputs available to tool steps and agent steps."
 ---
 
 import JiraTools from '../../../generated/integrations/jira/tools.mdx';
 
-This reference lists the shipped Jira agent-tool catalog. See the [Jira
+This reference lists the shipped Jira tool catalog. See the [Jira
 overview](/integrations/jira) for authentication and setup.
 
 ## Selectors
 
-Use a standalone tool selector in an agent step's `integrations:` block. For the
-agent integration contract, see the [workflow schema reference](/reference/workflow-schema#agent-integration-fields).
+A tool step names one standalone tool id in its `tool` field. An agent step
+lists standalone selectors in its `integrations:` block. For the field
+contracts, see [Tool step fields](/reference/workflow-schema#tool-step-fields)
+and [Agent integration fields](/reference/workflow-schema#agent-integration-fields).
 
 ## Tool catalog
 
 Jira read tools require the `read:jira-work` OAuth scope. Jira write tools
-require `write:jira-work`, and the workflow step's `integrations` entry must set
-`allow_write: true` or Shipfox rejects the step at validation.
+require `write:jira-work`.
+
+An agent step's `integrations` entry must set `allow_write: true` to include a
+write tool, or Shipfox rejects the step at validation. A tool step needs no
+flag: naming the write tool is the choice.
 
 <JiraTools />

--- a/apps/docs/content/docs/integrations/linear/index.mdx
+++ b/apps/docs/content/docs/integrations/linear/index.mdx
@@ -1,10 +1,10 @@
 ---
 title: "Linear integration"
 sidebarTitle: "Overview"
-description: "Connect Linear to trigger workflows from workspace events and give agents Linear tools."
+description: "Connect Linear to trigger workflows from workspace events and call Linear tools from workflows."
 catalog:
   name: "Linear"
-  summary: "Connect a Linear workspace, receive events, and give agents scoped Linear tools."
+  summary: "Connect a Linear workspace, receive events, and call scoped Linear tools from workflows."
   capabilities: ["events", "agent_tools"]
   categories: ["issue-tracking"]
   aliases: ["issues", "tickets"]
@@ -41,6 +41,6 @@ For trigger and agent integration fields, see the
 | Capability | Details |
 | --- | --- |
 | Events | [View Linear events](/integrations/linear/events). |
-| Agent tools | [View Linear agent tools](/integrations/linear/tools). |
+| Tools | [View Linear tools](/integrations/linear/tools). |
 
 [Connect Linear](/integrations/linear/setup) to create an integration connection.

--- a/apps/docs/content/docs/integrations/linear/setup.mdx
+++ b/apps/docs/content/docs/integrations/linear/setup.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Connect Linear to a Shipfox workspace"
 sidebarTitle: "Setup"
-description: "Authorize a Linear workspace, copy the integration connection slug, and use Linear events or agent tools."
+description: "Authorize a Linear workspace, copy the integration connection slug, and use Linear events or tools."
 ---
 
 Connect Linear to trigger workflows from workspace events or let agents read and
@@ -28,15 +28,15 @@ authorize an OAuth app in the target Linear workspace.
     **Authorize the workspace**
 
     Select the target Linear workspace and authorize the Shipfox app. Grant the
-    requested access so Shipfox can receive Linear events and use agent tools.
+    requested access so Shipfox can receive Linear events and call Linear tools.
   </Step>
   <Step>
 
     **Record the integration connection slug**
 
     Open the new integration connection's menu. Select **Use this integration**.
-    Copy the slug. Triggers use that value as `source`. Agent steps use it as
-    `connection`.
+    Copy the slug. Triggers use that value as `source`. Tool steps and agent
+    steps use it as `connection`.
   </Step>
 </Steps>
 
@@ -44,4 +44,4 @@ authorize an OAuth app in the target Linear workspace.
 
 Open **Settings → Integrations** and check that the Linear integration connection
 is active. Use the saved slug with a [Linear event](/integrations/linear/events)
-or a selector from the [Linear agent-tool reference](/integrations/linear/tools).
+or a tool from the [Linear tool reference](/integrations/linear/tools).

--- a/apps/docs/content/docs/integrations/linear/tools.mdx
+++ b/apps/docs/content/docs/integrations/linear/tools.mdx
@@ -1,23 +1,29 @@
 ---
-title: "Linear agent tools"
+title: "Linear tools"
 sidebarTitle: "Tools"
-description: "Look up the Linear tools, selectors, permissions, inputs, and outputs available to agent steps."
+description: "Look up the Linear tools, selectors, permissions, inputs, and outputs available to tool steps and agent steps."
 ---
 
 import LinearTools from '../../../generated/integrations/linear/tools.mdx';
 
-This reference lists the shipped Linear agent-tool catalog. See the [Linear
+This reference lists the shipped Linear tool catalog. See the [Linear
 overview](/integrations/linear) for authentication and setup.
 
 ## Selectors
 
-Use a standalone tool selector in an agent step's `integrations:` block. For the
-agent integration contract, see the [workflow schema reference](/reference/workflow-schema#agent-integration-fields).
+A tool step names one standalone tool id, such as `get_issue`, in its `tool`
+field. An agent step lists standalone selectors in its `integrations:` block.
+For the field contracts, see [Tool step
+fields](/reference/workflow-schema#tool-step-fields) and [Agent integration
+fields](/reference/workflow-schema#agent-integration-fields).
 
 ## Tool catalog
 
 The catalog uses Linear's OAuth scopes. Read tools require `read` access. Write
-tools require `write` access, and the workflow step's `integrations` entry must
-set `allow_write: true` or Shipfox rejects the step at validation.
+tools require `write` access.
+
+An agent step's `integrations` entry must set `allow_write: true` to include a
+write tool, or Shipfox rejects the step at validation. A tool step needs no
+flag: naming the write tool is the choice.
 
 <LinearTools />

--- a/apps/docs/content/docs/integrations/slack/index.mdx
+++ b/apps/docs/content/docs/integrations/slack/index.mdx
@@ -1,10 +1,10 @@
 ---
 title: "Slack integration"
 sidebarTitle: "Overview"
-description: "Connect Slack to trigger workflows from messages, reactions, mentions, or slash commands, and give agents Slack tools."
+description: "Connect Slack to trigger workflows from messages, reactions, mentions, or slash commands, and call Slack tools from workflows."
 catalog:
   name: "Slack"
-  summary: "Connect a Slack workspace, receive events, and give agents scoped Slack tools."
+  summary: "Connect a Slack workspace, receive events, and call scoped Slack tools from workflows."
   capabilities: ["events", "agent_tools"]
   categories: ["messaging"]
   aliases: ["chatops", "notifications"]
@@ -45,7 +45,7 @@ triggers:
     event: app_mention
 ```
 
-For trigger and agent integration fields, see the
+For trigger, tool step, and agent integration fields, see the
 [workflow schema reference](/reference/workflow-schema).
 
 ## Capabilities
@@ -53,6 +53,6 @@ For trigger and agent integration fields, see the
 | Capability | Details |
 | --- | --- |
 | Events | [View Slack events](/integrations/slack/events). |
-| Agent tools | [View Slack agent tools](/integrations/slack/tools). |
+| Tools | [View Slack tools](/integrations/slack/tools). |
 
 [Connect Slack](/integrations/slack/setup) to create an integration connection.

--- a/apps/docs/content/docs/integrations/slack/setup.mdx
+++ b/apps/docs/content/docs/integrations/slack/setup.mdx
@@ -1,11 +1,11 @@
 ---
 title: "Connect Slack to a Shipfox workspace"
 sidebarTitle: "Setup"
-description: "Install the Shipfox Slack app, copy the integration connection slug, and use Slack events or agent tools."
+description: "Install the Shipfox Slack app, copy the integration connection slug, and use Slack events or tools."
 ---
 
-Connect Slack to trigger workflows from workspace events or let agents read and
-update Slack. See the [Slack overview](/integrations/slack) for its capabilities.
+Connect Slack to trigger workflows from workspace events or let workflows read
+and update Slack. See the [Slack overview](/integrations/slack) for its capabilities.
 
 ## Before you begin
 
@@ -27,15 +27,15 @@ install and approve an app in the target Slack workspace.
     **Approve the app**
 
     Select the target Slack workspace and install the Shipfox app. Approve the
-    requested bot scopes so Shipfox can receive Slack events and use agent tools.
+    requested bot scopes so Shipfox can receive Slack events and call Slack tools.
   </Step>
   <Step>
 
     **Record the integration connection slug**
 
     Open the new integration connection's menu. Select **Use this integration**.
-    Copy the slug. Triggers use that value as `source`. Agent steps use it as
-    `connection`.
+    Copy the slug. Triggers use that value as `source`. Tool steps and agent
+    steps use it as `connection`.
   </Step>
 </Steps>
 
@@ -43,4 +43,4 @@ install and approve an app in the target Slack workspace.
 
 Open **Settings → Integrations** and check that the Slack integration connection
 is active. Use the saved slug with a [Slack event](/integrations/slack/events) or
-a selector from the [Slack agent-tool reference](/integrations/slack/tools).
+a tool from the [Slack tool reference](/integrations/slack/tools).

--- a/apps/docs/content/docs/integrations/slack/tools.mdx
+++ b/apps/docs/content/docs/integrations/slack/tools.mdx
@@ -1,24 +1,29 @@
 ---
-title: "Slack agent tools"
+title: "Slack tools"
 sidebarTitle: "Tools"
-description: "Look up the Slack tools, selectors, permissions, inputs, and outputs available to agent steps."
+description: "Look up the Slack tools, selectors, permissions, inputs, and outputs available to tool steps and agent steps."
 ---
 
 import SlackTools from '../../../generated/integrations/slack/tools.mdx';
 
-This reference lists the shipped Slack agent-tool catalog. See the [Slack
+This reference lists the shipped Slack tool catalog. See the [Slack
 overview](/integrations/slack) for authentication and setup.
 
 ## Selectors
 
-Use a standalone tool selector in an agent step's `integrations:` block. For the
-agent integration contract, see the [workflow schema reference](/reference/workflow-schema#agent-integration-fields).
+A tool step names one standalone tool id, such as `send_message`, in its `tool`
+field. An agent step lists standalone selectors in its `integrations:` block.
+For the field contracts, see [Tool step
+fields](/reference/workflow-schema#tool-step-fields) and [Agent integration
+fields](/reference/workflow-schema#agent-integration-fields).
 
 ## Tool catalog
 
 The catalog uses the Slack bot scopes required by each tool. Read tools inspect
-workspace data. Write tools change messages, reactions, or canvases, and the
-workflow step's `integrations` entry must set `allow_write: true` or Shipfox
-rejects the step at validation.
+workspace data. Write tools change messages, reactions, or canvases.
+
+An agent step's `integrations` entry must set `allow_write: true` to include a
+write tool, or Shipfox rejects the step at validation. A tool step needs no
+flag: naming the write tool is the choice.
 
 <SlackTools />

--- a/apps/docs/content/docs/reference/contexts.mdx
+++ b/apps/docs/content/docs/reference/contexts.mdx
@@ -27,6 +27,12 @@ reads `step` and `vars`.
 A field cannot read the value it sets. For example, `run_name` cannot read
 `run.name`.
 
+The `result` context exists only while a tool step maps its outputs, after the
+provider returns. The `outputs` mapping of a tool step reads `result` and
+`vars`. Every other field reads the stored value as
+`steps.<step_key>.outputs.result`. See [Tool step
+fields](/reference/workflow-schema#tool-step-fields).
+
 Reading a context the table does not list for the field fails the sync, with an
 error that names the context. The workflow never runs with an empty value in its
 place. See [Correct a context that is not

--- a/apps/docs/content/docs/reference/glossary.mdx
+++ b/apps/docs/content/docs/reference/glossary.mdx
@@ -54,7 +54,7 @@ A group of steps that runs on a single runner. Jobs within a workflow run in par
 
 ## Step key
 
-A stable identifier on a step, set with the `key` field. Unlike `name` (a display label), `key` is what other parts of the workflow reference: `gate.on_failure.restart_from` restarts a job from the step carrying that key, and `steps.<key>.outputs` reads its outputs. Must be at least one character. Valid on both run steps and agent steps.
+A stable identifier on a step, set with the `key` field. Unlike `name` (a display label), `key` is what other parts of the workflow reference: `gate.on_failure.restart_from` restarts a job from the step carrying that key, and `steps.<key>.outputs` reads its outputs. Must be at least one character. Valid on run steps, agent steps, and tool steps.
 
 ## Listening job
 
@@ -93,7 +93,7 @@ The record created when a workflow starts for one event or manual action. A run 
 
 ## Runner
 
-A process you deploy on your own infrastructure that polls Shipfox for jobs. Jobs are dispatched to runners whose labels match the job's `runner:` field. Runners execute both run steps and agent steps. Multiple runners can be registered in a workspace. See [Runners and execution environments](/understand/runners-and-execution-environments).
+A process you deploy on your own infrastructure that polls Shipfox for jobs. Jobs are dispatched to runners whose labels match the job's `runner:` field. Runners execute run steps and agent steps; the Shipfox API executes tool steps while the runner waits. Multiple runners can be registered in a workspace. See [Runners and execution environments](/understand/runners-and-execution-environments).
 
 ## Run step
 
@@ -108,7 +108,16 @@ predicates. See [Secrets and variables](/reference/secrets-variables).
 
 ## Workflow step
 
-The smallest unit of work in a Shipfox workflow. A step is either a run step (executes a shell command) or an agent step (invokes an AI model). Steps within a job run sequentially. Each step can optionally carry a `gate` block for success evaluation and failure recovery.
+The smallest unit of work in a Shipfox workflow. A step is a run step (executes a shell command), an agent step (invokes an AI model), or a tool step (calls one integration tool). Steps within a job run sequentially. Each step can optionally carry a `gate` block for success evaluation and failure recovery.
+
+## Tool step
+
+A workflow step that calls one integration tool with inputs the workflow
+supplies. Defined with `tool` (required), plus optional `connection`, `with`,
+and an `outputs` mapping over `result`. Shipfox makes the call on its API
+through the integration connection, so the runner never sees the credential or
+the arguments. See [Tool step
+fields](/reference/workflow-schema#tool-step-fields).
 
 ## Thinking level
 

--- a/apps/docs/content/docs/reference/workflow-schema.mdx
+++ b/apps/docs/content/docs/reference/workflow-schema.mdx
@@ -197,32 +197,55 @@ shell reads it as text and not as part of the command.
 
 ### Tool step fields
 
+A tool step calls one integration tool with inputs from the workflow. Shipfox
+makes the call on its API through the integration connection. The step has no
+working tree, so `run`, `prompt`, `checkout`, `env`, and `working_directory`
+are rejected on it.
+
 <ToolStepFields />
 
 The `tool` value is a literal integration tool id. A tool id can name a
-standalone tool or one method in a tool family with `family.method`. The
-optional `connection` value is the slug of an integration connection. Omit it
-to use the project's source connection.
+standalone tool or one method in a tool family with `family.method`. A family
+name alone or `family.*` is rejected. Each provider's tools page lists the ids;
+see the [GitHub tools](/integrations/github/tools) page for family methods.
+
+The optional `connection` value is the slug of an integration connection. Omit
+it to use the source integration connection of the project. A tool from
+another provider needs an explicit `connection`.
 
 The `with` block contains JSON-compatible tool inputs. String values can use
-workflow expressions. Tool outputs use a mapping from output names to one
-expression over `result` or `vars`.
+workflow expressions over every server-evaluated context listed for
+`jobs.<job_id>.steps[*].with` in [Context
+availability](/reference/contexts#context-availability). `secrets` and
+`runner` are rejected. A leaf that is exactly one expression keeps the
+expression's type. Sync checks required inputs and literal values against the
+tool's input schema.
+
+A write tool needs no `allow_write` flag on a tool step. Naming the tool is the
+choice. Tool outputs use a mapping from output names to one expression over
+`result` or `vars`.
 
 Mappings are checked against the provider catalog's `outputSchema`. A closed
 object whose properties are all required keeps typed field access. Open objects,
-optional properties, and unknown schema shapes resolve to `map` or `dyn`, so a
-mapped value is declared as schema-less JSON and can retain a number, boolean,
-object, or list at runtime. A tool without an `outputSchema` keeps its reserved
-`result` root open.
+optional properties, and unknown schema shapes resolve to `map` or `dyn`. A
+mapped value from such a shape is declared as schema-less JSON. It can retain a
+number, boolean, object, or list at runtime. A tool without an `outputSchema`
+keeps its reserved `result` root open.
 
 Tool-step authoring requires a validation API deployment that supports these
-fields. Deploy the editor schema and validation API together; rolling back the
+fields. Deploy the editor schema and validation API together. Rolling back the
 validation API after tool-step definitions are saved makes those definitions
-fail validation until tool-step support is restored.
+fail validation until support is restored.
 
 ### Tool step outputs
 
 <ToolStepOutputs />
+
+Every tool step exposes `result`, the provider response, as a `json` output.
+Later steps read it as `steps.<key>.outputs.result`. A gate on a tool step
+reads `step.status` and `step.outputs`; `step.exit_code` does not exist on a
+tool step. See [Call an integration
+tool](/how-to/author-workflows/call-integration-tool) for a complete example.
 
 ### Checkout step fields
 

--- a/apps/docs/content/docs/understand/agents.mdx
+++ b/apps/docs/content/docs/understand/agents.mdx
@@ -12,21 +12,23 @@ The workflow still sets the limits. It chooses the prompt, the harness, the
 model, the tools, the repository access, and the check that follows. The agent
 chooses how to work inside those limits.
 
-A run step follows a known command. An agent step chooses its path from what it
-finds.
+A run step follows a known command. A tool step makes one known integration
+call. An agent step chooses its path from what it finds.
 
 ## When to use an agent step
 
-The two step types make different tradeoffs.
+The three step kinds make different tradeoffs.
 
 | Step | Fits | Tradeoff |
 | --- | --- | --- |
 | Run step | A known command with a repeatable procedure. | Predictable, fast, and easy to compare. |
+| Tool step | One known integration operation with known inputs. | Deterministic and free of model cost, but limited to one call. |
 | Agent step | A goal that needs investigation or judgment. | Flexible, but slower, more costly, and less predictable. |
 
 Use the most predictable step that can finish the work. Tests, builds,
-formatting tools, and deploy scripts belong in run steps. Root-cause analysis,
-code review, and open-ended edits often need an agent.
+formatting tools, and deploy scripts belong in run steps. Posting a message or
+reading a ticket with known values belongs in a tool step. Root-cause
+analysis, code review, and open-ended edits often need an agent.
 
 A long or complex command is still a command. Use an agent only when the
 workflow can't choose the path before it reads the code or the event.
@@ -85,8 +87,9 @@ write after an objective check.
 
 Repository permission applies to the whole job, because every step uses the
 same checkout. Integration tools apply to one step. When a workflow needs local
-edits and one external write, put the write tool on the final agent step, not
-on the step that edits.
+edits and one external write, put the write on a later step, not on the step
+that edits. A tool step fits when the workflow knows the exact call. An agent
+step with a write tool fits when the agent must decide what to write.
 
 [Agent access](/how-to/author-workflows/use-integration-tools) shows the setup
 task. [Integrations, integration connections, and

--- a/apps/docs/content/docs/understand/data-and-templating.mdx
+++ b/apps/docs/content/docs/understand/data-and-templating.mdx
@@ -23,6 +23,10 @@ Context is a flow, not one global object. Data joins it at five points:
 5. **Runner execution** resolves secret bindings for the command that needs
    them. The secret value never enters the run plan.
 
+A tool step adds one short-lived value. Its provider response is readable as
+`result` only while that step maps its outputs, right after the call returns.
+Later steps read the stored value as `steps.<key>.outputs.result`.
+
 Workspace variables and project settings hold long-lived configuration. Events
 and outputs describe this run. Secrets grant access and follow a stricter path.
 

--- a/apps/docs/content/docs/understand/integrations-connections-and-tools.mdx
+++ b/apps/docs/content/docs/understand/integrations-connections-and-tools.mdx
@@ -12,7 +12,7 @@ A workspace can connect the same provider more than once. Each
 integration connection has its own events, its own reach, and its own saved
 credential.
 
-An integration connection can bring events in, give an agent tools to act
+An integration connection can bring events in, give a workflow tools to act
 outside the run, and provide checkout access to code. None of these grants
 another one by itself. Name the account, the tool, and the repository, and add
 write access only when the task needs it. The workflow then shows both the
@@ -29,11 +29,11 @@ account and the allowed action.
 | Event source | The integration connection that sent an event. |
 | Project source | The integration connection and repository used for workflow files and checkout. |
 | Native agent tool | A harness action inside the runner, such as reading or editing files. |
-| Integration tool | An external action that an agent performs through an integration connection. |
+| Integration tool | An external operation that a tool step or an agent performs through an integration connection. |
 
 Each term answers a different question. The provider is the external system.
 The integration connection is the account. The project source is the
-repository that owns the work. A tool is one operation that the agent can
+repository that owns the work. A tool is one operation that a step can
 perform.
 
 ## An integration connection can receive events, provide tools, or both
@@ -42,8 +42,8 @@ An integration connection can play one or both roles.
 
 - **Event source:** the provider delivers events that triggers or listening
   jobs can match.
-- **Tool provider:** an agent receives selected operations to read or change
-  data in that system.
+- **Tool provider:** a tool step calls one operation, or an agent receives
+  selected operations, to read or change data in that system.
 
 An event grants no tool. A read tool grants no write tool. The workflow makes
 each choice separately.
@@ -53,14 +53,35 @@ example, a Sentry issue can start an agent that reads only the project
 checkout. A later, checked step can then receive one narrow GitHub operation to
 open a pull request.
 
+## A tool step and an agent step use the same tools
+
+A **tool step** names one tool and its inputs in the workflow. Shipfox makes
+the call on its API and stores the response as step outputs. No model chooses
+the call, so the same run data always produces the same call.
+
+An **agent step** receives a selection of tools. The agent decides when to call
+them and with which values. That freedom fits work that needs judgment. It
+costs a model turn and makes the exact calls less predictable.
+
+Both paths use the same tool catalog, the same integration connection checks,
+and the same audit record. Use a tool step when the workflow already knows the
+operation and its values. Use an agent step with tools when the agent must
+decide.
+
+The two paths treat writes differently. An agent step must set `allow_write`
+to receive a write tool, because the model chooses the calls. A tool step needs
+no flag, because naming the write tool is the choice. The run view marks the
+step as a write either way.
+
 ## A slug names one integration connection
 
-Triggers and agent tools use the slug of an integration connection. The slug
-names one integration connection in the workspace, not a kind of provider.
+Triggers, tool steps, and agent tools use the slug of an
+integration connection. The slug names one integration connection in the
+workspace, not a kind of provider.
 
 Two GitHub integration connections can send the same event name. Their slugs
-keep those events apart. The same rule stops an agent tool from switching to
-another account without notice.
+keep those events apart. The same rule stops a tool from switching to another
+account without notice.
 
 The [workflow schema reference](/reference/workflow-schema#trigger-fields)
 defines the exact trigger contract. [Set up work](/how-to/set-up-work) explains
@@ -100,8 +121,8 @@ indirect target.
 ## The workflow never receives the credential
 
 The workflow names an integration connection and the selected operations. It
-doesn't receive the saved provider credential. The agent gets a tool interface,
-and Shipfox makes the authorized calls behind it.
+doesn't receive the saved provider credential. A tool step or an agent gets a
+tool interface, and Shipfox makes the authorized calls behind it.
 
 This limits both disclosure and use.
 
@@ -110,15 +131,16 @@ This limits both disclosure and use.
 - Repository scope limits where the operation can act.
 - Read and write access stay explicit in the workflow.
 
-The boundary doesn't make every tool call safe. An agent can still choose a bad
-value or act on misleading event data. Use the smallest tool selection, put
+The boundary doesn't make every tool call safe. A tool step can carry a bad
+value from the event, and an agent can act on misleading event data. Use the smallest tool selection, put
 writes after checks, and read back important external results.
 
 ## Give each step only the access it needs
 
-Start with no integration tool. Add a read operation when the agent needs
+Start with no integration tool. Add a read operation when a step needs
 external context. Add a write operation only when the workflow intends an
-external change.
+external change. Prefer a tool step for a write with known values, so the
+workflow states the exact call.
 
 Keep the repository boundary as narrow as the work. For GitHub, use `selected`
 mode and a narrow App installation when the task concerns one repository.
@@ -127,8 +149,11 @@ A general credential supports many operations but hides the real reach of the
 step. A small tool selection makes that reach visible in the workflow and at
 sync time.
 
-Use [Agent access](/how-to/author-workflows/use-integration-tools) for the
-authoring task. The reference for [agent integration
+Use [Call an integration
+tool](/how-to/author-workflows/call-integration-tool) for a tool step and
+[Agent access](/how-to/author-workflows/use-integration-tools) for an agent
+with tools. The reference for [tool step
+fields](/reference/workflow-schema#tool-step-fields) and [agent integration
 fields](/reference/workflow-schema#agent-integration-fields) lists the exact
 selection and write fields. [Agents](/understand/agents) explains how this
 access fits with the harness, model, and native tools. [Manage GitHub repository

--- a/apps/docs/content/docs/understand/jobs-and-steps.mdx
+++ b/apps/docs/content/docs/understand/jobs-and-steps.mdx
@@ -5,11 +5,32 @@ description: "Understand how the split into jobs affects shared files, parallel 
 ---
 
 A **job** is the unit that Shipfox places on a runner. A **step** is one ordered
-action inside that job.
+action inside that job. A step is a run step, an agent step, or a tool step.
 
 The main design choice is where one job ends and the next begins. That choice
 decides which steps share a checkout, what can run at the same time, and which
 results must pass from one job to another.
+
+## Three kinds of step
+
+Each kind of step performs a different kind of work.
+
+| Step | Performs | Runs on |
+| --- | --- | --- |
+| Run step | A shell command in the job's checkout. | The runner. |
+| Agent step | A goal that an agent pursues in the checkout. | The runner. |
+| Tool step | One integration operation with inputs the workflow supplies. | The Shipfox API, through an integration connection. |
+
+A tool step has no working tree. It can't read files, set `env`, or use
+`secrets`. Its inputs come from run data, and its result becomes step outputs
+for later steps. Shipfox makes the call, so the provider credential never
+reaches the runner.
+
+The job still holds its runner while a tool step runs. The runner waits for
+the call to finish and then continues with the next step. A job made only of
+tool steps still needs a runner. [Integrations, integration connections, and
+tools](/understand/integrations-connections-and-tools) explains when a tool
+step fits better than an agent with tools.
 
 ## When to keep steps in one job
 
@@ -109,13 +130,15 @@ private network, special hardware, or another operating system. Keep it
 together when every step needs the same environment.
 
 Repository checkout permission also applies to the whole job. Each agent step
-selects its own integration tools, separate from Git access. This matters when
-an agent reads code but only one later step must write to an external system.
+selects its own integration tools, and each tool step names one operation.
+Both are separate from Git access. This matters when an agent reads code but
+only one later step must write to an external system.
 
 [Runners and execution
 environments](/understand/runners-and-execution-environments) explains
 placement. [Agent access](/how-to/author-workflows/use-integration-tools) shows
-the separate repository and integration controls.
+the separate repository and integration controls. [Call an integration
+tool](/how-to/author-workflows/call-integration-tool) shows a tool step.
 
 ## Retries and later events stay inside the job
 

--- a/apps/docs/src/app/components/integration-catalog.tsx
+++ b/apps/docs/src/app/components/integration-catalog.tsx
@@ -359,7 +359,7 @@ function IntegrationDirectoryItem({
     provider.eventCount > 0 &&
       `${provider.eventCount} ${provider.eventCount === 1 ? 'event' : 'events'}`,
     provider.toolCount > 0 &&
-      `${provider.toolCount} ${provider.toolCount === 1 ? 'agent tool' : 'agent tools'}`,
+      `${provider.toolCount} ${provider.toolCount === 1 ? 'tool' : 'tools'}`,
   ].filter(Boolean);
 
   return (

--- a/apps/docs/src/lib/integration-catalog.ts
+++ b/apps/docs/src/lib/integration-catalog.ts
@@ -26,7 +26,7 @@ export type CatalogIcon = (typeof INTEGRATION_CATALOG_ICONS)[number];
 export const catalogCapabilityLabels: Record<CatalogCapability, string> = {
   source_control: 'Code checkout',
   events: 'Events',
-  agent_tools: 'Agent tools',
+  agent_tools: 'Tools',
 };
 
 export const catalogCategoryLabels: Record<CatalogCategory, string> = {

--- a/apps/docs/src/lib/machine-readable.test.ts
+++ b/apps/docs/src/lib/machine-readable.test.ts
@@ -117,7 +117,7 @@ test('serializes integration catalog placeholders as complete Markdown facts', (
       '| Events | 18 ([event catalog](https://www.shipfox.io/docs/integrations/github/events)) |',
     ),
   );
-  assert.ok(markdown.includes('| Agent tools | 21'));
+  assert.ok(markdown.includes('| Tools | 21'));
   assert.equal(markdown.includes('](/'), false);
 });
 

--- a/apps/docs/src/lib/machine-readable.ts
+++ b/apps/docs/src/lib/machine-readable.ts
@@ -96,7 +96,7 @@ export function serializeIntegrationCatalog(providers: readonly CatalogProvider[
       `| Categories | ${tableValue(provider.categories.map((value) => catalogCategoryLabels[value]).join(', '))} |`,
       `| Aliases | ${tableValue(provider.aliases.map(inlineCode).join(', '))} |`,
       `| Events | ${tableValue(events)} |`,
-      `| Agent tools | ${tableValue(tools)} |`,
+      `| Tools | ${tableValue(tools)} |`,
       `| Overview | ${tableValue(`[${provider.name}](${provider.overviewHref})`)} |`,
       `| Setup | ${tableValue(provider.setupHref ? `[Connect ${provider.name}](${provider.setupHref})` : 'Not available')} |`,
     ].join('\n');
@@ -105,7 +105,7 @@ export function serializeIntegrationCatalog(providers: readonly CatalogProvider[
   return [
     '## Integration catalog',
     '',
-    'Every integration listed here is available in the documentation and carries the capabilities, event, and agent-tool facts shown below.',
+    'Every integration listed here is available in the documentation and carries the capabilities, event, and tool facts shown below.',
     '',
     sections.join('\n\n'),
   ].join('\n');

--- a/apps/docs/src/lib/retrieval-headings.test.ts
+++ b/apps/docs/src/lib/retrieval-headings.test.ts
@@ -30,6 +30,7 @@ const glossaryHeadings = [
   'Run step',
   'Secret',
   'Workflow step',
+  'Tool step',
   'Thinking level',
   'Workflow trigger',
   'Variable',


### PR DESCRIPTION
Clarifies how workflows use fixed integration tool steps alongside agent tools. Adds a focused tool-step guide and aligns provider, schema, glossary, and machine-readable documentation with that distinction.

Streamlines workflow authoring guides so each page stays focused on one task, uses direct prerequisites, and verifies the promised result without unrelated setup detail.

Local validation passed with package-scoped checks, types, tests, the production route matrix, and the docs build.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies how workflows use fixed integration tool steps alongside agent tools. Adds a new `call-integration-tool` how-to guide, aligns provider tools pages, glossary, workflow schema, and understanding guides with that distinction, and renames "agent tools" to "tools" across the docs catalog and machine-readable output.

**Refactors**
- Trims generic "project can sync workflows" and runner prerequisites so each authoring guide lists only what it needs.
- Registers the new tool-step guide in the author-workflows index and metadata.

<sup>Written for commit ab0a20e33868c5f3c147465352563a11a526ed3f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1752?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

