### PR TITLE
[api-integration-github] Read private refs when creating pull requests

### DIFF
--- a/.changeset/private-pull-request-refs.md
+++ b/.changeset/private-pull-request-refs.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-integration-github": patch
+---
+
+Mint pull request tool credentials with contents read access so GitHub can validate private base and head refs.

--- a/e2e/suites/flow/workflows/src/github-api.ts
+++ b/e2e/suites/flow/workflows/src/github-api.ts
@@ -17,11 +17,13 @@ export const GITHUB_READ_RESULT_MARKER = 'github-read-result-marker';
 export const GITHUB_WRITE_RESULT_MARKER = 'github-write-result-marker';
 export const GITHUB_SEARCH_RESULT_MARKER = 'github-search-result-marker';
 export const GITHUB_GRAPHQL_RESULT_MARKER = 'github-graphql-result-marker';
+export const GITHUB_PULL_REQUEST_RESULT_MARKER = 'github-pull-request-result-marker';
 
 const INSTALLATION_TOKEN_PATH = /^\/app\/installations\/(\d+)\/access_tokens$/u;
 const REPOSITORY_PATH = /^\/repositories\/(\d+)$/u;
 const ISSUE_PATH = /^\/repos\/([^/]+)\/([^/]+)\/issues\/(\d+)$/u;
 const ISSUES_PATH = /^\/repos\/([^/]+)\/([^/]+)\/issues$/u;
+const PULL_REQUESTS_PATH = /^\/repos\/([^/]+)\/([^/]+)\/pulls$/u;
 const CHECK_RUN_CREATE_PATH = /^\/repos\/([^/]+)\/([^/]+)\/check-runs$/u;
 const CHECK_RUN_UPDATE_PATH = /^\/repos\/([^/]+)\/([^/]+)\/check-runs\/(\d+)$/u;
 const SEARCH_ISSUES_PATH = /^\/search\/issues$/u;
