### PR TITLE
[api-integration-github] Use full installation access for backend GitHub tools

### DIFF
--- a/.changeset/full-installation-token.md
+++ b/.changeset/full-installation-token.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-integration-github": patch
+---
+
+Use the full GitHub installation grant for backend agent tools.

--- a/apps/docs/content/docs/integrations/github/index.mdx
+++ b/apps/docs/content/docs/integrations/github/index.mdx
@@ -4,7 +4,7 @@ sidebarTitle: "Overview"
 description: "Connect GitHub repositories for project code, event triggers, and workflow tools."
 catalog:
   name: "GitHub"
-  summary: "Connect repositories, receive events, and call scoped GitHub tools from workflows."
+  summary: "Connect repositories, receive events, and call authorized GitHub tools from workflows."
   capabilities: ["source_control", "events", "agent_tools"]
   categories: ["source-control"]
   aliases: ["git", "vcs", "ci"]
@@ -15,6 +15,11 @@ catalog:
 
 Shipfox connects through a GitHub App. Install the App on the target account or
 organization. Grant it access only to the repositories Shipfox needs.
+
+Backend GitHub agent tools use the full access granted to the installation. Shipfox
+still authorizes the caller, selected tool and method, write access, inputs, and
+declared repository target. Runner checkout credentials remain scoped to the
+repository being checked out.
 
 ## Repository access
 

