### PR TITLE
[config] Resolve public URLs from validated configuration

### DIFF
--- a/.changeset/typed-config-fallbacks.md
+++ b/.changeset/typed-config-fallbacks.md
@@ -1,0 +1,6 @@
+---
+"@shipfox/config": minor
+"@shipfox/api-auth": patch
+---
+
+Adds typed configuration-key fallbacks and uses them to derive API_PUBLIC_URL from the resolved API_URL.

--- a/.changeset/typed-config-fallbacks.md
+++ b/.changeset/typed-config-fallbacks.md
@@ -3,4 +3,4 @@
 "@shipfox/api-auth": patch
 ---
 
-Adds typed configuration-key fallbacks and uses them to derive API_PUBLIC_URL from the resolved API_URL.
+Adds typed configuration-key fallbacks. API Auth now requires a validated API_URL in production and uses it when API_PUBLIC_URL is unset.

--- a/apps/api/.env
+++ b/apps/api/.env
@@ -15,7 +15,7 @@ LOG_PRETTY=true
 
 # Client
 CLIENT_BASE_URL=http://localhost:5173
-API_PUBLIC_URL=http://localhost:16101
+API_URL=http://localhost:16101
 
 # Workspaces / auth
 AUTH_ROOT_KEY=MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=

--- a/dev/worktree-services.config.mjs
+++ b/dev/worktree-services.config.mjs
@@ -15,7 +15,7 @@ export default defineWorktreeServices({
     return {
       ...standardAppEnv(ports),
       API_PORT: String(ports.api),
-      API_PUBLIC_URL: `http://localhost:${ports.api}`,
+      API_URL: `http://localhost:${ports.api}`,
       CLIENT_BASE_URL: `http://localhost:${ports.client}`,
       VITE_API_URL: `http://localhost:${ports.api}`,
     };

--- a/docs/policies/configuration.md
+++ b/docs/policies/configuration.md
@@ -17,8 +17,18 @@ validator for each variable it reads. Keep the schema first. Derive helpers
 below it.
 
 Use the validator that matches the value: `str`, `num`, `bool`, `host`, `port`,
-`url`, or `email`. A validator with a `default` is optional. Without a default,
-the setting is required. Startup fails when it is missing or invalid.
+`url`, or `email`. A `default` supplies a missing value in every environment.
+Without an active default or fallback, the setting is required. Startup fails
+when a required value is missing or any explicit value is invalid.
+
+Use `devDefault` when a value is safe only outside production. It applies when
+`NODE_ENV` is set and is not `production`; production still requires the
+setting. Use `testDefault` when tests need a separate value.
+
+Wrap a validator with `fallbackTo('SOURCE_KEY', validator)` when one setting
+uses another setting as its fallback. Both keys must be in the same schema and
+produce compatible types. The source default resolves before the dependent
+validator checks the value.
 
 `@shipfox/config` owns the library API and validator behavior. Read its
 [package README](../../libs/shared/common/config/README.md) when using or

--- a/libs/api/auth/README.md
+++ b/libs/api/auth/README.md
@@ -69,13 +69,14 @@ Required environment:
 | `AUTH_SIGNUP_ALLOWED_EMAIL_DOMAINS` | none | Comma-separated email domains allowed to create accounts, such as `shipfox.io,acme.com`. |
 | `AUTH_SIGNUP_ALLOWED_EMAILS` | none | Comma-separated exact email addresses allowed to create accounts. |
 | `AUTH_SIGNUP_NOT_ALLOWED_MESSAGE` | none | Markdown message returned when the signup gate blocks an account. Accepts at most 500 characters. Defaults to "This Shipfox deployment does not accept new accounts right now." |
-| `API_PUBLIC_URL` | `API_URL` | Public API origin used by Agent Access OAuth metadata and redirect flows. Local development may use `http://localhost:16101`; use HTTPS elsewhere. |
+| `API_URL` | `http://localhost:3000` in development and tests | Base API URL. Production requires an explicit value. |
+| `API_PUBLIC_URL` | `API_URL` | Public API origin used by Agent Access OAuth metadata and redirect flows. Use HTTPS outside localhost. |
 | `CLIENT_BASE_URL` | `http://localhost:5173` | Base URL used in email verification and password reset links. |
 | `ADMIN_BOOTSTRAP_TOKEN` | none | Deployment secret accepted once to create the first administrator owner. Set it before bootstrap and remove or rotate it after successful bootstrap. |
 
-`API_PUBLIC_URL` defaults to `API_URL`. Set it when the externally reachable
-origin differs from `API_URL`. OAuth route construction rejects non-loopback
-HTTP origins.
+`API_PUBLIC_URL` uses the validated `API_URL` value when it is not set. Set it
+when the externally reachable origin differs from `API_URL`. OAuth route
+construction rejects non-loopback HTTP origins.
 
 The recommended access-token lifetime is 15 minutes. Because user JWTs are
 verified from their claims, a token issued before logout, password changes,

--- a/libs/api/auth/src/config.test.ts
+++ b/libs/api/auth/src/config.test.ts
@@ -61,9 +61,22 @@ describe('signup gate configuration', () => {
     expect(config.AUTH_JWT_EXPIRES_IN).toBe('30s');
   });
 
-  test('requires API_PUBLIC_URL or API_URL', async () => {
+  test('defaults both API URLs to localhost in tests', async () => {
     vi.stubEnv('API_PUBLIC_URL', undefined);
     vi.stubEnv('API_URL', undefined);
+    vi.stubEnv('NODE_ENV', 'test');
+    vi.resetModules();
+
+    const {config} = await import('#config.js');
+
+    expect(config.API_URL).toBe('http://localhost:3000');
+    expect(config.API_PUBLIC_URL).toBe('http://localhost:3000');
+  });
+
+  test('requires an explicit API URL in production', async () => {
+    vi.stubEnv('API_PUBLIC_URL', 'https://api.example.test');
+    vi.stubEnv('API_URL', undefined);
+    vi.stubEnv('NODE_ENV', 'production');
     vi.resetModules();
 
     await expect(import('#config.js')).rejects.toThrow('process.exit unexpectedly called with "1"');

--- a/libs/api/auth/src/config.test.ts
+++ b/libs/api/auth/src/config.test.ts
@@ -92,7 +92,7 @@ describe('signup gate configuration', () => {
     expect(config.API_PUBLIC_URL).toBe('https://internal-api.example.test');
   });
 
-  test('rejects an invalid API_URL fallback', async () => {
+  test('rejects an invalid API_URL', async () => {
     vi.stubEnv('API_PUBLIC_URL', undefined);
     vi.stubEnv('API_URL', 'internal-api.example.test');
     vi.resetModules();

--- a/libs/api/auth/src/config.ts
+++ b/libs/api/auth/src/config.ts
@@ -1,4 +1,4 @@
-import {bool, createConfig, num, str, url} from '@shipfox/config';
+import {bool, createConfig, fallbackTo, num, str, url} from '@shipfox/config';
 import {durationToSeconds} from '@shipfox/node-jwt';
 import {SIGNUP_DENIAL_MESSAGE_MAX_LENGTH} from '#core/ports.js';
 
@@ -10,9 +10,16 @@ const configSchema = {
     desc: 'Deployment secret accepted once to create the first administrator owner. Set it before bootstrap and remove or rotate it after successful bootstrap.',
     default: undefined,
   }),
-  API_PUBLIC_URL: url({
-    desc: 'Public origin of the API used by Agent Access OAuth metadata and redirect flows. Defaults to API_URL. Set an externally reachable URL including the scheme. Use HTTPS outside localhost.',
+  API_URL: url({
+    desc: 'Base URL of the API. Development and test environments default to http://localhost:3000. Production requires an explicit URL.',
+    devDefault: 'http://localhost:3000',
   }),
+  API_PUBLIC_URL: fallbackTo(
+    'API_URL',
+    url({
+      desc: 'Public origin of the API used by Agent Access OAuth metadata and redirect flows. Defaults to API_URL. Set an externally reachable URL including the scheme. Use HTTPS outside localhost.',
+    }),
+  ),
   AUTH_JWT_EXPIRES_IN: str({
     desc: 'How long an access token stays valid. Accepts a duration string such as 15m, 1h, or 7d. When AUTH_IMPERSONATION_ENABLED is true, set it to at least 1 minute.',
     default: '15m',
@@ -71,9 +78,7 @@ const configSchema = {
   }),
 };
 
-export const config = createConfig(configSchema, {
-  API_PUBLIC_URL: process.env.API_PUBLIC_URL ?? process.env.API_URL,
-});
+export const config = createConfig(configSchema);
 
 export const impersonationWindowMaxSeconds = parseDurationSetting(
   'AUTH_IMPERSONATION_WINDOW_MAX',

--- a/libs/api/auth/test/env.ts
+++ b/libs/api/auth/test/env.ts
@@ -5,5 +5,4 @@ process.env.POSTGRES_PASSWORD ??= 'password';
 process.env.POSTGRES_DATABASE = 'api_test';
 process.env.POSTGRES_MAX_CONNECTIONS ??= '5';
 process.env.AUTH_ROOT_KEY = 'MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=';
-process.env.API_PUBLIC_URL ??= 'http://localhost:16101';
 process.env.TZ = 'UTC';

--- a/libs/api/server/README.md
+++ b/libs/api/server/README.md
@@ -98,7 +98,8 @@ node --import @shipfox/api-server/instrumentation ./dist/index.js
 | --- | --- | --- |
 | `E2E_ENABLED` | `false` | Enables routes under `/__e2e` when `E2E_ADMIN_API_KEY` is set. |
 | `E2E_ADMIN_API_KEY` | none | Required to enable and protect E2E routes. |
-| `API_PUBLIC_URL` | `API_URL` | Public API origin used by MCP OAuth metadata and redirect flows. Set it when the public origin differs from `API_URL`. Local development may use `http://localhost:16101`; use HTTPS elsewhere. |
+| `API_URL` | `http://localhost:3000` in development and tests | Base API URL. Production requires an explicit value. |
+| `API_PUBLIC_URL` | `API_URL` | Public API origin used by MCP OAuth metadata and redirect flows. Set it when the public origin differs from `API_URL`. Use HTTPS outside localhost. |
 | `API_PORT` | shared `PORT` | Sets the listener port. |
 | `API_TRUST_PROXY` | `false` | Sets proxy IP checks. |
 

--- a/libs/api/server/test/published/_environment.mjs
+++ b/libs/api/server/test/published/_environment.mjs
@@ -8,7 +8,7 @@ export function publishedTestEnvironment() {
   const postgresDatabase = 'api_test';
 
   return {
-    API_PUBLIC_URL: 'https://api.example.test',
+    API_URL: 'https://api.example.test',
     AUTH_ROOT_KEY: 'MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=',
     DATABASE_URL: `postgres://${postgresUsername}:${postgresPassword}@${postgresHost}:${postgresPort}/${postgresDatabase}`,
     GITEA_BASE_URL: 'https://gitea.example.com',

--- a/libs/shared/common/config/README.md
+++ b/libs/shared/common/config/README.md
@@ -38,8 +38,9 @@ config.DEBUG; // boolean
 ```
 
 `fallbackTo` accepts a key from the same schema with a compatible output type.
-The source value resolves before the dependent validator checks it. A fallback
-target cannot also declare a static or environment-specific default.
+The source value resolves before the dependent validator checks it. A key that
+declares `fallbackTo` cannot also declare a static or environment-specific
+default; the source key can.
 
 Pass `update` in tests to override `process.env`:
 

--- a/libs/shared/common/config/README.md
+++ b/libs/shared/common/config/README.md
@@ -4,11 +4,12 @@ Typed config for Shipfox packages. It checks `process.env` at startup and return
 
 ## What it does
 
-- **`createConfig(schema, update?)`** checks environment values with `envalid`.
+- **`createConfig(schema, update?)`** resolves declared fallbacks and checks environment values with `envalid`.
+- **`fallbackTo(key, validator)`** uses another validated schema value when the environment value is not set.
 - **Common validators** are re-exported: `str`, `num`, `bool`, `email`, `host`, `port`, and `url`.
 - **Fail-fast startup** means bad values throw before the app runs.
 
-## Installation
+## Installation and setup
 
 ```bash
 pnpm add @shipfox/config
@@ -21,22 +22,29 @@ npm install @shipfox/config
 ## Usage
 
 ```ts
-import {bool, createConfig, num, str} from "@shipfox/config";
+import {bool, createConfig, fallbackTo, num, str, url} from '@shipfox/config';
 
 const config = createConfig({
-  NODE_ENV: str({choices: ["development", "test", "production"]}),
+  NODE_ENV: str({choices: ['development', 'test', 'production']}),
+  API_URL: url({devDefault: 'http://localhost:3000'}),
+  API_PUBLIC_URL: fallbackTo('API_URL', url()),
   PORT: num({default: 3000}),
   DEBUG: bool({default: false}),
 });
 
+config.API_PUBLIC_URL; // string
 config.PORT; // number
 config.DEBUG; // boolean
 ```
 
+`fallbackTo` accepts a key from the same schema with a compatible output type.
+The source value resolves before the dependent validator checks it. A fallback
+target cannot also declare a static or environment-specific default.
+
 Pass `update` in tests to override `process.env`:
 
 ```ts
-const testConfig = createConfig({PORT: num()}, {PORT: "4000"});
+const testConfig = createConfig({PORT: num()}, {PORT: '4000'});
 ```
 
 ## Development

--- a/libs/shared/common/config/src/index.test.ts
+++ b/libs/shared/common/config/src/index.test.ts
@@ -123,6 +123,21 @@ describe('fallbacks', () => {
     );
   });
 
+  test('rejects a default on a key that declares a fallback', () => {
+    const loadConfig = () =>
+      createConfig({
+        TEST_PRIMARY_URL: fallbackTo(
+          'TEST_SOURCE_URL',
+          url({default: 'https://public.example.test'}),
+        ),
+        TEST_SOURCE_URL: url({default: 'https://internal.example.test'}),
+      });
+
+    expect(loadConfig).toThrow(
+      'Configuration key "TEST_PRIMARY_URL" cannot declare both a fallback and a default.',
+    );
+  });
+
   test('fails when a required fallback source has no value', () => {
     const loadConfig = () =>
       createConfig(

--- a/libs/shared/common/config/src/index.test.ts
+++ b/libs/shared/common/config/src/index.test.ts
@@ -1,11 +1,10 @@
-import {bool, createConfig, num, str} from './index.js';
+import {bool, createConfig, fallbackTo, num, str, url} from './index.js';
 
 describe('config', () => {
   afterEach(() => {
     delete process.env.TEST_STRING;
     delete process.env.TEST_NUMBER;
     delete process.env.TEST_BOOL;
-    delete process.env.TEST_STRING;
   });
 
   it('should create config with string validation', () => {
@@ -56,5 +55,102 @@ describe('config', () => {
     config = createConfig(schema, {TEST_STRING: 'test-value2'});
 
     expect(config.TEST_STRING).toBe('test-value2');
+  });
+});
+
+describe('fallbacks', () => {
+  test('resolves defaults before chained fallback values', () => {
+    const config = createConfig({
+      TEST_PRIMARY_URL: fallbackTo('TEST_SECONDARY_URL', url()),
+      TEST_SECONDARY_URL: fallbackTo('TEST_DEFAULT_URL', url()),
+      TEST_DEFAULT_URL: url({default: 'https://default.example.test'}),
+    });
+
+    expect(config.TEST_PRIMARY_URL).toBe('https://default.example.test');
+    expect(config.TEST_SECONDARY_URL).toBe('https://default.example.test');
+    expectTypeOf(config.TEST_PRIMARY_URL).toEqualTypeOf<string>();
+  });
+
+  test('prefers an explicit value to its fallback', () => {
+    const config = createConfig(
+      {
+        TEST_PRIMARY_URL: fallbackTo('TEST_SECONDARY_URL', url()),
+        TEST_SECONDARY_URL: url(),
+      },
+      {
+        TEST_PRIMARY_URL: 'https://public.example.test',
+        TEST_SECONDARY_URL: 'https://internal.example.test',
+      },
+    );
+
+    expect(config.TEST_PRIMARY_URL).toBe('https://public.example.test');
+  });
+
+  test('validates a fallback value with the dependent validator', () => {
+    const loadConfig = () =>
+      createConfig(
+        {
+          TEST_INPUT: str(),
+          TEST_URL: fallbackTo('TEST_INPUT', url()),
+        },
+        {TEST_INPUT: 'not-a-url'},
+      );
+
+    expect(loadConfig).toThrow('process.exit unexpectedly called with "1"');
+  });
+
+  test('requires compatible fallback value types', () => {
+    const loadConfig = () =>
+      createConfig(
+        // @ts-expect-error A numeric configuration value cannot fall back into a string validator.
+        {
+          TEST_NUMBER: num(),
+          TEST_STRING: fallbackTo('TEST_NUMBER', str()),
+        },
+        {TEST_NUMBER: '42'},
+      );
+
+    expect(loadConfig).toThrow('process.exit unexpectedly called with "1"');
+  });
+
+  test('fails when a fallback references a missing schema key', () => {
+    const loadConfig = () =>
+      // @ts-expect-error The fallback key must exist in the same schema.
+      createConfig({TEST_URL: fallbackTo('TEST_MISSING_URL', url())});
+
+    expect(loadConfig).toThrow(
+      'Configuration fallback for "TEST_URL" references missing key "TEST_MISSING_URL".',
+    );
+  });
+
+  test('fails when a required fallback source has no value', () => {
+    const loadConfig = () =>
+      createConfig(
+        {
+          TEST_PRIMARY_URL: fallbackTo('TEST_SOURCE_URL', url()),
+          TEST_SOURCE_URL: url(),
+        },
+        {TEST_PRIMARY_URL: undefined, TEST_SOURCE_URL: undefined},
+      );
+
+    expect(loadConfig).toThrow('process.exit unexpectedly called with "1"');
+  });
+
+  test('fails deterministically when fallbacks form a cycle', () => {
+    const loadConfig = () =>
+      createConfig({
+        TEST_FIRST_URL: fallbackTo('TEST_SECOND_URL', url()),
+        TEST_SECOND_URL: fallbackTo('TEST_FIRST_URL', url()),
+      });
+
+    expect(loadConfig).toThrow(
+      'Configuration fallback cycle detected: TEST_FIRST_URL -> TEST_SECOND_URL -> TEST_FIRST_URL.',
+    );
+  });
+
+  test('keeps missing configuration required without a fallback', () => {
+    const loadConfig = () => createConfig({TEST_REQUIRED: str()}, {TEST_REQUIRED: undefined});
+
+    expect(loadConfig).toThrow('process.exit unexpectedly called with "1"');
   });
 });

--- a/libs/shared/common/config/src/index.ts
+++ b/libs/shared/common/config/src/index.ts
@@ -1,4 +1,9 @@
-import {type CleanedEnv, cleanEnv} from 'envalid';
+import {
+  type CleanedEnv,
+  cleanEnv,
+  type OptionalValidatorSpec,
+  type RequiredValidatorSpec,
+} from 'envalid';
 
 export type {
   BaseValidator,
@@ -12,9 +17,182 @@ export type {
 } from 'envalid';
 export {bool, cleanEnv, email, host, num, port, str, url} from 'envalid';
 
-export function createConfig<T extends Record<string, unknown>>(
-  schema: T,
+type ConfigValue<Validator> =
+  Validator extends OptionalValidatorSpec<infer Value>
+    ? Value | undefined
+    : Validator extends RequiredValidatorSpec<infer Value>
+      ? Value
+      : never;
+
+type InvalidFallbackKeys<Schema extends Record<string, unknown>> = {
+  [Key in keyof Schema]: Schema[Key] extends {
+    readonly fallbackTo: infer Dependency extends PropertyKey;
+  }
+    ? Dependency extends keyof Schema
+      ? ConfigValue<Schema[Dependency]> extends ConfigValue<Schema[Key]>
+        ? never
+        : Key
+      : Key
+    : never;
+}[keyof Schema];
+
+type ValidFallbackSchema<Schema extends Record<string, unknown>> = [
+  InvalidFallbackKeys<Schema>,
+] extends [never]
+  ? unknown
+  : never;
+
+type FallbackValidatorSpec<Validator extends object, Dependency extends string> = Validator & {
+  readonly fallbackTo: Dependency;
+};
+
+/**
+ * Uses another validated configuration value when this value is not set.
+ * The dependency must be present in the same schema and produce a compatible value.
+ */
+export function fallbackTo<const Dependency extends string, const Validator extends object>(
+  dependency: Dependency,
+  validator: Validator,
+): FallbackValidatorSpec<Validator, Dependency> {
+  return {...validator, fallbackTo: dependency};
+}
+
+export function createConfig<Schema extends Record<string, unknown>>(
+  schema: Schema & ValidFallbackSchema<Schema>,
   update?: Partial<NodeJS.ProcessEnv>,
-): CleanedEnv<T> {
-  return cleanEnv({...process.env, ...update}, schema);
+): CleanedEnv<Schema> {
+  const environment: Record<string, unknown> = {...process.env, ...update};
+  const fallbackOrder = validateFallbackGraph(schema);
+  if (fallbackOrder.length === 0) return cleanEnv(environment, schema);
+
+  const preflightSchema = createPreflightSchema(schema);
+  const preflightConfig = cleanEnv(environment, preflightSchema) as unknown as Record<
+    string,
+    unknown
+  >;
+  const fallbackInputs: Record<string, unknown> = {};
+  const resolvedFallbacks = new Map<string, unknown>();
+
+  for (const key of fallbackOrder) {
+    if (environment[key] !== undefined) continue;
+
+    const validator = schema[key];
+    if (validator === undefined) {
+      throw new Error(`Configuration fallback key "${key}" is missing from the schema.`);
+    }
+
+    const dependency = getFallbackDependency(validator);
+    if (dependency === undefined) continue;
+
+    const dependencyValue = resolvedFallbacks.has(dependency)
+      ? resolvedFallbacks.get(dependency)
+      : preflightConfig[dependency];
+    if (dependencyValue === undefined) continue;
+
+    fallbackInputs[key] = dependencyValue;
+    resolvedFallbacks.set(
+      key,
+      validateFallbackValue(key, dependencyValue, environment.NODE_ENV, validator),
+    );
+  }
+
+  return cleanEnv({...environment, ...fallbackInputs}, schema);
+}
+
+function validateFallbackGraph<Schema extends Record<string, unknown>>(schema: Schema): string[] {
+  const dependencies = new Map<string, string>();
+
+  for (const [key, validator] of Object.entries(schema)) {
+    const dependency = getFallbackDependency(validator);
+    if (dependency === undefined) continue;
+
+    if (!Object.hasOwn(schema, dependency)) {
+      throw new Error(
+        `Configuration fallback for "${key}" references missing key "${dependency}".`,
+      );
+    }
+    if (hasDefault(validator)) {
+      throw new Error(`Configuration key "${key}" cannot declare both a fallback and a default.`);
+    }
+
+    dependencies.set(key, dependency);
+  }
+
+  return orderFallbacks(dependencies);
+}
+
+function orderFallbacks(dependencies: ReadonlyMap<string, string>): string[] {
+  const ordered: string[] = [];
+  const path: string[] = [];
+  const states = new Map<string, 'visiting' | 'visited'>();
+
+  function visit(key: string): void {
+    const state = states.get(key);
+    if (state === 'visited') return;
+    if (state === 'visiting') {
+      const cycleStart = path.indexOf(key);
+      const cycle = [...path.slice(cycleStart), key];
+      throw new Error(`Configuration fallback cycle detected: ${cycle.join(' -> ')}.`);
+    }
+
+    states.set(key, 'visiting');
+    path.push(key);
+
+    const dependency = dependencies.get(key);
+    if (dependency !== undefined && dependencies.has(dependency)) visit(dependency);
+
+    path.pop();
+    states.set(key, 'visited');
+    ordered.push(key);
+  }
+
+  for (const key of dependencies.keys()) visit(key);
+  return ordered;
+}
+
+function createPreflightSchema<Schema extends Record<string, unknown>>(
+  schema: Schema,
+): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(schema).map(([key, validator]) => {
+      if (getFallbackDependency(validator) === undefined) return [key, validator];
+
+      return [key, {...(validator as object), default: undefined, requiredWhen: undefined}];
+    }),
+  );
+}
+
+function validateFallbackValue(
+  key: string,
+  value: unknown,
+  nodeEnv: unknown,
+  validator: unknown,
+): unknown {
+  try {
+    const resolved = cleanEnv(
+      {NODE_ENV: nodeEnv, [key]: value},
+      {[key]: validator},
+      {reporter: null},
+    ) as unknown as Record<string, unknown>;
+    return resolved[key];
+  } catch {
+    return value;
+  }
+}
+
+function getFallbackDependency(validator: unknown): string | undefined {
+  if (typeof validator !== 'object' || validator === null) return undefined;
+
+  const fallbackTo = (validator as {fallbackTo?: unknown}).fallbackTo;
+  if (fallbackTo === undefined) return undefined;
+  if (typeof fallbackTo !== 'string' || fallbackTo.length === 0) {
+    throw new Error('Configuration fallback keys must be non-empty strings.');
+  }
+  return fallbackTo;
+}
+
+function hasDefault(validator: unknown): boolean {
+  if (typeof validator !== 'object' || validator === null) return false;
+
+  return ['default', 'devDefault', 'testDefault'].some((key) => Object.hasOwn(validator, key));
 }


### PR DESCRIPTION
## Summary

Add typed configuration-key fallbacks to `@shipfox/config` so defaults resolve before dependent settings and every resolved value still passes its own validator.

Use that contract in `@shipfox/api-auth` to derive `API_PUBLIC_URL` from the resolved `API_URL`, while keeping the localhost default limited to development and tests. This removes the package test fixture that previously concealed the missing shared configuration behavior.

The fallback graph now rejects missing dependencies, incompatible value types, and cycles deterministically. A Changeset publishes a minor `@shipfox/config` release and a patch `@shipfox/api-auth` release.

## Validation

- `mise exec -- pnpm turbo test type check build --filter=@shipfox/config... --output-logs=errors-only`
- `mise exec -- pnpm turbo test type check build depcruise --filter=@shipfox/api-auth --output-logs=errors-only`
- `mise exec -- pnpm turbo type check test build depcruise --filter=@shipfox/api-server --output-logs=errors-only`
- `mise exec -- pnpm turbo type --filter='...@shipfox/config' --output-logs=errors-only`
- `mise exec -- pnpm turbo verify --filter=@shipfox/prose-policy --output-logs=errors-only`
- `mise exec -- pnpm exec changeset status --output=.context/changeset-status.json`
- `mise exec -- pnpm --filter=@shipfox/application-release test:external`
- `mise exec -- git diff --check`