@@ -60,6 +62,13 @@ export type GithubApiMockCall =
     }
   | {
       kind: 'create-issue';
+      authorization: string | undefined;
+      owner: string;
+      repo: string;
+      body: Record<string, unknown>;
+    }
+  | {
+      kind: 'create-pull-request';
       authorization: string | undefined;
       owner: string;
       repo: string;
@@ -197,6 +206,11 @@ async function handleGithubRequest(params: {
     await handleCreateIssueRequest(context, createIssueMatch);
     return;
   }
+  const createPullRequestMatch = requestUrl.pathname.match(PULL_REQUESTS_PATH);
+  if (requestMatches(params.request, 'POST', createPullRequestMatch)) {
+    await handleCreatePullRequestRequest(context, createPullRequestMatch);
+    return;
+  }
   const checkRunCreateMatch = requestUrl.pathname.match(CHECK_RUN_CREATE_PATH);
   if (requestMatches(params.request, 'POST', checkRunCreateMatch)) {
     await handleCreateCheckRunRequest(context, checkRunCreateMatch);
@@ -306,6 +320,26 @@ async function handleCreateIssueRequest(
   sendJson(params.response, 201, {
     number: 2,
     marker: GITHUB_WRITE_RESULT_MARKER,
+  });
+}
+
+async function handleCreatePullRequestRequest(
+  params: GithubRequestContext,
+  match: RegExpMatchArray,
+): Promise<void> {
+  const body = await readJsonBody(params.request);
+  if (isCurrentInstallationAuthorization(params)) {
+    params.calls.push({
+      kind: 'create-pull-request',
+      authorization: params.authorization,
+      owner: decodeURIComponent(match[1] ?? ''),
+      repo: decodeURIComponent(match[2] ?? ''),
+      body,
+    });
+  }
+  sendJson(params.response, 201, {
+    number: 3,
+    marker: GITHUB_PULL_REQUEST_RESULT_MARKER,
   });
 }
 

--- a/e2e/suites/flow/workflows/tests/github-agent-tools.e2e.ts
+++ b/e2e/suites/flow/workflows/tests/github-agent-tools.e2e.ts
@@ -15,6 +15,7 @@ import {
 } from '#attachments.js';
 import {
   GITHUB_GRAPHQL_RESULT_MARKER,
+  GITHUB_PULL_REQUEST_RESULT_MARKER,
   GITHUB_READ_RESULT_MARKER,
   GITHUB_SEARCH_RESULT_MARKER,
   GITHUB_STATEFUL_INSTALLATION_TOKEN,
@@ -276,6 +277,60 @@ test('enforces selected GitHub authorization for deterministic tools', async ({
         owner: 'shipfox',
         repo: 'e2e',
         issueNumber: 1,
+      },
+    ]);
+  } finally {
+    await fixture.githubApi.stop();
+  }
+});
+
+test('mints private-ref read access for pull request creation', async ({suite}, testInfo) => {
+  const uniqueId = shortId();
+  const fixture = await createGithubFixture(suite, uniqueId);
+
+  try {
+    const result = await runGithubWorkflow({
+      suite,
+      testInfo,
+      uniqueId,
+      scenario: 'github-create-private-pull-request',
+      workflowYaml: deterministicToolWorkflow({
+        connection: fixture.connection.slug,
+        tool: 'create_pull_request',
+        with: {
+          owner: 'shipfox',
+          repo: 'e2e',
+          title: 'Synthetic pull request',
+          head: 'feature',
+          base: 'main',
+        },
+        outputs: {marker: `\${{ result.pull_request.marker }}`},
+        verification: {
+          env: {MARKER: `\${{ steps.github.outputs.marker }}`},
+          run: `test "$MARKER" = "${GITHUB_PULL_REQUEST_RESULT_MARKER}"`,
+        },
+      }),
+    });
+
+    expect(result.terminal.status).toBe('succeeded');
+    expect(githubAgentToolCalls(fixture.githubApi)).toEqual([
+      {
+        kind: 'mint-token',
+        authorization: expect.any(String),
+        tokenFormatOverride: 'enabled',
+        installationId: fixture.installationId,
+        body: {permissions: {contents: 'read', pull_requests: 'write'}},
+      },
+      {
+        kind: 'create-pull-request',
+        authorization: `bearer ${fixture.installationToken}`,
+        owner: 'shipfox',
+        repo: 'e2e',
+        body: {
+          title: 'Synthetic pull request',
+          head: 'feature',
+          base: 'main',
+        },
       },
     ]);
   } finally {

--- a/libs/api/integration/github/src/core/agent-tools.test.ts
+++ b/libs/api/integration/github/src/core/agent-tools.test.ts
@@ -128,7 +128,10 @@ const expectedCatalogRows = [
     category: 'pull_requests',
     sensitivity: 'write',
     sensitive: false,
-    requiredScope: [{permission: 'pull_requests', access: 'write'}],
+    requiredScope: [
+      {permission: 'pull_requests', access: 'write'},
+      {permission: 'contents', access: 'read'},
+    ],
   },
   {
     id: 'create_commit',
@@ -1384,6 +1387,110 @@ describe('github agent tool catalog', () => {
     });
   });
 
+  it('requests pull request write and contents read access for private refs', async () => {
+    const request = vi.fn(() => Promise.resolve({data: {number: 7}}));
+    const getInstallationAccessToken = vi.fn(() =>
+      Promise.resolve({
+        token: 'pull-request-token',
+        expiresAt: new Date(),
+        permissions: {
+          contents: 'read' as const,
+          pull_requests: 'write' as const,
+        },
+      }),
+    );
+    const createPullRequest = githubAgentToolCatalog.find(
+      (entry) => entry.id === 'create_pull_request',
+    );
+    if (!createPullRequest) throw new Error('Missing create_pull_request tool');
+    const provider = new GithubAgentToolsProvider({
+      getInstallationByConnectionId: vi.fn(() => Promise.resolve(installation())),
+      tokenProvider: {getInstallationAccessToken},
+      createClient: vi.fn(() => ({request})),
+    });
+    const session = await provider.openSession({
+      connection: connection(),
+      tools: [createPullRequest],
+      scope: undefined,
+    });
+
+    const result = await session.call({
+      toolId: 'create_pull_request',
+      arguments: {
+        owner: 'shipfox',
+        repo: 'private-repository',
+        title: 'Title',
+        head: 'feature',
+        base: 'main',
+      },
+    });
+
+    expect(result).toMatchObject({structuredContent: {pull_request: {number: 7}}});
+    expect(getInstallationAccessToken).toHaveBeenCalledWith(1, undefined, {
+      contents: 'read',
+      pull_requests: 'write',
+    });
+    expect(request).toHaveBeenCalledWith('POST /repos/{owner}/{repo}/pulls', {
+      owner: 'shipfox',
+      repo: 'private-repository',
+      title: 'Title',
+      head: 'feature',
+      base: 'main',
+    });
+  });
+
+  it.each([
+    {
+      missingPermission: 'contents read',
+      permissions: {pull_requests: 'write' as const},
+    },
+    {
+      missingPermission: 'pull requests write',
+      permissions: {contents: 'read' as const},
+    },
+  ])('rejects private pull request creation without $missingPermission', async ({permissions}) => {
+    const request = vi.fn();
+    const provider = new GithubAgentToolsProvider({
+      getInstallationByConnectionId: vi.fn(() => Promise.resolve(installation())),
+      tokenProvider: {
+        getInstallationAccessToken: vi.fn(() =>
+          Promise.resolve({token: 'installation-token', expiresAt: new Date(), permissions}),
+        ),
+      },
+      createClient: vi.fn(() => ({request})),
+    });
+    const tool = githubAgentToolCatalog.find((entry) => entry.id === 'create_pull_request');
+    if (!tool) throw new Error('Missing create_pull_request tool');
+    const session = await provider.openSession({
+      connection: connection(),
+      tools: [tool],
+      scope: undefined,
+    });
+
+    const result = await session.call({
+      toolId: 'create_pull_request',
+      arguments: {
+        owner: 'shipfox',
+        repo: 'private-repository',
+        title: 'Title',
+        head: 'feature',
+        base: 'main',
+      },
+    });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: 'text',
+          text: 'GitHub installation token is missing permission for this operation: create_pull_request requires pull_requests: write, contents: read',
+        },
+      ],
+      structuredContent: {code: 'access-denied'},
+    });
+    expect(request).not.toHaveBeenCalled();
+  });
+
   it('keeps the strongest permission when selected tools share a scope', async () => {
     const request = vi.fn(() => Promise.resolve({data: {number: 1}}));
     const getInstallationAccessToken = vi.fn(() =>
@@ -1826,6 +1933,87 @@ describe('github agent tool catalog', () => {
       repo: 'platform',
       pull_number: 7,
       title: 'Updated',
+    });
+  });
+
+  it('translates unreadable pull request refs into an actionable non-retryable error', async () => {
+    const request = vi.fn(() =>
+      Promise.reject(
+        new RequestError('Validation Failed: not all refs are readable', 422, {
+          request: {
+            method: 'POST',
+            url: 'https://api.github.com/repos/shipfox/private-repository/pulls',
+            headers: {},
+          },
+        }),
+      ),
+    );
+    const provider = createAgentToolsProvider({request});
+    const tool = githubAgentToolCatalog.find((entry) => entry.id === 'create_pull_request');
+    if (!tool) throw new Error('Missing create_pull_request tool');
+    const session = await provider.openSession({
+      connection: connection(),
+      tools: [tool],
+      scope: undefined,
+    });
+
+    const result = session.call({
+      toolId: 'create_pull_request',
+      arguments: {
+        owner: 'shipfox',
+        repo: 'private-repository',
+        title: 'Title',
+        head: 'feature',
+        base: 'main',
+      },
+    });
+
+    await expect(result).rejects.toMatchObject({
+      reason: 'provider-rejected',
+      message:
+        'GitHub could not read the pull request base or head ref. Verify both refs exist in the target repository and that the GitHub App has Contents: read access.',
+      retryAfterSeconds: undefined,
+      status: 422,
+    });
+    expect(request).toHaveBeenCalledOnce();
+  });
+
+  it('preserves other pull request validation failures', async () => {
+    const request = vi.fn(() =>
+      Promise.reject(
+        new RequestError('No commits between main and feature', 422, {
+          request: {
+            method: 'POST',
+            url: 'https://api.github.com/repos/shipfox/public-repository/pulls',
+            headers: {},
+          },
+        }),
+      ),
+    );
+    const provider = createAgentToolsProvider({request});
+    const tool = githubAgentToolCatalog.find((entry) => entry.id === 'create_pull_request');
+    if (!tool) throw new Error('Missing create_pull_request tool');
+    const session = await provider.openSession({
+      connection: connection(),
+      tools: [tool],
+      scope: undefined,
+    });
+
+    const result = session.call({
+      toolId: 'create_pull_request',
+      arguments: {
+        owner: 'shipfox',
+        repo: 'public-repository',
+        title: 'Title',
+        head: 'feature',
+        base: 'main',
+      },
+    });
+
+    await expect(result).rejects.toMatchObject({
+      reason: 'provider-rejected',
+      message: 'No commits between main and feature',
+      status: 422,
     });
   });
 

--- a/libs/api/integration/github/src/core/agent-tools.ts
+++ b/libs/api/integration/github/src/core/agent-tools.ts
@@ -79,6 +79,8 @@ const NO_PENDING_REVIEW_MESSAGE =
   'No pending pull request review found for the authenticated GitHub user.';
 const NO_REVIEW_THREAD_MESSAGE =
   'GitHub did not create the review thread. Check that path, line, side, and any start_line range describe a line in the pull request diff.';
+const UNREADABLE_PULL_REQUEST_REFS_MESSAGE =
+  'GitHub could not read the pull request base or head ref. Verify both refs exist in the target repository and that the GitHub App has Contents: read access.';
 const CHECK_RUN_INPUT_STATUSES = new Set<string>(checkRunInputStatuses);
 const CHECK_RUN_INPUT_CONCLUSIONS = new Set<string>(checkRunInputConclusions);
 const CHECK_RUN_OUTPUT_STATUSES = new Set<string>(checkRunOutputStatuses);
@@ -945,7 +947,7 @@ async function savePullRequestWithReviewers(
   parameters: Record<string, unknown>,
 ): Promise<GithubToolResponse> {
   const {reviewers, ...pullRequestParameters} = parameters;
-  const response = await client.request(route, pullRequestParameters);
+  const response = await savePullRequest(client, route, pullRequestParameters);
   const requested = splitRequestedReviewers(reviewers);
   if (requested === undefined) return response;
 
@@ -972,6 +974,32 @@ async function savePullRequestWithReviewers(
     );
   } catch (error) {
     throw reviewerRequestFailure(pullNumber, error);
+  }
+}
+
+async function savePullRequest(
+  client: GithubToolClient,
+  route: string,
+  parameters: Record<string, unknown>,
+): Promise<GithubToolResponse> {
+  try {
+    return await mapGithubError(() => client.request(route, parameters));
+  } catch (error) {
+    if (
+      route === 'POST /repos/{owner}/{repo}/pulls' &&
+      error instanceof GithubIntegrationProviderError &&
+      error.reason === 'provider-rejected' &&
+      error.status === 422 &&
+      error.message.toLowerCase().includes('not all refs are readable')
+    ) {
+      throw new GithubIntegrationProviderError(
+        'provider-rejected',
+        UNREADABLE_PULL_REQUEST_REFS_MESSAGE,
+        undefined,
+        error.status,
+      );
+    }
+    throw error;
   }
 }
 