--- a/apps/docs/content/docs/integrations/github/tools.mdx
+++ b/apps/docs/content/docs/integrations/github/tools.mdx
@@ -22,12 +22,20 @@ fields](/reference/workflow-schema#agent-integration-fields).
 
 ## Tool catalog
 
-Grant the GitHub App only the repository permissions required by selected tools.
-The catalog states each tool's read or write sensitivity and its required GitHub
-permissions. An agent step's `integrations` entry must set `allow_write: true`
-to include a write tool such as `merge_pull_request`, or Shipfox rejects the
-step at validation. A tool step needs no flag: naming the write tool is the
-choice.
+The permission fields in this catalog are advisory provider requirements. Backend
+GitHub agent tools use the full access granted to the GitHub App installation, and
+GitHub determines whether the requested operation is permitted. Shipfox still
+checks the caller, selected tool and method, write access, inputs, and declared
+repository target.
+
+Authorized `create_commit` calls can write files under `.github/workflows/`. Those
+writes reach GitHub, which returns success or denial based on the installation's
+grants and repository rules. They do not use a separate workflow-file switch.
+
+Write tools (for example `create_branch` and `merge_pull_request`) in an agent
+step require the workflow step's `integrations` entry to set `allow_write: true`;
+without it, Shipfox rejects the step at validation. A tool step needs no flag:
+naming the write tool is the choice.
 
 The generated catalog also states each operation's repository classification:
 

--- a/docs/adr/0017-github-backend-tool-authorization.md
+++ b/docs/adr/0017-github-backend-tool-authorization.md
@@ -1,0 +1,56 @@
+# Architecture decision record 0017: Full installation access for backend GitHub tools
+
+- **Status:** Accepted.
+- **Date:** 2026-09-09.
+- **Decision owners:** Integrations and Agent maintainers.
+- **Linear issue:** [ENG-2038](https://linear.app/shipfox/issue/ENG-2038/use-full-installation-access-for-backend-github-tools).
+- **Related:** [GitHub authorization product spec](https://linear.app/shipfox/document/github-backend-tool-authorization-product-spec-f3053280d42e), [GitHub authorization system design](https://linear.app/shipfox/document/github-backend-tool-authorization-system-design-f56109f0d2cb), and the [GitHub agent-tool catalog](../../libs/api/integration/github/src/core/github-agent-tool-catalog.ts).
+
+## Context
+
+Backend GitHub tools previously derived a permission profile from selected catalog
+entries and performed a local permission preflight from the minted token metadata.
+That narrowed token could reject an operation that GitHub would allow. It also
+blocked workflow-file commits before GitHub could apply its own installation and
+repository rules.
+
+The tool catalog remains useful for documenting provider requirements, but its
+permission fields cannot be the credential or authorization boundary.
+
+## Decision
+
+Backend GitHub tools request the existing full installation access token with the
+installation ID only. They do not derive token permissions, repository selectors,
+or permission fingerprints from selected tools. Existing cache identity, persisted
+keys, locking, and provider signatures remain unchanged.
+
+The catalog's `requiredScope` and `alternativeScopes` fields remain published as
+advisory metadata for documentation and diagnostics. GitHub is the authority for
+provider permission decisions. Authorized workflow-file writes reach GitHub and
+surface its success or denial without a local workflow-file preflight.
+
+Shipfox continues to authorize the caller, workspace, connection, selected tools
+and methods, write access, arguments, and declared repository targets before the
+provider call. Checkout credentials keep their existing exact repository scope.
+Provider operation denials are not token-mint failures: they do not invalidate,
+remint, or replay the write.
+
+## Consequences
+
+Installation grants are the effective provider credential boundary, so the
+installation must be configured with the intended access. Shipfox authorization
+checks remain necessary to prevent an otherwise valid installation token from
+being used outside the workflow's selected scope. Mixed-version deployments can
+temporarily contain replicas using the previous token behavior.
+
+Error mapping distinguishes Shipfox validation from provider outcomes and only
+classifies a permission denial as `access-denied` when GitHub supplies evidence for
+that classification. Ambiguous provider responses remain provider rejections.
+
+## Non-goals
+
+This decision adds no tools, settings, GitHub App grants, repository semantics, or
+checkout scope. Removal of obsolete permission-profile cache data is handled by
+[ENG-2039](https://linear.app/shipfox/issue/ENG-2039/remove-obsolete-github-tool-permission-profile-cache-data),
+and shared-cache cleanup follows in
+[ENG-2040](https://linear.app/shipfox/issue/ENG-2040/remove-obsolete-github-tool-permission-profile-cache-keys).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -26,6 +26,7 @@ documentation model and other engineering sources, start with the
 | [0014: Admin user impersonation](0014-admin-user-impersonation.md) | Accepted; amends ADR 0001; supersedes the private 2026-07-27 "User impersonation" non-goal by reference | The access-token-only session model, renewal semantics, the administrator-authority and durable-artefact hardening rules, and capability placement. |
 | [0015: Usage context and application seams](0015-usage-context-and-application-seams.md) | Accepted; amends ADR 0001 and ADR 0002 | The Usage bounded context and its per-entity scope, the `usagePricing` client seam, the workflow admission policy seam, and the server-only admission decision. |
 | [0016: Workflow run concurrency](0016-workflow-run-concurrency.md) | Proposed | Workflow group scope, latest-wins arbitration, dev isolation, waiting and rerun behavior, unordered integration delivery, lock order, and cancellation boundaries. |
+| [0017: Full installation access for backend GitHub tools](0017-github-backend-tool-authorization.md) | Accepted | Backend GitHub agent-tool credential boundaries, authorization split, provider-error handling, and workflow-file writes. |
 
 When a decision changes, add a new ADR that supersedes or amends the earlier
 record. Keep the original record intact so readers can understand why the

--- a/e2e/suites/flow/workflows/tests/github-agent-tools.e2e.ts
+++ b/e2e/suites/flow/workflows/tests/github-agent-tools.e2e.ts
@@ -268,7 +268,7 @@ test('enforces selected GitHub authorization for deterministic tools', async ({
         authorization: expect.any(String),
         tokenFormatOverride: 'enabled',
         installationId: fixture.installationId,
-        body: {permissions: {issues: 'read'}},
+        body: {},
       },
       {
         kind: 'read-issue',
@@ -392,7 +392,7 @@ test('allows an all-mode GitHub tool target outside Shipfox projects', async ({
         authorization: expect.any(String),
         tokenFormatOverride: 'enabled',
         installationId: fixture.installationId,
-        body: {permissions: {issues: 'read'}},
+        body: {},
       },
       {
         kind: 'read-issue',

--- a/e2e/suites/flow/workflows/tests/github-agent-tools.e2e.ts
+++ b/e2e/suites/flow/workflows/tests/github-agent-tools.e2e.ts
@@ -191,7 +191,7 @@ for (const tokenCase of GITHUB_TOKEN_CASES) {
           authorization: expect.stringMatching(BEARER_AUTHORIZATION),
           tokenFormatOverride: 'enabled',
           installationId,
-          body: {permissions: {issues: 'write', pull_requests: 'write'}},
+          body: {},
         },
         {
           kind: 'read-issue',

--- a/libs/api/integration/github/src/api/client.test.ts
+++ b/libs/api/integration/github/src/api/client.test.ts
@@ -229,7 +229,7 @@ describe('OctokitGithubApiClient.getBotUser', () => {
 });
 
 describe('mapGithubError', () => {
-  it.each([400, 409, 422])('maps HTTP %i to a terminal provider rejection', async (status) => {
+  it.each([400, 404, 409, 422])('maps HTTP %i to a terminal provider rejection', async (status) => {
     const error = new RequestErrorMock(`GitHub rejected request with HTTP ${status}`, status);
 
     const result = mapGithubError(() => Promise.reject(error));
@@ -255,13 +255,13 @@ describe('mapGithubError', () => {
     });
   });
 
-  it('keeps the provider message when a denial carries no accepted-permissions header', async () => {
+  it('keeps an ambiguous 403 as a provider rejection', async () => {
     const error = new RequestErrorMock('Resource not accessible by integration', 403);
 
     const result = mapGithubError(() => Promise.reject(error));
 
     await expect(result).rejects.toMatchObject({
-      reason: 'access-denied',
+      reason: 'provider-rejected',
       message: 'Resource not accessible by integration',
     });
   });

--- a/libs/api/integration/github/src/api/client.ts
+++ b/libs/api/integration/github/src/api/client.ts
@@ -228,8 +228,9 @@ class OctokitGithubApiClient implements GithubApiClient, GithubBotUserClient {
   }
 
   async getInstallation(installationId: number): Promise<GithubInstallationDetails> {
-    const response = await mapGithubError(() =>
-      this.getApp().octokit.rest.apps.getInstallation({installation_id: installationId}),
+    const response = await mapGithubError(
+      () => this.getApp().octokit.rest.apps.getInstallation({installation_id: installationId}),
+      'installation-not-found',
     );
     const data = response.data;
     const account = data.account;
@@ -259,15 +260,18 @@ class OctokitGithubApiClient implements GithubApiClient, GithubBotUserClient {
     limit: number;
     cursor?: string | undefined;
   }): Promise<GithubRepositoryPage> {
-    const octokit = await mapGithubError(() =>
-      getGithubInstallationOctokit(this.getApp(), input.installationId),
+    const octokit = await mapGithubError(
+      () => getGithubInstallationOctokit(this.getApp(), input.installationId),
+      'installation-not-found',
     );
     const page = cursorToPage(input.cursor);
-    const response = await mapGithubError(() =>
-      octokit.rest.apps.listReposAccessibleToInstallation({
-        per_page: input.limit,
-        page,
-      }),
+    const response = await mapGithubError(
+      () =>
+        octokit.rest.apps.listReposAccessibleToInstallation({
+          per_page: input.limit,
+          page,
+        }),
+      'installation-not-found',
     );
 
     return {
@@ -280,14 +284,17 @@ class OctokitGithubApiClient implements GithubApiClient, GithubBotUserClient {
     installationId: number;
     repositoryId: number;
   }): Promise<GithubRepository> {
-    const octokit = await mapGithubError(() =>
-      getGithubInstallationOctokit(this.getApp(), input.installationId),
+    const octokit = await mapGithubError(
+      () => getGithubInstallationOctokit(this.getApp(), input.installationId),
+      'installation-not-found',
     );
-    const response = await mapGithubError(() =>
-      octokit.request('GET /repositories/{repository_id}', {
-        repository_id: input.repositoryId,
-        request: {signal: AbortSignal.timeout(GITHUB_API_TIMEOUT_MS)},
-      }),
+    const response = await mapGithubError(
+      () =>
+        octokit.request('GET /repositories/{repository_id}', {
+          repository_id: input.repositoryId,
+          request: {signal: AbortSignal.timeout(GITHUB_API_TIMEOUT_MS)},
+        }),
+      'repository-not-found',
     );
 
     return toGithubRepository(response.data);
@@ -301,8 +308,9 @@ class OctokitGithubApiClient implements GithubApiClient, GithubBotUserClient {
     limit: number;
     cursor?: string | undefined;
   }): Promise<GithubFilePage> {
-    const octokit = await mapGithubError(() =>
-      getGithubInstallationOctokit(this.getApp(), input.installationId),
+    const octokit = await mapGithubError(
+      () => getGithubInstallationOctokit(this.getApp(), input.installationId),
+      'installation-not-found',
     );
     const repository = await this.getRepository({
       installationId: input.installationId,
@@ -381,8 +389,9 @@ class OctokitGithubApiClient implements GithubApiClient, GithubBotUserClient {
     ref: string;
     path: string;
   }): Promise<GithubFileContent> {
-    const octokit = await mapGithubError(() =>
-      getGithubInstallationOctokit(this.getApp(), input.installationId),
+    const octokit = await mapGithubError(
+      () => getGithubInstallationOctokit(this.getApp(), input.installationId),
+      'installation-not-found',
     );
     const repository = await this.getRepository({
       installationId: input.installationId,
@@ -428,8 +437,9 @@ class OctokitGithubApiClient implements GithubApiClient, GithubBotUserClient {
     repositoryId: number;
     ref: string;
   }): Promise<GithubCommit[]> {
-    const octokit = await mapGithubError(() =>
-      getGithubInstallationOctokit(this.getApp(), input.installationId),
+    const octokit = await mapGithubError(
+      () => getGithubInstallationOctokit(this.getApp(), input.installationId),
+      'installation-not-found',
     );
     const repository = await this.getRepository({
       installationId: input.installationId,
@@ -471,12 +481,14 @@ class OctokitGithubApiClient implements GithubApiClient, GithubBotUserClient {
         'GitHub installation access token request did not include a repository',
       );
     }
-    const response = await mapGithubError(() =>
-      this.getApp().octokit.rest.apps.createInstallationAccessToken({
-        installation_id: input.installationId,
-        ...repositorySelector,
-        permissions: input.permissions ?? {contents: 'read'},
-      }),
+    const response = await mapGithubError(
+      () =>
+        this.getApp().octokit.rest.apps.createInstallationAccessToken({
+          installation_id: input.installationId,
+          ...repositorySelector,
+          permissions: input.permissions ?? {contents: 'read'},
+        }),
+      'repository-not-found',
     );
 
     if (typeof response.data.token !== 'string') {
@@ -627,7 +639,7 @@ export async function mapGithubError<T>(
     | 'installation-not-found'
     | 'file-not-found'
     | 'ref-not-found'
-    | 'provider-rejected' = 'repository-not-found',
+    | 'provider-rejected' = 'provider-rejected',
 ): Promise<T> {
   try {
     return await operation();
@@ -659,9 +671,11 @@ function mapGithubRequestError(
   } else if (error.status === 429 || isGithubRateLimitError(error)) {
     reason = 'rate-limited';
     retryAfter = retryAfterSeconds(error);
-  } else if (error.status === 401 || error.status === 403) {
+  } else if (error.status === 401 || isGithubAccessDenied(error)) {
     reason = 'access-denied';
     retryAfter = retryAfterSeconds(error);
+  } else if (error.status === 403) {
+    reason = 'provider-rejected';
   } else if (error.status >= 500) {
     reason = 'provider-unavailable';
   } else if (error.status >= 400) {
@@ -674,9 +688,19 @@ function mapGithubRequestError(
 // GitHub names the grants that would have satisfied a denied request in this header. It is
 // the only way to tell a missing permission apart from a resource the token cannot see.
 function withAcceptedPermissions(error: RequestError): string {
-  const accepted = error.response?.headers['x-accepted-github-permissions'];
-  if (typeof accepted !== 'string' || accepted.length === 0) return error.message;
+  const accepted = acceptedGithubPermissions(error);
+  if (accepted === undefined) return error.message;
   return `${error.message} (GitHub accepts permissions: ${accepted})`;
+}
+
+function acceptedGithubPermissions(error: RequestError): string | undefined {
+  const accepted = error.response?.headers['x-accepted-github-permissions'];
+  if (typeof accepted !== 'string' || accepted.trim().length === 0) return undefined;
+  return accepted.trim();
+}
+
+function isGithubAccessDenied(error: RequestError): boolean {
+  return error.status === 403 && acceptedGithubPermissions(error) !== undefined;
 }
 
 function isGithubTimeoutError(error: unknown): boolean {

--- a/libs/api/integration/github/src/core/agent-tools.test.ts
+++ b/libs/api/integration/github/src/core/agent-tools.test.ts
@@ -1254,7 +1254,7 @@ describe('github agent tool catalog', () => {
     expect(request).not.toHaveBeenCalled();
   });
 
-  it('derives the token profile from live catalog ids and method allowlists', async () => {
+  it('applies live catalog authorization without deriving a token profile', async () => {
     const request = vi.fn(() => Promise.resolve({data: {number: 1}}));
     const getInstallationAccessToken = vi.fn(() =>
       Promise.resolve({
@@ -1334,13 +1334,10 @@ describe('github agent tool catalog', () => {
       }),
     ).resolves.toMatchObject({structuredContent: {number: 1}});
 
-    expect(getInstallationAccessToken).toHaveBeenCalledWith(1, undefined, {
-      contents: 'write',
-      issues: 'read',
-    });
+    expect(getInstallationAccessToken).toHaveBeenCalledWith(1);
   });
 
-  it('requests issue and pull request write access for issue comments', async () => {
+  it('uses the full installation token for issue comments', async () => {
     const request = vi.fn(() => Promise.resolve({data: {id: 7}}));
     const getInstallationAccessToken = vi.fn(() =>
       Promise.resolve({
@@ -1378,13 +1375,10 @@ describe('github agent tool catalog', () => {
     });
 
     expect(result).toMatchObject({structuredContent: {id: 7}});
-    expect(getInstallationAccessToken).toHaveBeenCalledWith(1, undefined, {
-      issues: 'write',
-      pull_requests: 'write',
-    });
+    expect(getInstallationAccessToken).toHaveBeenCalledWith(1);
   });
 
-  it('keeps the strongest permission when selected tools share a scope', async () => {
+  it('does not derive a token profile from selected tool scopes', async () => {
     const request = vi.fn(() => Promise.resolve({data: {number: 1}}));
     const getInstallationAccessToken = vi.fn(() =>
       Promise.resolve({
@@ -1415,10 +1409,10 @@ describe('github agent tool catalog', () => {
       }),
     ).resolves.toMatchObject({structuredContent: {number: 1}});
 
-    expect(getInstallationAccessToken).toHaveBeenCalledWith(1, undefined, {issues: 'write'});
+    expect(getInstallationAccessToken).toHaveBeenCalledWith(1);
   });
 
-  it('uses the full integration scope for a single-tool session profile', async () => {
+  it('ignores frozen tool scope when requesting the full installation token', async () => {
     const request = vi.fn(() => Promise.resolve({data: {number: 1}}));
     const getInstallationAccessToken = vi.fn(() =>
       Promise.resolve({
@@ -1449,10 +1443,10 @@ describe('github agent tool catalog', () => {
       }),
     ).resolves.toMatchObject({structuredContent: {number: 1}});
 
-    expect(getInstallationAccessToken).toHaveBeenCalledWith(1, undefined, {issues: 'write'});
+    expect(getInstallationAccessToken).toHaveBeenCalledWith(1);
   });
 
-  it('requests checks read for check-run reads', async () => {
+  it('uses the full installation token for check-run reads', async () => {
     const request = vi.fn(() => Promise.resolve({data: {total_count: 1}}));
     const getInstallationAccessToken = vi.fn(() =>
       Promise.resolve({
@@ -1493,10 +1487,10 @@ describe('github agent tool catalog', () => {
       }),
     ).resolves.toMatchObject({structuredContent: {total_count: 1}});
 
-    expect(getInstallationAccessToken).toHaveBeenCalledWith(1, undefined, {checks: 'read'});
+    expect(getInstallationAccessToken).toHaveBeenCalledWith(1);
   });
 
-  it('requests contents read for pull request diffs', async () => {
+  it('uses the full installation token for pull request diffs', async () => {
     const request = vi.fn(() => Promise.resolve({data: 'diff --git a/file b/file'}));
     const getInstallationAccessToken = vi.fn(() =>
       Promise.resolve({
@@ -1529,22 +1523,21 @@ describe('github agent tool catalog', () => {
       }),
     ).resolves.toMatchObject({structuredContent: {result: 'diff --git a/file b/file'}});
 
-    expect(getInstallationAccessToken).toHaveBeenCalledWith(1, undefined, {contents: 'read'});
+    expect(getInstallationAccessToken).toHaveBeenCalledWith(1);
   });
 
-  it('denies a pull request diff when the token lacks contents read', async () => {
-    const request = vi.fn();
+  it('sends a pull request diff to GitHub when token metadata is incomplete', async () => {
+    const request = vi.fn(() => Promise.resolve({data: 'diff --git a/file b/file'}));
+    const getInstallationAccessToken = vi.fn(() =>
+      Promise.resolve({
+        token: 'installation-token',
+        expiresAt: new Date(),
+        permissions: {pull_requests: 'read' as const},
+      }),
+    );
     const provider = new GithubAgentToolsProvider({
       getInstallationByConnectionId: vi.fn(() => Promise.resolve(installation())),
-      tokenProvider: {
-        getInstallationAccessToken: vi.fn(() =>
-          Promise.resolve({
-            token: 'installation-token',
-            expiresAt: new Date(),
-            permissions: {pull_requests: 'read' as const},
-          }),
-        ),
-      },
+      tokenProvider: {getInstallationAccessToken},
       createClient: vi.fn(() => ({request})),
     });
     const session = await provider.openSession({
@@ -1558,20 +1551,12 @@ describe('github agent tool catalog', () => {
       arguments: {method: 'get_diff', owner: 'shipfox', repo: 'platform', pull_number: 1},
     });
 
-    expect(request).not.toHaveBeenCalled();
-    expect(result).toEqual({
-      isError: true,
-      content: [
-        {
-          type: 'text',
-          text: 'GitHub installation token is missing permission for this operation: pull_request_read requires contents: read',
-        },
-      ],
-      structuredContent: {code: 'access-denied'},
-    });
+    expect(request).toHaveBeenCalledOnce();
+    expect(result).toMatchObject({structuredContent: {result: 'diff --git a/file b/file'}});
+    expect(getInstallationAccessToken).toHaveBeenCalledWith(1);
   });
 
-  it('requests commit statuses read for combined status reads', async () => {
+  it('uses the full installation token for combined status reads', async () => {
     const request = vi.fn(() => Promise.resolve({data: {state: 'success'}}));
     const getInstallationAccessToken = vi.fn(() =>
       Promise.resolve({
@@ -1616,13 +1601,15 @@ describe('github agent tool catalog', () => {
       pull_number: 1,
       ref: 'abc123',
     });
-    expect(getInstallationAccessToken).toHaveBeenCalledWith(1, undefined, {statuses: 'read'});
+    expect(getInstallationAccessToken).toHaveBeenCalledWith(1);
   });
 
   it.each([
     {label: 'pull_requests read', permissions: {pull_requests: 'read' as const}},
     {label: 'issues read', permissions: {issues: 'read' as const}},
-  ])('reads pull request timeline comments with $label', async ({permissions}) => {
+  ])('reads pull request timeline comments with incomplete token metadata: $label', async ({
+    permissions,
+  }) => {
     const request = vi.fn(() => Promise.resolve({data: [{id: 1}]}));
     const provider = new GithubAgentToolsProvider({
       getInstallationByConnectionId: vi.fn(() => Promise.resolve(installation())),
@@ -1660,19 +1647,18 @@ describe('github agent tool catalog', () => {
     );
   });
 
-  it('names the alternative grant when pull request timeline comments are denied', async () => {
-    const request = vi.fn();
+  it('does not preflight timeline comments from token metadata', async () => {
+    const request = vi.fn(() => Promise.resolve({data: [{id: 1}]}));
+    const getInstallationAccessToken = vi.fn(() =>
+      Promise.resolve({
+        token: 'installation-token',
+        expiresAt: new Date(),
+        permissions: {checks: 'read' as const},
+      }),
+    );
     const provider = new GithubAgentToolsProvider({
       getInstallationByConnectionId: vi.fn(() => Promise.resolve(installation())),
-      tokenProvider: {
-        getInstallationAccessToken: vi.fn(() =>
-          Promise.resolve({
-            token: 'installation-token',
-            expiresAt: new Date(),
-            permissions: {checks: 'read' as const},
-          }),
-        ),
-      },
+      tokenProvider: {getInstallationAccessToken},
       createClient: vi.fn(() => ({request})),
     });
     const pullRequestRead = githubAgentToolCatalog.find(
@@ -1690,17 +1676,9 @@ describe('github agent tool catalog', () => {
       arguments: {method: 'get_comments', owner: 'shipfox', repo: 'platform', pull_number: 1},
     });
 
-    expect(request).not.toHaveBeenCalled();
-    expect(result).toEqual({
-      isError: true,
-      content: [
-        {
-          type: 'text',
-          text: 'GitHub installation token is missing permission for this operation: pull_request_read requires pull_requests: read (or issues: read)',
-        },
-      ],
-      structuredContent: {code: 'access-denied'},
-    });
+    expect(request).toHaveBeenCalledOnce();
+    expect(result).toMatchObject({structuredContent: {result: [{id: 1}]}});
+    expect(getInstallationAccessToken).toHaveBeenCalledWith(1);
   });
 
   it('removes a sub-issue through the singular endpoint with the child id in the body', async () => {
@@ -2004,8 +1982,13 @@ describe('github agent tool catalog', () => {
     });
   });
 
-  it('rejects workflow file changes when the token lacks workflows write', async () => {
-    const graphql = vi.fn();
+  it('sends authorized workflow file changes to GitHub', async () => {
+    const oid = '0'.repeat(40);
+    const graphql = vi.fn().mockResolvedValueOnce({
+      createCommitOnBranch: {
+        commit: {oid, url: `https://github.com/shipfox/platform/commit/${oid}`},
+      },
+    });
     const provider = createAgentToolsProvider({request: vi.fn(), graphql});
     const session = await provider.openSession({
       connection: connection(),
@@ -2024,25 +2007,11 @@ describe('github agent tool catalog', () => {
       },
     });
 
-    expect(graphql).not.toHaveBeenCalled();
-    expect(result).toEqual({
-      isError: true,
-      content: [
-        {
-          type: 'text',
-          text: 'GitHub installation token is missing permission for this operation: create_commit requires workflows: write to change .github/workflows/ci.yml',
-        },
-      ],
-      structuredContent: {code: 'access-denied'},
-    });
+    expect(graphql).toHaveBeenCalledOnce();
+    expect(result).toMatchObject({structuredContent: {commit: {oid}}});
   });
 
   it.each([
-    {
-      label: 'a deleted workflow file',
-      changes: {deletions: [{path: '.github/workflows/old.yml'}]},
-      code: 'access-denied',
-    },
     {
       label: 'a relative workflow path',
       changes: {additions: [{path: './.github/workflows/ci.yml', contents: 'name: ci\n'}]},
@@ -2053,7 +2022,7 @@ describe('github agent tool catalog', () => {
       changes: {additions: [{path: 'docs/../.github/workflows/ci.yml', contents: 'name: ci\n'}]},
       code: 'invalid-request',
     },
-  ])('rejects $label when the token lacks workflows write', async ({changes, code}) => {
+  ])('rejects $label before GitHub', async ({changes, code}) => {
     const graphql = vi.fn();
     const provider = createAgentToolsProvider({request: vi.fn(), graphql});
     const session = await provider.openSession({
@@ -2077,19 +2046,19 @@ describe('github agent tool catalog', () => {
     expect(result).toMatchObject({isError: true, structuredContent: {code}});
   });
 
-  it('denies workflow file commits under the production create_commit profile', async () => {
-    const graphql = vi.fn();
-    const getInstallationAccessToken = vi.fn(
-      (
-        _installationId: number,
-        _permissionFingerprint?: string,
-        permissions?: Record<string, 'read' | 'write'>,
-      ) =>
-        Promise.resolve({
-          token: 'installation-token',
-          expiresAt: new Date(),
-          permissions: permissions ?? {},
-        }),
+  it('sends workflow file commits when token metadata is incomplete', async () => {
+    const oid = '0'.repeat(40);
+    const graphql = vi.fn().mockResolvedValueOnce({
+      createCommitOnBranch: {
+        commit: {oid, url: `https://github.com/shipfox/platform/commit/${oid}`},
+      },
+    });
+    const getInstallationAccessToken = vi.fn(() =>
+      Promise.resolve({
+        token: 'installation-token',
+        expiresAt: new Date(),
+        permissions: {},
+      }),
     );
     const provider = new GithubAgentToolsProvider({
       getInstallationByConnectionId: vi.fn(() => Promise.resolve(installation())),
@@ -2113,53 +2082,9 @@ describe('github agent tool catalog', () => {
       },
     });
 
-    // The live profile never requests workflows, so the allow path stays closed until the
-    // catalog scope declares it.
-    expect(getInstallationAccessToken).toHaveBeenCalledWith(1, undefined, {contents: 'write'});
-    expect(graphql).not.toHaveBeenCalled();
-    expect(result).toMatchObject({isError: true, structuredContent: {code: 'access-denied'}});
-  });
-
-  it('commits workflow file changes only when the minted token carries workflows write', async () => {
-    const oid = '0'.repeat(40);
-    const graphql = vi.fn().mockResolvedValueOnce({
-      createCommitOnBranch: {
-        commit: {oid, url: `https://github.com/shipfox/platform/commit/${oid}`},
-      },
-    });
-    const provider = new GithubAgentToolsProvider({
-      getInstallationByConnectionId: vi.fn(() => Promise.resolve(installation())),
-      tokenProvider: {
-        getInstallationAccessToken: vi.fn(() =>
-          Promise.resolve({
-            token: 'installation-token',
-            expiresAt: new Date(),
-            permissions: {contents: 'write' as const, workflows: 'write' as const},
-          }),
-        ),
-      },
-      createClient: vi.fn(() => ({request: vi.fn(), graphql})),
-    });
-    const session = await provider.openSession({
-      connection: connection(),
-      tools: [createCommitTool()],
-      scope: undefined,
-    });
-
-    await expect(
-      session.call({
-        toolId: 'create_commit',
-        arguments: {
-          repository: 'shipfox/platform',
-          branch: 'feature',
-          expected_head_oid: 'a'.repeat(40),
-          message: {headline: 'Remove CI'},
-          deletions: [{path: '.github/workflows/old.yml'}],
-        },
-      }),
-    ).resolves.toMatchObject({structuredContent: {commit: {oid}}});
-
+    expect(getInstallationAccessToken).toHaveBeenCalledWith(1);
     expect(graphql).toHaveBeenCalledOnce();
+    expect(result).toMatchObject({structuredContent: {commit: {oid}}});
   });
 
   it('returns artifact download metadata without buffering archive bytes', async () => {
@@ -3021,18 +2946,26 @@ describe('github agent tool catalog', () => {
     expect(graphql).not.toHaveBeenCalled();
   });
 
-  it('rejects a create_commit call when the installation lacks contents write', async () => {
+  it('sends create_commit to GitHub when token metadata is incomplete', async () => {
+    const oid = '0'.repeat(40);
+    const graphql = vi.fn().mockResolvedValueOnce({
+      createCommitOnBranch: {
+        commit: {oid, url: `https://github.com/shipfox/platform/commit/${oid}`},
+      },
+    });
+    const getInstallationAccessToken = vi.fn(() =>
+      Promise.resolve({
+        token: 'installation-token',
+        expiresAt: new Date(),
+        permissions: {issues: 'write' as const, pull_requests: 'write' as const},
+      }),
+    );
     const provider = new GithubAgentToolsProvider({
       getInstallationByConnectionId: vi.fn(() => Promise.resolve(installation())),
       tokenProvider: {
-        getInstallationAccessToken: vi.fn(() =>
-          Promise.resolve({
-            token: 'installation-token',
-            expiresAt: new Date(),
-            permissions: {issues: 'write' as const, pull_requests: 'write' as const},
-          }),
-        ),
+        getInstallationAccessToken,
       },
+      createClient: vi.fn(() => ({request: vi.fn(), graphql})),
     });
     const session = await provider.openSession({
       connection: connection(),
@@ -3051,16 +2984,9 @@ describe('github agent tool catalog', () => {
       },
     });
 
-    expect(result).toEqual({
-      isError: true,
-      content: [
-        {
-          type: 'text',
-          text: 'GitHub installation token is missing permission for this operation: create_commit requires contents: write',
-        },
-      ],
-      structuredContent: {code: 'access-denied'},
-    });
+    expect(result).toMatchObject({structuredContent: {commit: {oid}}});
+    expect(graphql).toHaveBeenCalledOnce();
+    expect(getInstallationAccessToken).toHaveBeenCalledWith(1);
   });
 
   it('rejects a createCommitOnBranch response without a commit', async () => {
@@ -3393,18 +3319,19 @@ describe('github agent tool catalog', () => {
     });
   });
 
-  it('returns an access-denied code when the installation lacks a required permission', async () => {
+  it('sends issue reads to GitHub when token metadata is incomplete', async () => {
+    const request = vi.fn(() => Promise.resolve({data: []}));
+    const getInstallationAccessToken = vi.fn(() =>
+      Promise.resolve({
+        token: 'installation-token',
+        expiresAt: new Date(),
+        permissions: {},
+      }),
+    );
     const provider = new GithubAgentToolsProvider({
       getInstallationByConnectionId: vi.fn(() => Promise.resolve(installation())),
-      tokenProvider: {
-        getInstallationAccessToken: vi.fn(() =>
-          Promise.resolve({
-            token: 'installation-token',
-            expiresAt: new Date(),
-            permissions: {},
-          }),
-        ),
-      },
+      tokenProvider: {getInstallationAccessToken},
+      createClient: vi.fn(() => ({request})),
     });
     const tool = githubAgentToolCatalog.find((entry) => entry.id === 'list_issues');
     if (!tool) throw new Error('Missing list_issues tool');
@@ -3419,16 +3346,9 @@ describe('github agent tool catalog', () => {
       arguments: {owner: 'shipfox', repo: 'platform'},
     });
 
-    expect(result).toEqual({
-      isError: true,
-      content: [
-        {
-          type: 'text',
-          text: 'GitHub installation token is missing permission for this operation: list_issues requires issues: read',
-        },
-      ],
-      structuredContent: {code: 'access-denied'},
-    });
+    expect(result).toMatchObject({structuredContent: {issues: []}});
+    expect(request).toHaveBeenCalledOnce();
+    expect(getInstallationAccessToken).toHaveBeenCalledWith(1);
   });
 
   it.each([
@@ -3440,9 +3360,10 @@ describe('github agent tool catalog', () => {
       missingPermission: 'pull_requests',
       permissions: {contents: 'write' as const},
     },
-  ])('rejects update_pull_request_branch when $missingPermission write is missing', async ({
+  ])('sends update_pull_request_branch when token metadata is incomplete: $missingPermission', async ({
     permissions,
   }) => {
+    const request = vi.fn(() => Promise.resolve({data: {message: 'Branch updated'}}));
     const provider = new GithubAgentToolsProvider({
       getInstallationByConnectionId: vi.fn(() => Promise.resolve(installation())),
       tokenProvider: {
@@ -3454,6 +3375,7 @@ describe('github agent tool catalog', () => {
           }),
         ),
       },
+      createClient: vi.fn(() => ({request})),
     });
     const tool = githubAgentToolCatalog.find((entry) => entry.id === 'update_pull_request_branch');
     if (!tool) throw new Error('Missing update_pull_request_branch tool');
@@ -3468,19 +3390,11 @@ describe('github agent tool catalog', () => {
       arguments: {owner: 'shipfox', repo: 'platform', pull_number: 1},
     });
 
-    expect(result).toEqual({
-      isError: true,
-      content: [
-        {
-          type: 'text',
-          text: 'GitHub installation token is missing permission for this operation: update_pull_request_branch requires pull_requests: write, contents: write',
-        },
-      ],
-      structuredContent: {code: 'access-denied'},
-    });
+    expect(result).toMatchObject({structuredContent: {message: 'Branch updated'}});
+    expect(request).toHaveBeenCalledOnce();
   });
 
-  it('authorizes update_pull_request_branch when the installation grants both permissions', async () => {
+  it('uses the full installation token for update_pull_request_branch', async () => {
     const request = vi.fn(() => Promise.resolve({data: {message: 'Branch updated'}}));
     const getInstallationAccessToken = vi.fn(() =>
       Promise.resolve({
@@ -3528,10 +3442,7 @@ describe('github agent tool catalog', () => {
       content: [{type: 'text', text: '{"message":"Branch updated"}'}],
       structuredContent: {message: 'Branch updated'},
     });
-    expect(getInstallationAccessToken).toHaveBeenCalledWith(1, undefined, {
-      contents: 'write',
-      pull_requests: 'write',
-    });
+    expect(getInstallationAccessToken).toHaveBeenCalledWith(1);
   });
 
   it('creates a branch from a commit oid through the provider session', async () => {
@@ -3890,18 +3801,27 @@ describe('github agent tool catalog', () => {
     });
   });
 
-  it('returns an access-denied code when the installation lacks contents write permission', async () => {
+  it('sends branch creation to GitHub when token metadata is incomplete', async () => {
+    const request = vi.fn(() =>
+      Promise.resolve({
+        data: {
+          ref: 'refs/heads/feature',
+          url: 'https://api.github.com/repos/shipfox/platform/git/refs/heads/feature',
+          object: {sha: 'aa218f56b14c9653891f9e74264a383fa43fefbd'},
+        },
+      }),
+    );
+    const getInstallationAccessToken = vi.fn(() =>
+      Promise.resolve({
+        token: 'installation-token',
+        expiresAt: new Date(),
+        permissions: {pull_requests: 'write' as const},
+      }),
+    );
     const provider = new GithubAgentToolsProvider({
       getInstallationByConnectionId: vi.fn(() => Promise.resolve(installation())),
-      tokenProvider: {
-        getInstallationAccessToken: vi.fn(() =>
-          Promise.resolve({
-            token: 'installation-token',
-            expiresAt: new Date(),
-            permissions: {pull_requests: 'write' as const},
-          }),
-        ),
-      },
+      tokenProvider: {getInstallationAccessToken},
+      createClient: vi.fn(() => ({request})),
     });
     const tool = githubAgentToolCatalog.find((entry) => entry.id === 'create_branch');
     if (!tool) throw new Error('Missing create_branch tool');
@@ -3920,16 +3840,9 @@ describe('github agent tool catalog', () => {
       },
     });
 
-    expect(result).toEqual({
-      isError: true,
-      content: [
-        {
-          type: 'text',
-          text: 'GitHub installation token is missing permission for this operation: create_branch requires contents: write',
-        },
-      ],
-      structuredContent: {code: 'access-denied'},
-    });
+    expect(result).toMatchObject({structuredContent: {branch: 'feature'}});
+    expect(request).toHaveBeenCalledOnce();
+    expect(getInstallationAccessToken).toHaveBeenCalledWith(1);
   });
 
   it('rejects a repository argument that is not in owner/name form', async () => {
@@ -5061,7 +4974,7 @@ describe('github agent tool catalog', () => {
     ).rejects.toMatchObject({reason: 'provider-rejected', status: 404});
   });
 
-  it('maps a create 404 to repository-not-found', async () => {
+  it('keeps a create 404 as a provider rejection', async () => {
     const providerError = new RequestError('Not Found', 404, {
       request: {
         method: 'POST',
@@ -5083,24 +4996,33 @@ describe('github agent tool catalog', () => {
         },
         request,
       ),
-    ).rejects.toMatchObject({reason: 'repository-not-found', status: 404});
+    ).rejects.toMatchObject({reason: 'provider-rejected', status: 404});
   });
 
-  it('denies check-run calls when the minted token lacks checks write', async () => {
-    const request = vi.fn();
+  it('sends check-run calls when token metadata is incomplete', async () => {
+    const request = vi.fn(() =>
+      Promise.resolve({
+        data: {
+          id: 123456,
+          name: 'Shipfox review',
+          head_sha: 'a'.repeat(40),
+          html_url: 'https://github.com/shipfox/platform/runs/123456',
+          status: 'queued',
+        },
+      }),
+    );
+    const getInstallationAccessToken = vi.fn(() =>
+      Promise.resolve({
+        token: 'installation-token',
+        expiresAt: new Date(),
+        permissions: {checks: 'read' as const},
+      }),
+    );
     const checkRunWrite = githubAgentToolCatalog.find((entry) => entry.id === 'check_run_write');
     if (!checkRunWrite) throw new Error('Missing check-run write catalog entry');
     const provider = new GithubAgentToolsProvider({
       getInstallationByConnectionId: vi.fn(() => Promise.resolve(installation())),
-      tokenProvider: {
-        getInstallationAccessToken: vi.fn(() =>
-          Promise.resolve({
-            token: 'installation-token',
-            expiresAt: new Date(),
-            permissions: {checks: 'read' as const},
-          }),
-        ),
-      },
+      tokenProvider: {getInstallationAccessToken},
       createClient: vi.fn(() => ({request})),
     });
     const session = await provider.openSession({
@@ -5120,11 +5042,9 @@ describe('github agent tool catalog', () => {
       },
     });
 
-    expect(result).toMatchObject({
-      isError: true,
-      structuredContent: {code: 'access-denied'},
-    });
-    expect(request).not.toHaveBeenCalled();
+    expect(result).toMatchObject({structuredContent: {check_run: {id: 123456}}});
+    expect(request).toHaveBeenCalledOnce();
+    expect(getInstallationAccessToken).toHaveBeenCalledWith(1);
   });
 });
 

--- a/libs/api/integration/github/src/core/agent-tools.ts
+++ b/libs/api/integration/github/src/core/agent-tools.ts
@@ -11,7 +11,6 @@ import type {
 import {isValidGitObjectId, MAX_REPOSITORY_FILE_BYTES} from '@shipfox/api-integration-spi';
 import {Octokit} from 'octokit';
 import {mapGithubError} from '#api/client.js';
-import type {GithubInstallationTokenPermissions} from '#api/installation-token-envelope.js';
 import {
   createGithubInstallationTokenProvider,
   type GithubInstallationTokenProvider,
@@ -213,12 +212,6 @@ export class GithubAgentToolsProvider
     }
     const liveCatalog = this.catalog();
     const authorizedTools = intersectGithubToolsWithLiveCatalog(input.tools, liveCatalog);
-    // The core tool-call service opens one-tool sessions, while scope retains
-    // the full frozen integration selection. Aggregate the token profile from
-    // that selection so sequential calls reuse one token profile.
-    const selectedTools = input.scope?.tools ?? input.tools;
-    const profileTools = intersectGithubToolsWithLiveCatalog(selectedTools, liveCatalog);
-    const permissionProfile = githubToolPermissionProfile(profileTools);
     let tokenPromise:
       | ReturnType<GithubInstallationTokenProvider['getInstallationAccessToken']>
       | undefined;
@@ -236,15 +229,8 @@ export class GithubAgentToolsProvider
             ? githubToolError(validationError, 'invalid-request')
             : githubToolError(validationError.message, validationError.code);
         }
-        tokenPromise ??= this.tokenProvider.getInstallationAccessToken(
-          installationId,
-          undefined,
-          permissionProfile.permissions,
-        );
+        tokenPromise ??= this.tokenProvider.getInstallationAccessToken(installationId);
         const token = await tokenPromise;
-        const permissionDenial = githubPermissionDenial(token.permissions ?? {}, tool, call);
-        if (permissionDenial !== undefined)
-          return githubToolError(permissionDenial, 'access-denied');
         const client = (this.options.createClient ?? createOctokitClient)(token.token);
         const method =
           typeof call.arguments.method === 'string' ? call.arguments.method : undefined;
@@ -262,24 +248,27 @@ async function executeGithubToolOperation(
 ): Promise<GithubToolCallResult> {
   const toolId = tool.id as GithubAgentToolId;
   if (operation.kind === 'graphql') {
-    const data = await mapGithubError(() =>
-      executeGithubGraphqlOperation(client, toolId, method, operation.parameters),
+    const data = await mapGithubError(
+      () => executeGithubGraphqlOperation(client, toolId, method, operation.parameters),
+      'provider-rejected',
     );
     return toolId === 'add_comment_to_pending_review'
       ? pendingReviewCommentResult(data)
       : githubToolResult(toolId, data);
   }
-  const parameters = await mapGithubError(() =>
-    resolveGithubOperationParameters(client, operation.parameters, toolId, method),
+  const parameters = await mapGithubError(
+    () => resolveGithubOperationParameters(client, operation.parameters, toolId, method),
+    'provider-rejected',
   );
   if (parameters === undefined) {
     return githubToolError(NO_PENDING_REVIEW_MESSAGE, 'provider-rejected');
   }
   const response =
     toolId === 'check_run_write'
-      ? await executeGithubCheckRunRequest(client, operation.route, parameters, method)
-      : await mapGithubError(() =>
-          executeGithubRestOperation(client, operation.route, parameters, toolId),
+      ? await executeGithubCheckRunRequest(client, operation.route, parameters)
+      : await mapGithubError(
+          () => executeGithubRestOperation(client, operation.route, parameters, toolId),
+          'provider-rejected',
         );
   return githubToolResult(toolId, response.data, response, parameters, operation.route);
 }
@@ -288,12 +277,8 @@ async function executeGithubCheckRunRequest(
   client: GithubToolClient,
   route: string,
   parameters: Record<string, unknown>,
-  method: string | undefined,
 ): Promise<GithubToolResponse> {
-  return await mapGithubError(
-    () => client.request(route, parameters),
-    method === 'update' ? 'provider-rejected' : undefined,
-  );
+  return await mapGithubError(() => client.request(route, parameters), 'provider-rejected');
 }
 
 // GitHub answers a malformed thread position with a null thread and no error, so the
@@ -320,10 +305,6 @@ export interface GithubAgentToolsProviderOptions {
     | undefined;
   tokenProvider?: GithubInstallationTokenProvider | undefined;
   createClient?: GithubToolClientFactory | undefined;
-}
-
-interface GithubToolPermissionProfile {
-  permissions: GithubInstallationTokenPermissions;
 }
 
 interface GithubToolSelection {
@@ -361,43 +342,6 @@ function intersectGithubToolWithLiveCatalog(
   const allowedMethods = new Set(tool.methods.map((method) => method.id));
   const methods = liveTool.methods.filter((method) => allowedMethods.has(method.id));
   return methods.length === 0 ? undefined : {...liveTool, methods};
-}
-
-function githubToolPermissionProfile(
-  authorizedTools: readonly AgentToolCatalogEntry<GithubAgentToolRequiredScope>[],
-): GithubToolPermissionProfile {
-  const permissionsByName = new Map<string, 'read' | 'write'>();
-
-  for (const tool of authorizedTools) {
-    if (tool.methods === undefined) {
-      addGithubRequiredScope(permissionsByName, tool.requiredScope);
-      continue;
-    }
-    for (const method of tool.methods) {
-      addGithubRequiredScope(permissionsByName, method.requiredScope);
-    }
-  }
-
-  const permissions = Object.fromEntries(
-    [...permissionsByName.entries()].sort(([first], [second]) => {
-      if (first < second) return -1;
-      if (first > second) return 1;
-      return 0;
-    }),
-  ) as GithubInstallationTokenPermissions;
-  return {
-    permissions,
-  };
-}
-
-function addGithubRequiredScope(
-  permissions: Map<string, 'read' | 'write'>,
-  requiredScope: GithubAgentToolRequiredScope,
-): void {
-  for (const {permission, access} of requiredScope) {
-    if (permissions.get(permission) === 'write') continue;
-    permissions.set(permission, access);
-  }
 }
 
 export interface GithubToolResponse {
@@ -1106,13 +1050,15 @@ async function createGitBranch(
   const sha = parameters.sha;
   let response: GithubToolResponse;
   try {
-    response = await mapGithubError(() =>
-      client.request('POST /repos/{owner}/{repo}/git/refs', {
-        owner,
-        repo,
-        ref: `refs/heads/${branch}`,
-        sha,
-      }),
+    response = await mapGithubError(
+      () =>
+        client.request('POST /repos/{owner}/{repo}/git/refs', {
+          owner,
+          repo,
+          ref: `refs/heads/${branch}`,
+          sha,
+        }),
+      'provider-rejected',
     );
   } catch (error) {
     if (
@@ -1135,12 +1081,14 @@ async function reconcileExistingBranch(
   sha: unknown,
 ): Promise<GithubToolResponse> {
   try {
-    const existing = await mapGithubError(() =>
-      client.request('GET /repos/{owner}/{repo}/git/ref/heads/{branch}', {
-        owner,
-        repo,
-        branch,
-      }),
+    const existing = await mapGithubError(
+      () =>
+        client.request('GET /repos/{owner}/{repo}/git/ref/heads/{branch}', {
+          owner,
+          repo,
+          branch,
+        }),
+      'provider-rejected',
     );
     const object =
       isRecord(existing.data) && isRecord(existing.data.object) ? existing.data.object : undefined;
@@ -2128,80 +2076,4 @@ function methodRequiredParameters(
   }
 
   return [];
-}
-
-function githubPermissionDeniedMessage(
-  tool: GithubAgentToolCatalogEntry,
-  call: AgentToolCallInput,
-): string {
-  const [required, ...alternatives] = acceptedScopes(tool, call);
-  const alternativeText =
-    alternatives.length === 0 ? '' : ` (or ${alternatives.map(formatGithubScope).join('; ')})`;
-  return `GitHub installation token is missing permission for this operation: ${tool.id} requires ${formatGithubScope(required)}${alternativeText}`;
-}
-
-function formatGithubScope(scope: GithubAgentToolRequiredScope): string {
-  return scope.map(({permission, access}) => `${permission}: ${access}`).join(', ');
-}
-
-/** The declared scope first, then every alternative GitHub documents for the same operation. */
-function acceptedScopes(
-  tool: GithubAgentToolCatalogEntry,
-  call: AgentToolCallInput,
-): readonly [GithubAgentToolRequiredScope, ...GithubAgentToolRequiredScope[]] {
-  const methodId = typeof call.arguments.method === 'string' ? call.arguments.method : undefined;
-  const method = tool.methods?.find((candidate) => candidate.id === methodId);
-  if (method === undefined) return [tool.requiredScope];
-  return [method.requiredScope, ...(method.alternativeScopes ?? [])];
-}
-
-const GITHUB_WORKFLOWS_DIRECTORY = '.github/workflows/';
-
-function githubPermissionDenial(
-  granted: Record<string, 'read' | 'write' | 'admin'>,
-  tool: GithubAgentToolCatalogEntry,
-  call: AgentToolCallInput,
-): string | undefined {
-  if (!hasGrantedPermissions(granted, tool, call)) return githubPermissionDeniedMessage(tool, call);
-  return githubWorkflowsPermissionDenial(tool, call, granted);
-}
-
-// GitHub refuses any commit that adds or changes an Actions workflow file unless the token
-// carries the workflows permission, which no catalog scope requests. Deny locally so the
-// agent gets a deterministic access-denied instead of an opaque provider rejection.
-function githubWorkflowsPermissionDenial(
-  tool: AgentToolCatalogEntry<GithubAgentToolRequiredScope>,
-  call: AgentToolCallInput,
-  granted: Record<string, 'read' | 'write' | 'admin'>,
-): string | undefined {
-  if (tool.id !== 'create_commit') return undefined;
-  if (granted.workflows === 'write' || granted.workflows === 'admin') return undefined;
-  // Argument validation already rejects leading slashes and dot segments, so a plain prefix
-  // test cannot be bypassed by an alternative spelling of the workflows directory.
-  const workflowPath = [
-    ...fileChangePaths(call.arguments.additions),
-    ...fileChangePaths(call.arguments.deletions),
-  ].find((path) => path.startsWith(GITHUB_WORKFLOWS_DIRECTORY));
-  if (workflowPath === undefined) return undefined;
-  return `GitHub installation token is missing permission for this operation: ${tool.id} requires workflows: write to change ${workflowPath}`;
-}
-
-function fileChangePaths(changes: unknown): string[] {
-  if (!Array.isArray(changes)) return [];
-  return changes.flatMap((change) =>
-    isRecord(change) && typeof change.path === 'string' ? [change.path] : [],
-  );
-}
-
-function hasGrantedPermissions(
-  granted: Record<string, 'read' | 'write' | 'admin'>,
-  tool: GithubAgentToolCatalogEntry,
-  call: AgentToolCallInput,
-): boolean {
-  return acceptedScopes(tool, call).some((scope) =>
-    scope.every(({permission, access}) => {
-      const actual = granted[permission];
-      return actual === 'write' || actual === 'admin' || actual === access;
-    }),
-  );
 }

--- a/libs/api/integration/github/src/core/github-agent-tool-catalog.ts
+++ b/libs/api/integration/github/src/core/github-agent-tool-catalog.ts
@@ -15,8 +15,8 @@ interface GithubCatalogMethod<RequiredScope = unknown>
   repositoryScope: GithubRepositoryScopeClassifier;
   indirectTargetNote?: string | undefined;
   /**
-   * Permission sets GitHub documents as sufficient instead of `requiredScope`. Only
-   * `requiredScope` shapes the minted token profile; alternatives are honored at call time.
+   * Permission sets GitHub documents as sufficient instead of `requiredScope`. Both fields are
+   * advisory provider requirements for catalog documentation and diagnostics.
    */
   alternativeScopes?: readonly RequiredScope[] | undefined;
 }
@@ -295,9 +295,8 @@ const pullRequestReadMethods = [
     scopes.pullRequestsRead,
   ),
   {
-    // GitHub accepts pull_requests read or issues read for timeline comments. Pull requests read
-    // drives the token profile like every sibling method; issues read is honored when a token
-    // already carries it.
+    // GitHub accepts pull_requests read or issues read for timeline comments. Keep both grants in
+    // the catalog so the provider requirement remains visible to callers and diagnostics.
     ...method(
       'get_comments',
       'Get conversation comments for a specific pull request.',
@@ -850,7 +849,7 @@ export const githubAgentToolCatalog = [
     id: 'create_commit',
     category: 'repository',
     description:
-      'Create a commit on an existing branch in a GitHub repository. The commit is authored and signed by GitHub on behalf of the Shipfox bot (shipfox-ai[bot]) and shows the Verified badge. Renames are expressed as a deletion of the old path plus an addition of the new path. File contents are validated server-side and limited to a total of about 1 MiB per call; keep edits small and explicit. Text contents are sent as utf8 and transcoded to base64 by the server; binary contents can be provided with encoding base64. The expected_head_oid must be the current head of the branch (compare-and-swap): if the branch moved, the commit is rejected with a stale-head error and the call should be retried with the new head. When issuing several dependent commits, derive each expected_head_oid from the returned oid of the previous commit so the commits land in order. Branch protection rules are the only barrier to writing the default branch. Files under .github/workflows need the workflows permission, which the installation token may not carry; such changes are rejected with access-denied when it is missing.',
+      "Create a commit on an existing branch in a GitHub repository. The commit is authored and signed by GitHub on behalf of the Shipfox bot (shipfox-ai[bot]) and shows the Verified badge. Renames are expressed as a deletion of the old path plus an addition of the new path. File contents are validated server-side and limited to a total of about 1 MiB per call; keep edits small and explicit. Text contents are sent as utf8 and transcoded to base64 by the server; binary contents can be provided with encoding base64. The expected_head_oid must be the current head of the branch (compare-and-swap): if the branch moved, the commit is rejected with a stale-head error and the call should be retried with the new head. When issuing several dependent commits, derive each expected_head_oid from the returned oid of the previous commit so the commits land in order. Branch protection rules are the only barrier to writing the default branch. Authorized changes to files under .github/workflows are sent to GitHub, which returns success or denial based on the installation's grants and repository rules.",
     sensitivity: 'write',
     sensitive: false,
     requiredScope: scopes.contentsWrite,


### PR DESCRIPTION
This makes the GitHub installation grant the provider credential boundary for backend agent tools. The catalog permission metadata remains advisory, GitHub determines provider permission outcomes, and Shipfox retains invocation authorization for callers, tools, methods, writes, arguments, and declared repository targets.

Authorized workflow-file changes now reach GitHub so its installation and repository rules decide success or denial. The existing cache identity, provider signatures, and checkout scope remain unchanged. Obsolete permission-profile cache cleanup is intentionally deferred to ENG-2039 and ENG-2040.

Validated with the affected Turbo check, type, and test graph, plus the GitHub package and docs suites.

Closes ENG-2038

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Backend GitHub agent tools now use the full GitHub installation access token instead of a narrowed permission profile derived from the selected tools. GitHub decides whether each operation is permitted; Shipfox still authorizes the caller, tool, method, write access, arguments, and declared repository target.

**Behavior changes**
- Catalog permission fields (`requiredScope`, `alternativeScopes`) are now advisory metadata for documentation and diagnostics.
- Authorized workflow-file commits reach GitHub and return its success or denial instead of a local preflight denial.
- Installation grants are now the effective provider credential boundary, so the GitHub App installation must be configured with the intended access.
- Checkout credentials keep their existing repository scope.
- Obsolete permission-profile cache cleanup is deferred to ENG-2039 and ENG-2040.

**Error handling**
- Ambiguous 403 responses without the `x-accepted-github-permissions` header map to `provider-rejected` instead of `access-denied`.
- Only 401 responses and 403 responses with the accepted-permissions header map to `access-denied`.
- Create 404 responses map to `provider-rejected` instead of `repository-not-found`.

Closes ENG-2038.

<sup>Written for commit 4c6d3417c9f06689c564528efa373eb43dceebca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1755?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