--- a/libs/api/integration/github/src/core/github-agent-tool-catalog.ts
+++ b/libs/api/integration/github/src/core/github-agent-tool-catalog.ts
@@ -84,6 +84,10 @@ const scopes = {
   pullRequestsRead: [{permission: 'pull_requests', access: 'read'}],
   contentsRead: [{permission: 'contents', access: 'read'}],
   pullRequestsWrite: [{permission: 'pull_requests', access: 'write'}],
+  createPullRequest: [
+    {permission: 'pull_requests', access: 'write'},
+    {permission: 'contents', access: 'read'},
+  ],
   actionsRead: [{permission: 'actions', access: 'read'}],
   actionsWrite: [{permission: 'actions', access: 'write'}],
   checksRead: [{permission: 'checks', access: 'read'}],
@@ -829,7 +833,7 @@ export const githubAgentToolCatalog = [
     description: 'Create a new pull request in a GitHub repository.',
     sensitivity: 'write',
     sensitive: false,
-    requiredScope: scopes.pullRequestsWrite,
+    requiredScope: scopes.createPullRequest,
     inputSchema: repositoryInputSchema(
       {
         title: stringSchema('PR title'),

--- a/libs/api/integration/github/src/core/github-agent-tool-permissions.test.ts
+++ b/libs/api/integration/github/src/core/github-agent-tool-permissions.test.ts
@@ -50,11 +50,12 @@ const graphqlRequirements: Record<string, GithubAppEndpointPermission> = {
 const metadataOnlyRoutes = new Set(['GET /search/issues']);
 
 /**
- * Requirements GitHub applies per media type, which the per-route table cannot express.
- * The pull request diff media type reads file contents and was observed to return 403
- * to a token holding only pull requests read.
+ * Requirements GitHub applies per operation detail, which the per-route table cannot express.
+ * Pull request diffs read file contents, and private pull request creation reads the base and
+ * head refs before GitHub accepts the write.
  */
 const operationRequirements: Record<string, GithubAppEndpointPermission[]> = {
+  create_pull_request: [{permission: 'contents', access: 'read'}],
   'pull_request_read.get_diff': [{permission: 'contents', access: 'read'}],
 };
 

--- a/libs/api/integration/github/src/core/source-control.test.ts
+++ b/libs/api/integration/github/src/core/source-control.test.ts
@@ -1,6 +1,7 @@
 import type {GithubApiClient, GithubRepository} from '#api/client.js';
 import type {GithubCheckoutTokenCachePort} from '#api/github-checkout-token-cache.js';
 import {githubInstallationFactory} from '#test/index.js';
+import {GithubAgentToolsProvider, githubAgentToolCatalog} from './agent-tools.js';
 import {GithubIntegrationProviderError} from './errors.js';
 import {GithubSourceControlProvider} from './source-control.js';
 
@@ -687,6 +688,99 @@ describe('GithubSourceControlProvider', () => {
       expect.any(Function),
       'rejected-generation',
     );
+  });
+
+  it('keeps private checkout and pull request tool credentials independently scoped', async () => {
+    await createInstallation();
+    const github = githubClient({
+      createInstallationAccessToken: vi.fn(() =>
+        Promise.resolve({
+          token: 'checkout-token',
+          expiresAt: new Date('2026-06-10T12:00:00.000Z'),
+          permissions: {contents: 'read' as const},
+          repositories: [CHECKOUT_REPOSITORY],
+        }),
+      ),
+    });
+    const getOrMint = vi.fn<GithubCheckoutTokenCachePort['getOrMint']>(async (_scope, mint) => {
+      const minted = await mint();
+      return {
+        token: minted.token,
+        expiresAt: minted.expiresAt,
+        generation: 'checkout-generation',
+      };
+    });
+    const checkoutProvider = new GithubSourceControlProvider(github, undefined, {getOrMint});
+    const getInstallationAccessToken = vi.fn(() =>
+      Promise.resolve({
+        token: 'pull-request-tool-token',
+        expiresAt: new Date('2026-06-10T12:00:00.000Z'),
+        permissions: {
+          contents: 'read' as const,
+          pull_requests: 'write' as const,
+        },
+      }),
+    );
+    const request = vi.fn(() => Promise.resolve({data: {number: 7}}));
+    const agentToolsProvider = new GithubAgentToolsProvider({
+      getInstallationByConnectionId: vi.fn(() =>
+        Promise.resolve(
+          githubInstallationFactory.build({
+            connectionId,
+            installationId: String(installationId),
+          }),
+        ),
+      ),
+      tokenProvider: {getInstallationAccessToken},
+      createClient: vi.fn(() => ({request})),
+    });
+
+    const checkoutCredentials = await checkoutProvider.createCheckoutCredentials({
+      connection: connection(),
+      externalRepositoryId: 'github:42',
+      permissions: {contents: 'read'},
+    });
+    expect(getInstallationAccessToken).not.toHaveBeenCalled();
+
+    const createPullRequest = githubAgentToolCatalog.find(
+      (entry) => entry.id === 'create_pull_request',
+    );
+    if (!createPullRequest) throw new Error('Missing create_pull_request tool');
+    const session = await agentToolsProvider.openSession({
+      connection: connection(),
+      tools: [createPullRequest],
+      scope: undefined,
+    });
+    const pullRequest = await session.call({
+      toolId: 'create_pull_request',
+      arguments: {
+        owner: 'shipfox',
+        repo: 'platform',
+        title: 'Title',
+        head: 'feature',
+        base: 'main',
+      },
+    });
+
+    expect(checkoutCredentials.token).toBe('checkout-token');
+    expect(pullRequest).toMatchObject({structuredContent: {pull_request: {number: 7}}});
+    expect(github.createInstallationAccessToken).toHaveBeenCalledWith({
+      installationId,
+      repositoryId: 42,
+      permissions: {contents: 'read'},
+    });
+    expect(getOrMint).toHaveBeenCalledOnce();
+    expect(getInstallationAccessToken).toHaveBeenCalledWith(installationId, undefined, {
+      contents: 'read',
+      pull_requests: 'write',
+    });
+    expect(request).toHaveBeenCalledWith('POST /repos/{owner}/{repo}/pulls', {
+      owner: 'shipfox',
+      repo: 'platform',
+      title: 'Title',
+      head: 'feature',
+      base: 'main',
+    });
   });
 
   it('does not return a rejected generation', async () => {


### PR DESCRIPTION
GitHub validates a pull request's base and head refs before accepting the create request. The existing tool credential only had pull request write access, so GitHub returned `not all refs are readable` for private repositories.

This gives the existing `create_pull_request` operation the minimum additional `contents:read` permission. Checkout credentials and agent-tool credentials remain independently scoped and cached, and neither credential gains permissions outside its role. Unreadable refs now produce a stable, actionable provider rejection instead of an opaque retry loop.

Validation:

- `mise exec -- turbo check type test --filter=@shipfox/api-integration-github...`
- `mise exec -- turbo check type test --filter=@shipfox/e2e-flow-workflows`
- Focused `create_pull_request` workflow E2E
- Changeset status and diff checks

Closes ENG-2037


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Grants `create_pull_request` credentials `contents:read` access so GitHub can validate private base and head refs when creating pull requests.

Previously the tool requested only `pull_requests:write`, and GitHub rejected private-repo PR creation with HTTP 422 `not all refs are readable`, causing an opaque retry loop. The tool now requests `contents:read` alongside `pull_requests:write`.

- Checkout credentials and agent-tool credentials stay independently scoped and cached; neither gains permissions outside its role.
- Unreadable refs now return a stable, non-retryable provider rejection with guidance to verify refs and the app's Contents read permission.
- Other PR validation failures, like "No commits between...", still surface with their original message.

Closes ENG-2037.

<sup>Written for commit c8f135b72c0ef422ce4290c372d65e5b34139af6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1754?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

