### PR TITLE
Preserve job timeout reasons when closing abandoned log streams

### DIFF
--- a/.changeset/preserve-log-terminal-causes.md
+++ b/.changeset/preserve-log-terminal-causes.md
@@ -1,0 +1,10 @@
+---
+"@shipfox/api-agent-access-dto": minor
+"@shipfox/api-logs-dto": minor
+"@shipfox/api-workflows-dto": minor
+"@shipfox/client-logs": minor
+"@shipfox/api-logs": patch
+"@shipfox/api-workflows": patch
+---
+
+Preserves job timeout, run cancellation, and runner loss causes when abandoned log streams are closed.

--- a/.changeset/preserve-log-terminal-causes.md
+++ b/.changeset/preserve-log-terminal-causes.md
@@ -5,6 +5,7 @@
 "@shipfox/client-logs": minor
 "@shipfox/api-logs": patch
 "@shipfox/api-workflows": patch
+"@shipfox/client-workflows": patch
 ---
 
-Preserves job timeout, run cancellation, and runner loss causes when abandoned log streams are closed.
+Adds timeout and run-cancellation log records, and preserves the authoritative cause while closing an abandoned stream.

--- a/.changeset/preserve-log-terminal-causes.md
+++ b/.changeset/preserve-log-terminal-causes.md
@@ -8,4 +8,4 @@
 "@shipfox/client-workflows": patch
 ---
 
-Adds timeout and run-cancellation log records, and preserves the authoritative cause while closing an abandoned stream.
+Adds `timed_out` and `run_cancelled` log records, exposes terminal causes on step-attempt termination events, and renders timeout, cancellation, and runner loss distinctly.

--- a/libs/api/agent-access-dto/src/schemas/workflow-tools.ts
+++ b/libs/api/agent-access-dto/src/schemas/workflow-tools.ts
@@ -108,6 +108,9 @@ const stepStatusReasonSchema = z.enum([
   'default_gate_rejected',
   'condition_rejected',
   'condition_errored',
+  'timed_out',
+  'run_cancelled',
+  'runner_lost',
 ]);
 const boundedExecutionCountSchema = z.union([
   z.number().int().nonnegative().max(AGENT_ACCESS_WORKFLOW_EXECUTION_COUNT_MAX),
@@ -652,7 +655,14 @@ const stepsJsonSchema = {
     status: jobStatusJsonSchema,
     status_reason: nullable({
       type: 'string',
-      enum: ['default_gate_rejected', 'condition_rejected', 'condition_errored'],
+      enum: [
+        'default_gate_rejected',
+        'condition_rejected',
+        'condition_errored',
+        'timed_out',
+        'run_cancelled',
+        'runner_lost',
+      ],
     }),
     current_attempt: {type: 'integer', minimum: 1, maximum: AGENT_ACCESS_WORKFLOW_ATTEMPT_MAX},
   },

--- a/libs/api/logs-dto/src/schemas/read.ts
+++ b/libs/api/logs-dto/src/schemas/read.ts
@@ -4,7 +4,7 @@ import {z} from 'zod';
  * Read endpoint contract: `GET .../steps/:stepId/attempts/:attempt/logs?cursor=N`.
  *
  * `cursor` is an opaque chunk-sequence position, not a byte offset. Server-injected
- * control tombstones (`capped`, `runner_lost`) do not advance the runner byte axis, so
+ * control tombstones do not advance the runner byte axis, so
  * the read walks chunks by insertion `seq` to keep every record in stream order. The
  * same `seq` walk backs compaction, so the inline `ndjson` is byte-identical to the
  * decompressed compacted object. Start at 0 and echo back `next_cursor` to page forward.

--- a/libs/api/logs-dto/src/schemas/record.test.ts
+++ b/libs/api/logs-dto/src/schemas/record.test.ts
@@ -42,6 +42,8 @@ const recordsByType: Array<{record: LogRecord; raw: boolean}> = [
     raw: false,
   },
   {record: {v: 1, ts, type: 'capped'}, raw: false},
+  {record: {v: 1, ts, type: 'timed_out'}, raw: false},
+  {record: {v: 1, ts, type: 'run_cancelled'}, raw: false},
   {record: {v: 1, ts, type: 'runner_lost'}, raw: false},
 ];
 
@@ -270,6 +272,8 @@ describe('parseRawLogRecordLine', () => {
 
   it('rejects a forged server-only tombstone', () => {
     expect(() => parseRawLogRecordLine('{"v":1,"ts":1,"type":"capped"}')).toThrow();
+    expect(() => parseRawLogRecordLine('{"v":1,"ts":1,"type":"timed_out"}')).toThrow();
+    expect(() => parseRawLogRecordLine('{"v":1,"ts":1,"type":"run_cancelled"}')).toThrow();
     expect(() => parseRawLogRecordLine('{"v":1,"ts":1,"type":"runner_lost"}')).toThrow();
   });
 });

--- a/libs/api/logs-dto/src/schemas/record.ts
+++ b/libs/api/logs-dto/src/schemas/record.ts
@@ -14,9 +14,9 @@ import {sessionViewRowSchema} from './session-view.js';
  * other field is fixed-shape.
  *
  * The envelope is `{v, ts}`, and every record is discriminated by a single flat
- * `type`. The raw/write and stored/read unions are distinct types: the server-only
- * `capped` / `runner_lost` tombstones are members of the read union only, so a forged
- * tombstone cannot pass append validation.
+ * `type`. The raw/write and stored/read unions are distinct types: server-only
+ * tombstones are members of the read union only, so a forged tombstone cannot
+ * pass append validation.
  *
  * The append-side `agent_session` record carries one verbatim agent session entry line
  * in `data`, forwarded opaquely by the runner. On successful ingest, the API normalizes
@@ -110,6 +110,8 @@ const agentSession = z.object({
 
 // Server-only tombstones: NOT members of the raw write union.
 const logCapped = z.object({...envelope, type: z.literal('capped')});
+const logTimedOut = z.object({...envelope, type: z.literal('timed_out')});
+const logRunCancelled = z.object({...envelope, type: z.literal('run_cancelled')});
 const logRunnerLost = z.object({...envelope, type: z.literal('runner_lost')});
 
 /** Records a lease-scoped runner may append. The write path validates against this. */
@@ -135,6 +137,8 @@ const storedLogRecordSchemas = [
 export const logRecordSchema = z.discriminatedUnion('type', [
   ...storedLogRecordSchemas,
   logCapped,
+  logTimedOut,
+  logRunCancelled,
   logRunnerLost,
 ]);
 
@@ -151,7 +155,7 @@ export function parseLogRecordLine(line: string): LogRecord {
 
 /**
  * Parses one NDJSON line against the raw write union. A forged
- * server-only `capped` / `runner_lost` record fails here even though it is valid
+ * server-only tombstone record fails here even though it is valid
  * under the read union: this is the write-path forgery guard.
  */
 export function parseRawLogRecordLine(line: string): RawLogRecord {

--- a/libs/api/logs/README.md
+++ b/libs/api/logs/README.md
@@ -56,6 +56,8 @@ output; control records are flat by `type`:
 {v: 1, ts, type: 'gap',           dropped_bytes}
 {v: 1, ts, type: 'agent_session', row}                                // normalized SessionView row
 {v: 1, ts, type: 'capped'}        // server-only
+{v: 1, ts, type: 'timed_out'}     // server-only
+{v: 1, ts, type: 'run_cancelled'} // server-only
 {v: 1, ts, type: 'runner_lost'}   // server-only
 ```
 
@@ -66,7 +68,7 @@ Two layers stop a runner from writing what it should not:
 1. **Lease scope**: the lease binds writes to the job's own `(step, attempt)`, so cross-job
    injection is structurally impossible.
 2. **Distinct raw/write and stored/read unions**: every line is validated against the **raw**
-   record union. The server-only `capped`/`runner_lost` tombstones are members of the read union
+   record union. Server-only tombstones are members of the read union
    only, not the raw write union, so a forged tombstone append is rejected (400). A forged
    tombstone that is otherwise a valid record is logged as a narrowed audit warning (no payload,
    no token).
@@ -155,8 +157,11 @@ abandoned it (carried on the event's `logOutcome`); the job-terminated sweep for
 job's still-open streams once the job goes terminal, after a grace period
 (`LOG_STREAM_CLOSE_GRACE_SECONDS`); and the reaper cron force-closes any stream still open past the
 lease window (`LOG_STREAM_REAP_AFTER_SECONDS`), the backstop for a stream the one-shot sweeps missed
-(one whose first append landed after they ran). Every timeout close sets `truncated` and injects a
-`runner_lost` tombstone; each close writes one `logs.stream.closed` event, which drives compaction.
+(one whose first append landed after they ran). Every timeout close sets `truncated`. When the
+terminal cause is known, the close also writes a `timed_out`, `run_cancelled`, or `runner_lost`
+tombstone. `runner_lost` is reserved for an unexpected runner disappearance, lease expiry, and
+legacy close workflows that predate explicit causes. A cause-free abandoned close writes no
+tombstone. Each close writes one `logs.stream.closed` event, which drives compaction.
 
 ## Setup
 

--- a/libs/api/logs/src/core/append-logs.test.ts
+++ b/libs/api/logs/src/core/append-logs.test.ts
@@ -16,14 +16,28 @@ import {
 } from '#test/fixtures/ndjson.js';
 import {findAccounting, findStream, listChunks, listStreamClosedEvents} from '#test/queries.js';
 
+interface MetricsMockState {
+  counters: Map<string, {add: ReturnType<typeof vi.fn>}>;
+  add: (name: string) => {add: ReturnType<typeof vi.fn>};
+}
+
 const metricsMocks = vi.hoisted(() => {
+  const testGlobal = globalThis as typeof globalThis & {
+    __shipfoxApiLogsMetricsMocks?: MetricsMockState;
+  };
+  if (testGlobal.__shipfoxApiLogsMetricsMocks) {
+    return testGlobal.__shipfoxApiLogsMetricsMocks;
+  }
+
   const counters = new Map<string, {add: ReturnType<typeof vi.fn>}>();
   const add = (name: string) => {
     const counter = {add: vi.fn()};
     counters.set(name, counter);
     return counter;
   };
-  return {counters, add};
+  const state = {counters, add};
+  testGlobal.__shipfoxApiLogsMetricsMocks = state;
+  return state;
 });
 
 vi.mock('#metrics/instance.js', () => ({

--- a/libs/api/logs/src/core/append-logs.test.ts
+++ b/libs/api/logs/src/core/append-logs.test.ts
@@ -31,6 +31,8 @@ const metricsMocks = vi.hoisted(() => {
 
   const counters = new Map<string, {add: ReturnType<typeof vi.fn>}>();
   const add = (name: string) => {
+    const existing = counters.get(name);
+    if (existing) return existing;
     const counter = {add: vi.fn()};
     counters.set(name, counter);
     return counter;

--- a/libs/api/logs/src/core/append-logs.ts
+++ b/libs/api/logs/src/core/append-logs.ts
@@ -76,7 +76,7 @@ interface ParsedBody {
  * budget charges the normalized body built from these parsed records.
  *
  * Each line is validated against the raw record union (a forged server-only
- * `capped`/`runner_lost` fails here); the declared total is pulled from an `end`
+ * server-only tombstone fails here); the declared total is pulled from an `end`
  * record. A line that is a valid server-only record under the read union surfaces
  * its type via `forgedType` for the narrowed audit warn.
  */
@@ -130,7 +130,7 @@ function parseAppendBody(body: Buffer): ParsedBody {
 
 /**
  * A line that fails the raw write union but is a valid record under the read union
- * can only be a server-only `capped`/`runner_lost` tombstone: i.e. a forgery
+ * can only be a server-only tombstone: i.e. a forgery
  * attempt. Returns its type for the audit warn, or undefined for plain garbage.
  */
 function detectForgedType(line: string): string | undefined {

--- a/libs/api/logs/src/core/append-logs.ts
+++ b/libs/api/logs/src/core/append-logs.ts
@@ -76,7 +76,7 @@ interface ParsedBody {
  * budget charges the normalized body built from these parsed records.
  *
  * Each line is validated against the raw record union (a forged server-only
- * server-only tombstone fails here); the declared total is pulled from an `end`
+ * tombstone fails here); the declared total is pulled from an `end`
  * record. A line that is a valid server-only record under the read union surfaces
  * its type via `forgedType` for the narrowed audit warn.
  */

--- a/libs/api/logs/src/core/append-server-records.test.ts
+++ b/libs/api/logs/src/core/append-server-records.test.ts
@@ -11,14 +11,28 @@ import {jobAccountingFactory} from '#test/factories/job-accounting.js';
 import {ndjsonBody, outputLine} from '#test/fixtures/ndjson.js';
 import {findAccounting, findStream, listChunks, listStreamClosedEvents} from '#test/queries.js';
 
+interface MetricsMockState {
+  counters: Map<string, {add: ReturnType<typeof vi.fn>}>;
+  add: (name: string) => {add: ReturnType<typeof vi.fn>};
+}
+
 const metricsMocks = vi.hoisted(() => {
+  const testGlobal = globalThis as typeof globalThis & {
+    __shipfoxApiLogsMetricsMocks?: MetricsMockState;
+  };
+  if (testGlobal.__shipfoxApiLogsMetricsMocks) {
+    return testGlobal.__shipfoxApiLogsMetricsMocks;
+  }
+
   const counters = new Map<string, {add: ReturnType<typeof vi.fn>}>();
   const add = (name: string) => {
     const counter = {add: vi.fn()};
     counters.set(name, counter);
     return counter;
   };
-  return {counters, add};
+  const state = {counters, add};
+  testGlobal.__shipfoxApiLogsMetricsMocks = state;
+  return state;
 });
 
 vi.mock('#metrics/instance.js', () => ({

--- a/libs/api/logs/src/core/append-server-records.test.ts
+++ b/libs/api/logs/src/core/append-server-records.test.ts
@@ -26,6 +26,8 @@ const metricsMocks = vi.hoisted(() => {
 
   const counters = new Map<string, {add: ReturnType<typeof vi.fn>}>();
   const add = (name: string) => {
+    const existing = counters.get(name);
+    if (existing) return existing;
     const counter = {add: vi.fn()};
     counters.set(name, counter);
     return counter;

--- a/libs/api/logs/src/core/close-stream.ts
+++ b/libs/api/logs/src/core/close-stream.ts
@@ -1,5 +1,6 @@
 import {Buffer} from 'node:buffer';
 import {LOG_STREAM_CLOSED, type LogRecord, type LogsEventMap} from '@shipfox/api-logs-dto';
+import type {StepAttemptTerminalCauseDto} from '@shipfox/api-workflows-dto';
 import {writeOutboxEvent} from '@shipfox/node-outbox';
 import type {AttemptStream, StreamCloseReason} from '#core/entities/attempt-stream.js';
 import {insertChunk} from '#db/chunks.js';
@@ -7,7 +8,7 @@ import type {Transaction} from '#db/db.js';
 import {logsOutbox} from '#db/schema/outbox.js';
 import {markStreamClosed} from '#db/streams.js';
 
-export type TombstoneKind = 'capped' | 'runner_lost';
+export type TombstoneKind = 'capped' | StepAttemptTerminalCauseDto;
 
 /**
  * Frames a server tombstone as one newline-terminated record. Typed against the
@@ -23,6 +24,7 @@ export function controlTombstone(kind: TombstoneKind): Buffer {
 export interface CloseStreamParams {
   streamId: string;
   reason: StreamCloseReason;
+  terminalCause?: StepAttemptTerminalCauseDto | null | undefined;
 }
 
 /**
@@ -31,8 +33,8 @@ export interface CloseStreamParams {
  * declared close vs the job-terminated timeout sweep) returns null, so no duplicate
  * `LOG_STREAM_CLOSED` is written and no second tombstone lands. A pending Claude result
  * is materialized before the close event, then a timeout close sets `truncated` and injects
- * a `runner_lost` tombstone in-band (a `capped` tombstone, if any, was injected earlier at
- * the append that tripped the cap).
+ * its authoritative terminal cause in-band when one is known (a `capped` tombstone, if any,
+ * was injected earlier at the append that tripped the cap).
  *
  * The event drives compaction; it is written in the same transaction as the flip.
  */
@@ -81,8 +83,8 @@ export async function closeStream(
     });
   }
 
-  if (params.reason === 'timeout') {
-    const tombstone = controlTombstone('runner_lost');
+  if (params.reason === 'timeout' && params.terminalCause != null) {
+    const tombstone = controlTombstone(params.terminalCause);
     await insertChunk(tx, {
       streamId: closed.id,
       streamOffset: closed.committedLength,

--- a/libs/api/logs/src/core/errors.ts
+++ b/libs/api/logs/src/core/errors.ts
@@ -9,7 +9,7 @@ export class OffsetGapError extends Error {
 /**
  * The append body is not whole, newline-terminated records of the raw log
  * record contract. `forgedType` is set only for the detectable forgery case: a
- * line that is a valid server-only record (`capped`/`runner_lost`) under the read
+ * line that is a valid server-only tombstone under the read
  * union but is not valid on the raw write path. The append path can emit a
  * narrowed audit warning without logging the payload.
  */

--- a/libs/api/logs/src/core/finalize-attempt-stream.test.ts
+++ b/libs/api/logs/src/core/finalize-attempt-stream.test.ts
@@ -34,6 +34,7 @@ function newIdentity(
     projectId: crypto.randomUUID(),
     workflowRunAttemptId: crypto.randomUUID(),
     logOutcome: 'drained',
+    terminalCause: null,
     ...overrides,
   };
 }
@@ -57,8 +58,8 @@ describe('finalizeAttemptLogStream', () => {
     expect(metrics.recordAppendedAdd).not.toHaveBeenCalled();
   });
 
-  it('closes an abandoned open stream with a runner_lost tombstone', async () => {
-    const identity = newIdentity({logOutcome: 'abandoned'});
+  it('closes an abandoned runner-loss stream with a runner_lost tombstone', async () => {
+    const identity = newIdentity({logOutcome: 'abandoned', terminalCause: 'runner_lost'});
     await db().transaction((tx) => getOrCreateAttemptStream(tx, identity));
 
     const stream = await finalizeAttemptLogStream(identity);
@@ -76,13 +77,42 @@ describe('finalizeAttemptLogStream', () => {
       .map(parseLogRecordLine);
     expect(records).toMatchObject([{type: 'runner_lost'}]);
     expect(await listStreamClosedEvents(stream.id)).toHaveLength(1);
-    expect(metrics.streamClosedAdd).toHaveBeenCalledWith(1, {reason: 'timeout'});
+    expect(metrics.streamClosedAdd).toHaveBeenCalledWith(1, {reason: 'runner_lost'});
     expect(metrics.recordAppendedAdd).toHaveBeenCalledWith(1, {kind: 'runner_lost'});
   });
 
   it.each([
+    {terminalCause: 'timed_out' as const, metricReason: 'job_timeout' as const},
+    {terminalCause: 'run_cancelled' as const, metricReason: 'run_cancelled' as const},
+  ])('preserves $terminalCause separately from the abandoned drain', async (params) => {
+    const identity = newIdentity({logOutcome: 'abandoned', terminalCause: params.terminalCause});
+
+    const stream = await finalizeAttemptLogStream(identity);
+    const records = (await listChunks(stream.id)).flatMap((chunk) =>
+      chunk.data.toString('utf8').split('\n').filter(Boolean).map(parseLogRecordLine),
+    );
+
+    expect(stream.closeReason).toBe('timeout');
+    expect(stream.truncated).toBe(true);
+    expect(records).toMatchObject([{type: params.terminalCause}]);
+    expect(metrics.streamClosedAdd).toHaveBeenCalledWith(1, {reason: params.metricReason});
+    expect(metrics.recordAppendedAdd).toHaveBeenCalledWith(1, {kind: params.terminalCause});
+  });
+
+  it('marks a cause-free abandoned drain truncated without inventing runner loss', async () => {
+    const stream = await finalizeAttemptLogStream(
+      newIdentity({logOutcome: 'abandoned', terminalCause: null}),
+    );
+
+    expect(stream.truncated).toBe(true);
+    expect(await listChunks(stream.id)).toHaveLength(0);
+    expect(metrics.streamClosedAdd).toHaveBeenCalledWith(1, {reason: 'abandoned'});
+    expect(metrics.recordAppendedAdd).not.toHaveBeenCalled();
+  });
+
+  it.each([
     {logOutcome: 'drained' as const, expectedOrigins: ['runner', 'control']},
-    {logOutcome: 'abandoned' as const, expectedOrigins: ['runner', 'control', 'control']},
+    {logOutcome: 'abandoned' as const, expectedOrigins: ['runner', 'control']},
   ])('flushes a pending Claude result before a $logOutcome close', async ({
     logOutcome,
     expectedOrigins,
@@ -144,18 +174,12 @@ describe('finalizeAttemptLogStream', () => {
           : [],
       ),
     ).toEqual(['Session started', 'Session completed']);
-    if (logOutcome === 'abandoned') {
-      expect(records.map((record) => record.type)).toEqual([
-        'agent_session',
-        'agent_session',
-        'runner_lost',
-      ]);
-    }
+    expect(records.map((record) => record.type)).toEqual(['agent_session', 'agent_session']);
     expect(stream.claudePendingResult).toBeNull();
   });
 
   it('does not emit another tombstone or close event when finalized again', async () => {
-    const identity = newIdentity({logOutcome: 'abandoned'});
+    const identity = newIdentity({logOutcome: 'abandoned', terminalCause: 'runner_lost'});
 
     const first = await finalizeAttemptLogStream(identity);
     const second = await finalizeAttemptLogStream(identity);

--- a/libs/api/logs/src/core/finalize-attempt-stream.ts
+++ b/libs/api/logs/src/core/finalize-attempt-stream.ts
@@ -1,27 +1,35 @@
-import type {LogOutcomeDto} from '@shipfox/api-workflows-dto';
+import type {LogOutcomeDto, StepAttemptTerminalCauseDto} from '@shipfox/api-workflows-dto';
 import type {AttemptStream} from '#core/entities/attempt-stream.js';
-import {db} from '#db/db.js';
+import {db, type Transaction} from '#db/db.js';
 import {
   type AttemptStreamIdentity,
   getAttemptStreamByIdInTransaction,
   getOrCreateAttemptStreamWithStatus,
 } from '#db/streams.js';
-import {recordAppendedCount, streamClosedCount} from '#metrics/instance.js';
+import {
+  recordAppendedCount,
+  type StreamClosedMetricReason,
+  streamClosedCount,
+} from '#metrics/instance.js';
 import {closeStream} from './close-stream.js';
 
 export interface FinalizeAttemptLogStreamParams extends AttemptStreamIdentity {
   logOutcome: LogOutcomeDto;
+  terminalCause?: StepAttemptTerminalCauseDto | null | undefined;
 }
 
 interface FinalizeAttemptLogStreamResult {
   stream: AttemptStream;
-  closedReason: 'declared' | 'timeout' | null;
+  metricReason: StreamClosedMetricReason | null;
+  tombstoneKind: StepAttemptTerminalCauseDto | null;
 }
 
 interface FinalizeMetrics {
-  recordAppendedCount: {add: (value: number, attributes: {kind: 'runner_lost'}) => void};
+  recordAppendedCount: {
+    add: (value: number, attributes: {kind: StepAttemptTerminalCauseDto}) => void;
+  };
   streamClosedCount: {
-    add: (value: number, attributes: {reason: 'declared' | 'timeout'}) => void;
+    add: (value: number, attributes: {reason: StreamClosedMetricReason}) => void;
   };
 }
 
@@ -34,26 +42,49 @@ export function createFinalizeAttemptLogStream(metrics: FinalizeMetrics = defaul
   return async (params: FinalizeAttemptLogStreamParams): Promise<AttemptStream> => {
     const result: FinalizeAttemptLogStreamResult = await db().transaction(async (tx) => {
       const {stream} = await getOrCreateAttemptStreamWithStatus(tx, params);
-      if (stream.state === 'closed') return {stream, closedReason: null};
-
-      const reason = params.logOutcome === 'abandoned' ? 'timeout' : 'declared';
-      const closed = await closeStream(tx, {streamId: stream.id, reason});
-      if (closed) return {stream: closed, closedReason: reason};
-
-      const current = await getAttemptStreamByIdInTransaction(tx, stream.id);
-      if (!current) throw new Error(`Log stream disappeared during finalization: ${stream.id}`);
-      return {stream: current, closedReason: null};
+      if (stream.state === 'closed') return {stream, metricReason: null, tombstoneKind: null};
+      return closeOpenAttemptStream(tx, stream, params);
     });
 
-    if (result.closedReason) {
-      if (result.closedReason === 'timeout') {
-        metrics.recordAppendedCount.add(1, {kind: 'runner_lost'});
-      }
-      metrics.streamClosedCount.add(1, {reason: result.closedReason});
+    if (result.tombstoneKind) {
+      metrics.recordAppendedCount.add(1, {kind: result.tombstoneKind});
+    }
+    if (result.metricReason) {
+      metrics.streamClosedCount.add(1, {reason: result.metricReason});
     }
 
     return result.stream;
   };
+}
+
+async function closeOpenAttemptStream(
+  tx: Transaction,
+  stream: AttemptStream,
+  params: FinalizeAttemptLogStreamParams,
+): Promise<FinalizeAttemptLogStreamResult> {
+  const reason = params.logOutcome === 'abandoned' ? 'timeout' : 'declared';
+  const terminalCause = params.logOutcome === 'abandoned' ? params.terminalCause : null;
+  const closed = await closeStream(tx, {streamId: stream.id, reason, terminalCause});
+  if (closed) {
+    return {
+      stream: closed,
+      metricReason: metricReasonForClose(reason, terminalCause),
+      tombstoneKind: terminalCause ?? null,
+    };
+  }
+
+  const current = await getAttemptStreamByIdInTransaction(tx, stream.id);
+  if (!current) throw new Error(`Log stream disappeared during finalization: ${stream.id}`);
+  return {stream: current, metricReason: null, tombstoneKind: null};
+}
+
+function metricReasonForClose(
+  reason: 'declared' | 'timeout',
+  terminalCause: StepAttemptTerminalCauseDto | null | undefined,
+): StreamClosedMetricReason {
+  if (reason === 'declared') return 'declared';
+  if (terminalCause === 'timed_out') return 'job_timeout';
+  return terminalCause ?? 'abandoned';
 }
 
 export const finalizeAttemptLogStream = createFinalizeAttemptLogStream();

--- a/libs/api/logs/src/core/log-tail.ts
+++ b/libs/api/logs/src/core/log-tail.ts
@@ -187,6 +187,10 @@ function formatRecordText(record: LogRecord): string {
       return formatSessionRow(record.row);
     case 'capped':
       return 'log capped';
+    case 'timed_out':
+      return 'execution timed out';
+    case 'run_cancelled':
+      return 'run cancelled';
     case 'runner_lost':
       return 'runner lost';
   }

--- a/libs/api/logs/src/core/reap-stale-open-streams.ts
+++ b/libs/api/logs/src/core/reap-stale-open-streams.ts
@@ -44,12 +44,16 @@ export async function reapStaleOpenStreams(
   for (const stream of stale) {
     try {
       const closed = await db().transaction((tx) =>
-        closeStream(tx, {streamId: stream.id, reason: 'timeout'}),
+        closeStream(tx, {
+          streamId: stream.id,
+          reason: 'timeout',
+          terminalCause: 'runner_lost',
+        }),
       );
       if (closed) {
         result.reaped += 1;
         recordAppendedCount.add(1, {kind: 'runner_lost'});
-        streamClosedCount.add(1, {reason: 'timeout'});
+        streamClosedCount.add(1, {reason: 'runner_lost'});
       }
     } catch (error) {
       result.failed += 1;

--- a/libs/api/logs/src/metrics/instance.ts
+++ b/libs/api/logs/src/metrics/instance.ts
@@ -30,7 +30,7 @@ export const streamOpenedCount = meter.createCounter<Record<string, never>>('log
 // appends share the axis; the server-origin append derives its offset from the stream tail.
 //
 // `logs_bytes_stored` counts only normalized bodies durably written as chunk rows, so a
-// capped job's dropped straggler and server-injected `capped`/`runner_lost` tombstones do
+// capped job's dropped straggler and server-injected tombstones do
 // not inflate it. ingested - stored is the normalization delta plus cap/close drops.
 export const bytesIngestedCount = meter.createCounter<Record<string, never>>(
   'logs_bytes_ingested',
@@ -47,7 +47,14 @@ export const bytesStoredCount = meter.createCounter<Record<string, never>>('logs
   unit: 'By',
 });
 
-export const streamClosedCount = meter.createCounter<{reason: 'declared' | 'timeout'}>(
+export type StreamClosedMetricReason =
+  | 'declared'
+  | 'abandoned'
+  | 'job_timeout'
+  | 'run_cancelled'
+  | 'runner_lost';
+
+export const streamClosedCount = meter.createCounter<{reason: StreamClosedMetricReason}>(
   'logs_stream_closed',
   {description: 'Log streams closed by reason'},
 );

--- a/libs/api/logs/src/presentation/subscribers/on-job-terminated.test.ts
+++ b/libs/api/logs/src/presentation/subscribers/on-job-terminated.test.ts
@@ -44,8 +44,29 @@ describe('onJobTerminated', () => {
     expect(startMock).toHaveBeenCalledWith('closeAbandonedStreams', {
       taskQueue: LOGS_LIFECYCLE_TASK_QUEUE,
       workflowId: `logs-close:${jobId}`,
-      args: [{jobId, graceSeconds: config.LOG_STREAM_CLOSE_GRACE_SECONDS}],
+      args: [
+        {
+          jobId,
+          graceSeconds: config.LOG_STREAM_CLOSE_GRACE_SECONDS,
+          terminalCause: 'runner_lost',
+        },
+      ],
     });
+  });
+
+  it.each([
+    {statusReason: 'timed_out' as const, terminalCause: 'timed_out'},
+    {statusReason: 'run_cancelled' as const, terminalCause: 'run_cancelled'},
+    {statusReason: 'runner_lost' as const, terminalCause: 'runner_lost'},
+  ])('passes $terminalCause into the grace sweep', async ({statusReason, terminalCause}) => {
+    const payload = {...buildPayload(crypto.randomUUID()), statusReason};
+
+    await onJobTerminated(payload);
+
+    expect(startMock).toHaveBeenCalledWith(
+      'closeAbandonedStreams',
+      expect.objectContaining({args: [expect.objectContaining({terminalCause})]}),
+    );
   });
 
   it('swallows a redelivered event when the workflow is already started', async () => {

--- a/libs/api/logs/src/presentation/subscribers/on-job-terminated.test.ts
+++ b/libs/api/logs/src/presentation/subscribers/on-job-terminated.test.ts
@@ -35,7 +35,7 @@ describe('onJobTerminated', () => {
     startMock.mockResolvedValue({});
   });
 
-  it('arms the close-abandoned-streams workflow keyed on the job id', async () => {
+  it('arms a cause-free close workflow for an ordinary terminal job', async () => {
     const jobId = crypto.randomUUID();
 
     await onJobTerminated(buildPayload(jobId));
@@ -48,7 +48,7 @@ describe('onJobTerminated', () => {
         {
           jobId,
           graceSeconds: config.LOG_STREAM_CLOSE_GRACE_SECONDS,
-          terminalCause: 'runner_lost',
+          terminalCause: null,
         },
       ],
     });
@@ -57,6 +57,7 @@ describe('onJobTerminated', () => {
   it.each([
     {statusReason: 'timed_out' as const, terminalCause: 'timed_out'},
     {statusReason: 'run_cancelled' as const, terminalCause: 'run_cancelled'},
+    {statusReason: 'user_cancelled' as const, terminalCause: 'run_cancelled'},
     {statusReason: 'runner_lost' as const, terminalCause: 'runner_lost'},
   ])('passes $terminalCause into the grace sweep', async ({statusReason, terminalCause}) => {
     const payload = {...buildPayload(crypto.randomUUID()), statusReason};

--- a/libs/api/logs/src/presentation/subscribers/on-job-terminated.ts
+++ b/libs/api/logs/src/presentation/subscribers/on-job-terminated.ts
@@ -34,10 +34,13 @@ export async function onJobTerminated(payload: WorkflowsJobTerminatedEventDto): 
   }
 }
 
-function terminalCauseForJob(payload: WorkflowsJobTerminatedEventDto): StepAttemptTerminalCauseDto {
+function terminalCauseForJob(
+  payload: WorkflowsJobTerminatedEventDto,
+): StepAttemptTerminalCauseDto | null {
   if (payload.statusReason === 'timed_out') return 'timed_out';
   if (payload.statusReason === 'run_cancelled' || payload.statusReason === 'user_cancelled') {
     return 'run_cancelled';
   }
-  return 'runner_lost';
+  if (payload.statusReason === 'runner_lost') return 'runner_lost';
+  return null;
 }

--- a/libs/api/logs/src/presentation/subscribers/on-job-terminated.ts
+++ b/libs/api/logs/src/presentation/subscribers/on-job-terminated.ts
@@ -1,4 +1,7 @@
-import type {WorkflowsJobTerminatedEventDto} from '@shipfox/api-workflows-dto';
+import type {
+  StepAttemptTerminalCauseDto,
+  WorkflowsJobTerminatedEventDto,
+} from '@shipfox/api-workflows-dto';
 import {logger} from '@shipfox/node-opentelemetry';
 import {temporalClient} from '@shipfox/node-temporal';
 import {config} from '#config.js';
@@ -14,7 +17,13 @@ export async function onJobTerminated(payload: WorkflowsJobTerminatedEventDto): 
     await temporalClient().workflow.start('closeAbandonedStreams', {
       taskQueue: LOGS_LIFECYCLE_TASK_QUEUE,
       workflowId: `logs-close:${payload.jobId}`,
-      args: [{jobId: payload.jobId, graceSeconds: config.LOG_STREAM_CLOSE_GRACE_SECONDS}],
+      args: [
+        {
+          jobId: payload.jobId,
+          graceSeconds: config.LOG_STREAM_CLOSE_GRACE_SECONDS,
+          terminalCause: terminalCauseForJob(payload),
+        },
+      ],
     });
   } catch (error) {
     if (error instanceof Error && error.name === 'WorkflowExecutionAlreadyStartedError') {
@@ -23,4 +32,12 @@ export async function onJobTerminated(payload: WorkflowsJobTerminatedEventDto): 
     }
     throw error;
   }
+}
+
+function terminalCauseForJob(payload: WorkflowsJobTerminatedEventDto): StepAttemptTerminalCauseDto {
+  if (payload.statusReason === 'timed_out') return 'timed_out';
+  if (payload.statusReason === 'run_cancelled' || payload.statusReason === 'user_cancelled') {
+    return 'run_cancelled';
+  }
+  return 'runner_lost';
 }

--- a/libs/api/logs/src/presentation/subscribers/on-step-attempt-terminated.test.ts
+++ b/libs/api/logs/src/presentation/subscribers/on-step-attempt-terminated.test.ts
@@ -1,0 +1,52 @@
+import type {
+  StepAttemptTerminalCauseDto,
+  WorkflowsStepAttemptTerminatedEventDto,
+} from '@shipfox/api-workflows-dto';
+import {onStepAttemptTerminated} from './on-step-attempt-terminated.js';
+
+const {finalizeAttemptLogStreamMock} = vi.hoisted(() => ({
+  finalizeAttemptLogStreamMock: vi.fn(),
+}));
+
+vi.mock('#core/finalize-attempt-stream.js', () => ({
+  finalizeAttemptLogStream: finalizeAttemptLogStreamMock,
+}));
+
+function buildPayload(
+  terminalCause: StepAttemptTerminalCauseDto | null | undefined,
+): WorkflowsStepAttemptTerminatedEventDto {
+  return {
+    jobId: crypto.randomUUID(),
+    workflowRunId: crypto.randomUUID(),
+    workflowRunAttemptId: crypto.randomUUID(),
+    workspaceId: crypto.randomUUID(),
+    projectId: crypto.randomUUID(),
+    stepId: crypto.randomUUID(),
+    attempt: 1,
+    logOutcome: 'abandoned',
+    terminalCause,
+  };
+}
+
+describe('onStepAttemptTerminated', () => {
+  beforeEach(() => {
+    finalizeAttemptLogStreamMock.mockReset();
+    finalizeAttemptLogStreamMock.mockResolvedValue(undefined);
+  });
+
+  it.each([
+    {terminalCause: 'timed_out' as const, expectedCause: 'timed_out'},
+    {terminalCause: 'run_cancelled' as const, expectedCause: 'run_cancelled'},
+    {terminalCause: 'runner_lost' as const, expectedCause: 'runner_lost'},
+    {terminalCause: null, expectedCause: null},
+    {terminalCause: undefined, expectedCause: 'runner_lost'},
+  ])('passes $expectedCause to stream finalization', async ({terminalCause, expectedCause}) => {
+    const payload = buildPayload(terminalCause);
+
+    await onStepAttemptTerminated(payload);
+
+    expect(finalizeAttemptLogStreamMock).toHaveBeenCalledWith(
+      expect.objectContaining({terminalCause: expectedCause}),
+    );
+  });
+});

--- a/libs/api/logs/src/presentation/subscribers/on-step-attempt-terminated.ts
+++ b/libs/api/logs/src/presentation/subscribers/on-step-attempt-terminated.ts
@@ -12,5 +12,8 @@ export async function onStepAttemptTerminated(
     stepId: payload.stepId,
     attempt: payload.attempt,
     logOutcome: payload.logOutcome,
+    // Preserve the old runner-loss behavior for pre-change events while new
+    // producers use null to distinguish an abandoned drain from runner loss.
+    terminalCause: payload.terminalCause === undefined ? 'runner_lost' : payload.terminalCause,
   });
 }

--- a/libs/api/logs/src/temporal/activities/close-abandoned-streams.test.ts
+++ b/libs/api/logs/src/temporal/activities/close-abandoned-streams.test.ts
@@ -1,3 +1,4 @@
+import {parseLogRecordLine} from '@shipfox/api-logs-dto';
 import {appendLogs} from '#core/append-logs.js';
 import {closeAbandonedStreamsActivity} from '#temporal/activities/close-abandoned-streams.js';
 import {endLine, ndjsonBody, outputLine} from '#test/fixtures/ndjson.js';
@@ -22,12 +23,16 @@ function newCtx(): Ctx {
 }
 
 describe('closeAbandonedStreamsActivity', () => {
-  it('force-closes an open stream with a runner_lost tombstone and one event', async () => {
+  it.each([
+    'timed_out',
+    'run_cancelled',
+    'runner_lost',
+  ] as const)('force-closes an open stream with a %s tombstone and one event', async (terminalCause) => {
     const ctx = newCtx();
     await appendLogs({...ctx, attempt: 1, offset: 0, body: ndjsonBody(outputLine('partial\n'))});
     const open = await findStream({...ctx, attempt: 1});
 
-    const {closed} = await closeAbandonedStreamsActivity({jobId: ctx.jobId});
+    const {closed} = await closeAbandonedStreamsActivity({jobId: ctx.jobId, terminalCause});
 
     expect(closed).toBe(1);
     const after = await findStream({...ctx, attempt: 1});
@@ -35,10 +40,13 @@ describe('closeAbandonedStreamsActivity', () => {
     expect(after?.closeReason).toBe('timeout');
     expect(after?.truncated).toBe(true);
     expect(after?.committedLength).toBe(open?.committedLength);
-    expect((await listChunks(after?.id as string)).map((c) => c.origin)).toEqual([
-      'runner',
-      'control',
-    ]);
+    const chunks = await listChunks(after?.id as string);
+    expect(chunks.map((c) => c.origin)).toEqual(['runner', 'control']);
+    expect(
+      chunks.flatMap((chunk) =>
+        chunk.data.toString('utf8').split('\n').filter(Boolean).map(parseLogRecordLine),
+      ),
+    ).toEqual(expect.arrayContaining([expect.objectContaining({type: terminalCause})]));
     expect(await listStreamClosedEvents(after?.id as string)).toHaveLength(1);
   });
 
@@ -62,7 +70,10 @@ describe('closeAbandonedStreamsActivity', () => {
     });
     const doneStream = await findStream({jobId: ctx.jobId, stepId: stepDone, attempt: 1});
 
-    const {closed} = await closeAbandonedStreamsActivity({jobId: ctx.jobId});
+    const {closed} = await closeAbandonedStreamsActivity({
+      jobId: ctx.jobId,
+      terminalCause: 'runner_lost',
+    });
 
     expect(closed).toBe(1);
     const openAfter = await findStream({jobId: ctx.jobId, stepId: stepOpen, attempt: 1});
@@ -77,7 +88,10 @@ describe('closeAbandonedStreamsActivity', () => {
   it('is a no-op for a job with no open streams', async () => {
     const ctx = newCtx();
 
-    const {closed} = await closeAbandonedStreamsActivity({jobId: ctx.jobId});
+    const {closed} = await closeAbandonedStreamsActivity({
+      jobId: ctx.jobId,
+      terminalCause: 'runner_lost',
+    });
 
     expect(closed).toBe(0);
   });

--- a/libs/api/logs/src/temporal/activities/close-abandoned-streams.test.ts
+++ b/libs/api/logs/src/temporal/activities/close-abandoned-streams.test.ts
@@ -1,6 +1,6 @@
 import {parseLogRecordLine} from '@shipfox/api-logs-dto';
 import {appendLogs} from '#core/append-logs.js';
-import {closeAbandonedStreamsActivity} from '#temporal/activities/close-abandoned-streams.js';
+import {closeAbandonedStreamsActivity as closeAbandonedStreams} from '#temporal/activities/close-abandoned-streams.js';
 import {endLine, ndjsonBody, outputLine} from '#test/fixtures/ndjson.js';
 import {findStream, listChunks, listStreamClosedEvents} from '#test/queries.js';
 
@@ -23,6 +23,16 @@ function newCtx(): Ctx {
 }
 
 describe('closeAbandonedStreamsActivity', () => {
+  const recordAppended = vi.fn();
+  const streamClosed = vi.fn();
+  const closeAbandonedStreamsActivity = (params: Parameters<typeof closeAbandonedStreams>[0]) =>
+    closeAbandonedStreams(params, {recordAppended, streamClosed});
+
+  beforeEach(() => {
+    recordAppended.mockReset();
+    streamClosed.mockReset();
+  });
+
   it.each([
     'timed_out',
     'run_cancelled',
@@ -48,6 +58,42 @@ describe('closeAbandonedStreamsActivity', () => {
       ),
     ).toEqual(expect.arrayContaining([expect.objectContaining({type: terminalCause})]));
     expect(await listStreamClosedEvents(after?.id as string)).toHaveLength(1);
+    expect(recordAppended).toHaveBeenCalledWith(terminalCause);
+    expect(streamClosed).toHaveBeenCalledWith(
+      terminalCause === 'timed_out' ? 'job_timeout' : terminalCause,
+    );
+  });
+
+  it('defaults a legacy activity input without a cause to runner loss', async () => {
+    const ctx = newCtx();
+    await appendLogs({...ctx, attempt: 1, offset: 0, body: ndjsonBody(outputLine('partial\n'))});
+
+    await closeAbandonedStreamsActivity({jobId: ctx.jobId});
+
+    const stream = await findStream({...ctx, attempt: 1});
+    const chunks = await listChunks(stream?.id as string);
+    expect(
+      chunks.flatMap((chunk) =>
+        chunk.data.toString('utf8').split('\n').filter(Boolean).map(parseLogRecordLine),
+      ),
+    ).toEqual(expect.arrayContaining([expect.objectContaining({type: 'runner_lost'})]));
+    expect(recordAppended).toHaveBeenCalledWith('runner_lost');
+    expect(streamClosed).toHaveBeenCalledWith('runner_lost');
+  });
+
+  it('closes an explicitly cause-free stream as truncated without a tombstone', async () => {
+    const ctx = newCtx();
+    await appendLogs({...ctx, attempt: 1, offset: 0, body: ndjsonBody(outputLine('partial\n'))});
+
+    await closeAbandonedStreamsActivity({jobId: ctx.jobId, terminalCause: null});
+
+    const stream = await findStream({...ctx, attempt: 1});
+    expect(stream).toMatchObject({state: 'closed', closeReason: 'timeout', truncated: true});
+    expect((await listChunks(stream?.id as string)).map((chunk) => chunk.origin)).toEqual([
+      'runner',
+    ]);
+    expect(recordAppended).not.toHaveBeenCalled();
+    expect(streamClosed).toHaveBeenCalledWith('abandoned');
   });
 
   it('closes only the still-open streams, skipping ones already declared-closed', async () => {

--- a/libs/api/logs/src/temporal/activities/close-abandoned-streams.ts
+++ b/libs/api/logs/src/temporal/activities/close-abandoned-streams.ts
@@ -2,7 +2,31 @@ import type {StepAttemptTerminalCauseDto} from '@shipfox/api-workflows-dto';
 import {closeStream} from '#core/close-stream.js';
 import {db} from '#db/db.js';
 import {listOpenStreamsByJob} from '#db/streams.js';
-import {recordAppendedCount, streamClosedCount} from '#metrics/instance.js';
+import {
+  recordAppendedCount,
+  type StreamClosedMetricReason,
+  streamClosedCount,
+} from '#metrics/instance.js';
+
+interface CloseAbandonedStreamsMetrics {
+  recordAppended(kind: StepAttemptTerminalCauseDto): void;
+  streamClosed(reason: StreamClosedMetricReason): void;
+}
+
+const defaultMetrics: CloseAbandonedStreamsMetrics = {
+  recordAppended: (kind) => recordAppendedCount.add(1, {kind}),
+  streamClosed: (reason) => streamClosedCount.add(1, {reason}),
+};
+
+function recordCloseMetrics(
+  metrics: CloseAbandonedStreamsMetrics,
+  terminalCause: StepAttemptTerminalCauseDto | null,
+): void {
+  if (terminalCause !== null) metrics.recordAppended(terminalCause);
+  metrics.streamClosed(
+    terminalCause === 'timed_out' ? 'job_timeout' : (terminalCause ?? 'abandoned'),
+  );
+}
 
 /**
  * Job termination does not guarantee the runner flushed an end record: it may have
@@ -10,10 +34,14 @@ import {recordAppendedCount, streamClosedCount} from '#metrics/instance.js';
  * through the guarded `closeStream`, so a declared-close race is skipped instead of
  * writing a duplicate event or tombstone.
  */
-export async function closeAbandonedStreamsActivity(params: {
-  jobId: string;
-  terminalCause: StepAttemptTerminalCauseDto;
-}): Promise<{closed: number}> {
+export async function closeAbandonedStreamsActivity(
+  params: {
+    jobId: string;
+    terminalCause?: StepAttemptTerminalCauseDto | null | undefined;
+  },
+  metrics: CloseAbandonedStreamsMetrics = defaultMetrics,
+): Promise<{closed: number}> {
+  const terminalCause = params.terminalCause === undefined ? 'runner_lost' : params.terminalCause;
   const open = await listOpenStreamsByJob(params.jobId);
 
   let closed = 0;
@@ -22,15 +50,12 @@ export async function closeAbandonedStreamsActivity(params: {
       closeStream(tx, {
         streamId: stream.id,
         reason: 'timeout',
-        terminalCause: params.terminalCause,
+        terminalCause,
       }),
     );
     if (result) {
       closed += 1;
-      recordAppendedCount.add(1, {kind: params.terminalCause});
-      streamClosedCount.add(1, {
-        reason: params.terminalCause === 'timed_out' ? 'job_timeout' : params.terminalCause,
-      });
+      recordCloseMetrics(metrics, terminalCause);
     }
   }
 

--- a/libs/api/logs/src/temporal/activities/close-abandoned-streams.ts
+++ b/libs/api/logs/src/temporal/activities/close-abandoned-streams.ts
@@ -1,3 +1,4 @@
+import type {StepAttemptTerminalCauseDto} from '@shipfox/api-workflows-dto';
 import {closeStream} from '#core/close-stream.js';
 import {db} from '#db/db.js';
 import {listOpenStreamsByJob} from '#db/streams.js';
@@ -11,18 +12,25 @@ import {recordAppendedCount, streamClosedCount} from '#metrics/instance.js';
  */
 export async function closeAbandonedStreamsActivity(params: {
   jobId: string;
+  terminalCause: StepAttemptTerminalCauseDto;
 }): Promise<{closed: number}> {
   const open = await listOpenStreamsByJob(params.jobId);
 
   let closed = 0;
   for (const stream of open) {
     const result = await db().transaction((tx) =>
-      closeStream(tx, {streamId: stream.id, reason: 'timeout'}),
+      closeStream(tx, {
+        streamId: stream.id,
+        reason: 'timeout',
+        terminalCause: params.terminalCause,
+      }),
     );
     if (result) {
       closed += 1;
-      recordAppendedCount.add(1, {kind: 'runner_lost'});
-      streamClosedCount.add(1, {reason: 'timeout'});
+      recordAppendedCount.add(1, {kind: params.terminalCause});
+      streamClosedCount.add(1, {
+        reason: params.terminalCause === 'timed_out' ? 'job_timeout' : params.terminalCause,
+      });
     }
   }
 

--- a/libs/api/logs/src/temporal/workflows/close-abandoned-streams.ts
+++ b/libs/api/logs/src/temporal/workflows/close-abandoned-streams.ts
@@ -9,7 +9,7 @@ const {closeAbandonedStreamsActivity} = proxyActivities<ReturnType<typeof create
 export interface CloseAbandonedStreamsInput {
   jobId: string;
   graceSeconds: number;
-  terminalCause?: StepAttemptTerminalCauseDto | undefined;
+  terminalCause?: StepAttemptTerminalCauseDto | null | undefined;
 }
 
 /**
@@ -22,7 +22,7 @@ export async function closeAbandonedStreams(input: CloseAbandonedStreamsInput): 
 
   const {closed} = await closeAbandonedStreamsActivity({
     jobId: input.jobId,
-    terminalCause: input.terminalCause ?? 'runner_lost',
+    terminalCause: input.terminalCause === undefined ? 'runner_lost' : input.terminalCause,
   });
   if (closed > 0) {
     log.info('Force-closed abandoned log streams', {jobId: input.jobId, closed});

--- a/libs/api/logs/src/temporal/workflows/close-abandoned-streams.ts
+++ b/libs/api/logs/src/temporal/workflows/close-abandoned-streams.ts
@@ -1,3 +1,4 @@
+import type {StepAttemptTerminalCauseDto} from '@shipfox/api-workflows-dto';
 import {log, proxyActivities, sleep} from '@temporalio/workflow';
 import type {createLogsActivities} from '../activities/index.js';
 
@@ -8,6 +9,7 @@ const {closeAbandonedStreamsActivity} = proxyActivities<ReturnType<typeof create
 export interface CloseAbandonedStreamsInput {
   jobId: string;
   graceSeconds: number;
+  terminalCause?: StepAttemptTerminalCauseDto | undefined;
 }
 
 /**
@@ -18,7 +20,10 @@ export interface CloseAbandonedStreamsInput {
 export async function closeAbandonedStreams(input: CloseAbandonedStreamsInput): Promise<void> {
   await sleep(input.graceSeconds * 1000);
 
-  const {closed} = await closeAbandonedStreamsActivity({jobId: input.jobId});
+  const {closed} = await closeAbandonedStreamsActivity({
+    jobId: input.jobId,
+    terminalCause: input.terminalCause ?? 'runner_lost',
+  });
   if (closed > 0) {
     log.info('Force-closed abandoned log streams', {jobId: input.jobId, closed});
   }

--- a/libs/api/logs/src/temporal/workflows/close-abandoned-streams.ts
+++ b/libs/api/logs/src/temporal/workflows/close-abandoned-streams.ts
@@ -22,7 +22,7 @@ export async function closeAbandonedStreams(input: CloseAbandonedStreamsInput): 
 
   const {closed} = await closeAbandonedStreamsActivity({
     jobId: input.jobId,
-    terminalCause: input.terminalCause === undefined ? 'runner_lost' : input.terminalCause,
+    terminalCause: input.terminalCause,
   });
   if (closed > 0) {
     log.info('Force-closed abandoned log streams', {jobId: input.jobId, closed});

--- a/libs/api/logs/test/fixtures/closed-stream.ts
+++ b/libs/api/logs/test/fixtures/closed-stream.ts
@@ -46,6 +46,7 @@ export function arrangeClosedStream(
     const closed = await closeStream(tx, {
       streamId: stream.id,
       reason: options.tombstone ? 'timeout' : 'declared',
+      terminalCause: options.tombstone ? 'runner_lost' : null,
     });
 
     return closed ?? stream;

--- a/libs/api/workflows-dto/src/events.test.ts
+++ b/libs/api/workflows-dto/src/events.test.ts
@@ -120,6 +120,7 @@ const validStepAttemptTerminated = {
   attempt: 1,
   status: 'failed',
   logOutcome: 'drained',
+  terminalCause: null,
   stepAttemptId: 'step-attempt-1',
 };
 
@@ -562,6 +563,24 @@ describe('workflowsStepAttemptTerminatedSchema', () => {
     const result = workflowsStepAttemptTerminatedSchema.parse(withoutStepAttemptId);
 
     expect(result.stepAttemptId).toBeUndefined();
+  });
+
+  it('accepts each authoritative terminal cause', () => {
+    for (const terminalCause of ['timed_out', 'run_cancelled', 'runner_lost'] as const) {
+      expect(
+        workflowsStepAttemptTerminatedSchema.parse({
+          ...validStepAttemptTerminated,
+          logOutcome: 'abandoned',
+          terminalCause,
+        }).terminalCause,
+      ).toBe(terminalCause);
+    }
+  });
+
+  it('accepts a payload without terminalCause from a pre-change producer', () => {
+    const {terminalCause: _terminalCause, ...legacy} = validStepAttemptTerminated;
+
+    expect(workflowsStepAttemptTerminatedSchema.parse(legacy).terminalCause).toBeUndefined();
   });
 });
 

--- a/libs/api/workflows-dto/src/events.ts
+++ b/libs/api/workflows-dto/src/events.ts
@@ -53,6 +53,9 @@ export const workflowRunTerminalStatusSchema = z.enum(['succeeded', 'failed', 'c
 export const jobTerminalStatusSchema = z.enum(['succeeded', 'failed', 'cancelled', 'skipped']);
 export const terminalStatusSchema = workflowRunTerminalStatusSchema;
 
+export const stepAttemptTerminalCauseSchema = z.enum(['timed_out', 'run_cancelled', 'runner_lost']);
+export type StepAttemptTerminalCauseDto = z.infer<typeof stepAttemptTerminalCauseSchema>;
+
 export const workflowsWorkflowRunTerminatedSchema = z.object({
   workflowRunId: nonEmptyStringSchema,
   workflowRunAttemptId: nonEmptyStringSchema,
@@ -247,6 +250,10 @@ export const workflowsStepAttemptTerminatedSchema = z.object({
   // before the status field was added. New outbox events always include it.
   status: terminalStatusSchema.optional(),
   logOutcome: logOutcomeSchema,
+  // Optional for events written before terminal cause was separated from the
+  // log-drain outcome. New events always include either the authoritative cause
+  // or null when an abandoned drain is not a runner termination.
+  terminalCause: stepAttemptTerminalCauseSchema.nullable().optional(),
   // Optional so the subscriber can continue to consume terminal events written
   // before the field was added. New outbox events always include the step-attempt
   // id; consumers that need the exact attempt identity (e.g. session claim

--- a/libs/api/workflows-dto/src/index.ts
+++ b/libs/api/workflows-dto/src/index.ts
@@ -284,6 +284,8 @@ export {
   type ListenerFilterExpressionType,
   type ListenerFilterOutputTypes,
   listenerFilterOutputTypesSchema,
+  type StepAttemptTerminalCauseDto,
+  stepAttemptTerminalCauseSchema,
   terminalStatusSchema,
   WORKFLOWS_JOB_ACTIVATED,
   WORKFLOWS_JOB_EVENT_DELIVERED,

--- a/libs/api/workflows-dto/src/schemas/step.test.ts
+++ b/libs/api/workflows-dto/src/schemas/step.test.ts
@@ -310,7 +310,7 @@ describe('stepStatusReasonSchema', () => {
   });
 
   it('rejects an unknown step status reason', () => {
-    expect(stepStatusReasonSchema.safeParse('runner_lost').success).toBe(false);
+    expect(stepStatusReasonSchema.safeParse('not_a_reason').success).toBe(false);
   });
 });
 

--- a/libs/api/workflows-dto/src/schemas/step.ts
+++ b/libs/api/workflows-dto/src/schemas/step.ts
@@ -7,6 +7,9 @@ export const STEP_STATUS_REASONS = [
   'default_gate_rejected',
   'condition_rejected',
   'condition_errored',
+  'timed_out',
+  'run_cancelled',
+  'runner_lost',
 ] as const;
 
 export const stepStatusReasonSchema = z.enum(STEP_STATUS_REASONS);

--- a/libs/api/workflows/drizzle/0011_overrated_adam_warlock.sql
+++ b/libs/api/workflows/drizzle/0011_overrated_adam_warlock.sql
@@ -1,0 +1,3 @@
+ALTER TYPE "public"."workflows_step_status_reason" ADD VALUE 'timed_out';--> statement-breakpoint
+ALTER TYPE "public"."workflows_step_status_reason" ADD VALUE 'run_cancelled';--> statement-breakpoint
+ALTER TYPE "public"."workflows_step_status_reason" ADD VALUE 'runner_lost';

--- a/libs/api/workflows/drizzle/meta/0011_snapshot.json
+++ b/libs/api/workflows/drizzle/meta/0011_snapshot.json
@@ -1,0 +1,2258 @@
+{
+  "id": "d99ce582-5d65-4d0a-9e8d-f85189d2bf8c",
+  "prevId": "5345bff7-25f3-44a4-aaab-8899faf68873",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.workflows_checkout_renewal_subjects": {
+      "name": "workflows_checkout_renewal_subjects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "step_id": {
+          "name": "step_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow_run_attempt_id": {
+          "name": "workflow_run_attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "workflows_checkout_renewal_subject_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "repository_url": {
+          "name": "repository_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_repository_id": {
+          "name": "external_repository_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permissions_contents": {
+          "name": "permissions_contents",
+          "type": "workflows_checkout_contents",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "promoted_at": {
+          "name": "promoted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workflows_crs_step_id_attempt_uq": {
+          "name": "workflows_crs_step_id_attempt_uq",
+          "columns": [
+            {
+              "expression": "step_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attempt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_crs_workflow_run_attempt_id_idx": {
+          "name": "workflows_crs_workflow_run_attempt_id_idx",
+          "columns": [
+            {
+              "expression": "workflow_run_attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflows_checkout_renewal_subjects_step_id_workflows_steps_id_fk": {
+          "name": "workflows_checkout_renewal_subjects_step_id_workflows_steps_id_fk",
+          "tableFrom": "workflows_checkout_renewal_subjects",
+          "tableTo": "workflows_steps",
+          "columnsFrom": ["step_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflows_checkout_renewal_subjects_workflow_run_attempt_id_workflows_workflow_run_attempts_id_fk": {
+          "name": "workflows_checkout_renewal_subjects_workflow_run_attempt_id_workflows_workflow_run_attempts_id_fk",
+          "tableFrom": "workflows_checkout_renewal_subjects",
+          "tableTo": "workflows_workflow_run_attempts",
+          "columnsFrom": ["workflow_run_attempt_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workflows_crs_attempt_positive_ck": {
+          "name": "workflows_crs_attempt_positive_ck",
+          "value": "\"workflows_checkout_renewal_subjects\".\"attempt\" > 0"
+        },
+        "workflows_crs_promoted_at_ck": {
+          "name": "workflows_crs_promoted_at_ck",
+          "value": "(\"workflows_checkout_renewal_subjects\".\"status\" = 'pending' and \"workflows_checkout_renewal_subjects\".\"promoted_at\" is null) or (\"workflows_checkout_renewal_subjects\".\"status\" = 'promoted' and \"workflows_checkout_renewal_subjects\".\"promoted_at\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workflows_job_executions": {
+      "name": "workflows_job_executions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runner": {
+          "name": "runner",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runner_labels": {
+          "name": "runner_labels",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template_key": {
+          "name": "template_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provisioner_id": {
+          "name": "provisioner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provisioner_scope": {
+          "name": "provisioner_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_kind": {
+          "name": "provider_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "launch_kind": {
+          "name": "launch_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "workflows_job_execution_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "status_reason": {
+          "name": "status_reason",
+          "type": "workflows_job_status_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_reason_message": {
+          "name": "status_reason_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_events": {
+          "name": "trigger_events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outputs": {
+          "name": "outputs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "evaluation_trace": {
+          "name": "evaluation_trace",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "queued_at": {
+          "name": "queued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timed_out_at": {
+          "name": "timed_out_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workflows_job_executions_job_id_idx": {
+          "name": "workflows_job_executions_job_id_idx",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_job_executions_running_idx": {
+          "name": "workflows_job_executions_running_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"workflows_job_executions\".\"status\" = 'running'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_job_executions_job_sequence_uq": {
+          "name": "workflows_job_executions_job_sequence_uq",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflows_job_executions_job_id_workflows_jobs_id_fk": {
+          "name": "workflows_job_executions_job_id_workflows_jobs_id_fk",
+          "tableFrom": "workflows_job_executions",
+          "tableTo": "workflows_jobs",
+          "columnsFrom": ["job_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflows_job_listener_events": {
+      "name": "workflows_job_listener_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disposition": {
+          "name": "disposition",
+          "type": "workflows_job_listener_event_disposition",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "workflows_job_listener_event_outcome",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "outcome_reason": {
+          "name": "outcome_reason",
+          "type": "workflows_job_listener_event_outcome_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_ref": {
+          "name": "event_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delivery_id": {
+          "name": "delivery_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event": {
+          "name": "event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_reference": {
+          "name": "trigger_reference",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stored_payload_bytes": {
+          "name": "stored_payload_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "normalized_event_bytes": {
+          "name": "normalized_event_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_by_execution_id": {
+          "name": "consumed_by_execution_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workflows_job_listener_events_job_event_ref_unique": {
+          "name": "workflows_job_listener_events_job_event_ref_unique",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_job_listener_events_job_received_idx": {
+          "name": "workflows_job_listener_events_job_received_idx",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_job_listener_events_pending_order_idx": {
+          "name": "workflows_job_listener_events_pending_order_idx",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"workflows_job_listener_events\".\"consumed_by_execution_id\" IS NULL AND \"workflows_job_listener_events\".\"outcome\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_job_listener_events_consumed_order_idx": {
+          "name": "workflows_job_listener_events_consumed_order_idx",
+          "columns": [
+            {
+              "expression": "consumed_by_execution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"workflows_job_listener_events\".\"consumed_by_execution_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflows_job_listener_events_job_id_workflows_jobs_id_fk": {
+          "name": "workflows_job_listener_events_job_id_workflows_jobs_id_fk",
+          "tableFrom": "workflows_job_listener_events",
+          "tableTo": "workflows_jobs",
+          "columnsFrom": ["job_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflows_job_listener_events_consumed_by_execution_id_workflows_job_executions_id_fk": {
+          "name": "workflows_job_listener_events_consumed_by_execution_id_workflows_job_executions_id_fk",
+          "tableFrom": "workflows_job_listener_events",
+          "tableTo": "workflows_job_executions",
+          "columnsFrom": ["consumed_by_execution_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workflows_job_listener_events_byte_counts_ck": {
+          "name": "workflows_job_listener_events_byte_counts_ck",
+          "value": "\"workflows_job_listener_events\".\"stored_payload_bytes\" >= 0 AND \"workflows_job_listener_events\".\"normalized_event_bytes\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workflows_jobs": {
+      "name": "workflows_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workflow_run_attempt_id": {
+          "name": "workflow_run_attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "workflows_job_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'one_shot'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "workflows_job_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "status_reason": {
+          "name": "status_reason",
+          "type": "workflows_job_status_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "carried_over": {
+          "name": "carried_over",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "checkout_persist_credentials": {
+          "name": "checkout_persist_credentials",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "checkout_permissions_contents": {
+          "name": "checkout_permissions_contents",
+          "type": "workflows_checkout_contents",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "success": {
+          "name": "success",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "evaluation_trace": {
+          "name": "evaluation_trace",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_timeout_ms": {
+          "name": "execution_timeout_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "listening_timeout_ms": {
+          "name": "listening_timeout_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_executions": {
+          "name": "max_executions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "on_resolve": {
+          "name": "on_resolve",
+          "type": "workflows_job_on_resolve",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "batch_debounce_ms": {
+          "name": "batch_debounce_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "batch_max_size": {
+          "name": "batch_max_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "batch_max_wait_ms": {
+          "name": "batch_max_wait_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "listener_status": {
+          "name": "listener_status",
+          "type": "workflows_listener_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'inactive'"
+        },
+        "resolution_reason": {
+          "name": "resolution_reason",
+          "type": "workflows_resolution_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "listening_on": {
+          "name": "listening_on",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "listening_until": {
+          "name": "listening_until",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outputs": {
+          "name": "outputs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dependencies": {
+          "name": "dependencies",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runner": {
+          "name": "runner",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workflows_jobs_workflow_run_attempt_id_idx": {
+          "name": "workflows_jobs_workflow_run_attempt_id_idx",
+          "columns": [
+            {
+              "expression": "workflow_run_attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_jobs_active_listeners_idx": {
+          "name": "workflows_jobs_active_listeners_idx",
+          "columns": [
+            {
+              "expression": "listener_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"workflows_jobs\".\"listener_status\" = 'listening'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflows_jobs_workflow_run_attempt_id_workflows_workflow_run_attempts_id_fk": {
+          "name": "workflows_jobs_workflow_run_attempt_id_workflows_workflow_run_attempts_id_fk",
+          "tableFrom": "workflows_jobs",
+          "tableTo": "workflows_workflow_run_attempts",
+          "columnsFrom": ["workflow_run_attempt_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflows_outbox": {
+      "name": "workflows_outbox",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ordering_key": {
+          "name": "ordering_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "dispatched_at": {
+          "name": "dispatched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dispatch_attempts": {
+          "name": "dispatch_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_dispatch_at": {
+          "name": "next_dispatch_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_dispatch_error": {
+          "name": "last_dispatch_error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_dispatch_failed_at": {
+          "name": "last_dispatch_failed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dead_lettered_at": {
+          "name": "dead_lettered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workflows_outbox_pending_idx": {
+          "name": "workflows_outbox_pending_idx",
+          "columns": [
+            {
+              "expression": "next_dispatch_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"dispatched_at\" IS NULL AND \"dead_lettered_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_outbox_dispatched_retention_idx": {
+          "name": "workflows_outbox_dispatched_retention_idx",
+          "columns": [
+            {
+              "expression": "dispatched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"dispatched_at\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflows_step_attempts": {
+      "name": "workflows_step_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "step_id": {
+          "name": "step_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_execution_id": {
+          "name": "job_execution_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "execution_order": {
+          "name": "execution_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "workflows_step_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "evaluation_trace": {
+          "name": "evaluation_trace",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output": {
+          "name": "output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exit_code": {
+          "name": "exit_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "log_outcome": {
+          "name": "log_outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gate_result": {
+          "name": "gate_result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "restart_feedback": {
+          "name": "restart_feedback",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invocations": {
+          "name": "invocations",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workflows_step_attempts_step_id_workflows_steps_id_fk": {
+          "name": "workflows_step_attempts_step_id_workflows_steps_id_fk",
+          "tableFrom": "workflows_step_attempts",
+          "tableTo": "workflows_steps",
+          "columnsFrom": ["step_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflows_step_attempts_step_id_job_execution_id_workflows_steps_fk": {
+          "name": "workflows_step_attempts_step_id_job_execution_id_workflows_steps_fk",
+          "tableFrom": "workflows_step_attempts",
+          "tableTo": "workflows_steps",
+          "columnsFrom": ["step_id", "job_execution_id"],
+          "columnsTo": ["id", "job_execution_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workflows_step_attempts_step_id_attempt_uq": {
+          "name": "workflows_step_attempts_step_id_attempt_uq",
+          "nullsNotDistinct": false,
+          "columns": ["step_id", "attempt"]
+        },
+        "workflows_step_attempts_job_execution_id_execution_order_uq": {
+          "name": "workflows_step_attempts_job_execution_id_execution_order_uq",
+          "nullsNotDistinct": false,
+          "columns": ["job_execution_id", "execution_order"]
+        },
+        "workflows_step_attempts_id_step_id_job_execution_id_uq": {
+          "name": "workflows_step_attempts_id_step_id_job_execution_id_uq",
+          "nullsNotDistinct": false,
+          "columns": ["id", "step_id", "job_execution_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "workflows_step_attempts_attempt_positive_ck": {
+          "name": "workflows_step_attempts_attempt_positive_ck",
+          "value": "\"workflows_step_attempts\".\"attempt\" > 0"
+        },
+        "workflows_step_attempts_execution_order_positive_ck": {
+          "name": "workflows_step_attempts_execution_order_positive_ck",
+          "value": "\"workflows_step_attempts\".\"execution_order\" > 0"
+        },
+        "workflows_step_attempts_status_dispatched_ck": {
+          "name": "workflows_step_attempts_status_dispatched_ck",
+          "value": "\"workflows_step_attempts\".\"status\" NOT IN ('pending', 'skipped')"
+        },
+        "workflows_step_attempts_log_outcome_ck": {
+          "name": "workflows_step_attempts_log_outcome_ck",
+          "value": "\"workflows_step_attempts\".\"log_outcome\" IS NULL OR \"workflows_step_attempts\".\"log_outcome\" IN ('drained', 'abandoned')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workflows_steps": {
+      "name": "workflows_steps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "job_execution_id": {
+          "name": "job_execution_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_location": {
+          "name": "source_location",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "workflows_step_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "status_reason": {
+          "name": "status_reason",
+          "type": "workflows_step_status_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "evaluation_trace": {
+          "name": "evaluation_trace",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "condition": {
+          "name": "condition",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config_plan": {
+          "name": "config_plan",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authored_config": {
+          "name": "authored_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "current_attempt": {
+          "name": "current_attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workflows_steps_job_execution_id_idx": {
+          "name": "workflows_steps_job_execution_id_idx",
+          "columns": [
+            {
+              "expression": "job_execution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_steps_id_job_execution_id_uq": {
+          "name": "workflows_steps_id_job_execution_id_uq",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "job_execution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflows_steps_job_execution_id_workflows_job_executions_id_fk": {
+          "name": "workflows_steps_job_execution_id_workflows_job_executions_id_fk",
+          "tableFrom": "workflows_steps",
+          "tableTo": "workflows_job_executions",
+          "columnsFrom": ["job_execution_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workflows_steps_current_attempt_positive_ck": {
+          "name": "workflows_steps_current_attempt_positive_ck",
+          "value": "\"workflows_steps\".\"current_attempt\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workflows_tool_invocations": {
+      "name": "workflows_tool_invocations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "step_id": {
+          "name": "step_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_attempt_id": {
+          "name": "step_attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_execution_id": {
+          "name": "job_execution_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "workflows_tool_invocation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "call_index": {
+          "name": "call_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "due_at": {
+          "name": "due_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimed_by": {
+          "name": "claimed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_expires_at": {
+          "name": "claim_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workflows_tool_invocations_job_execution_id_idx": {
+          "name": "workflows_tool_invocations_job_execution_id_idx",
+          "columns": [
+            {
+              "expression": "job_execution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_tool_invocations_due_at_unsettled_idx": {
+          "name": "workflows_tool_invocations_due_at_unsettled_idx",
+          "columns": [
+            {
+              "expression": "due_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"workflows_tool_invocations\".\"status\" <> 'settled'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflows_tool_invocations_step_id_workflows_steps_id_fk": {
+          "name": "workflows_tool_invocations_step_id_workflows_steps_id_fk",
+          "tableFrom": "workflows_tool_invocations",
+          "tableTo": "workflows_steps",
+          "columnsFrom": ["step_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflows_tool_invocations_step_attempt_id_workflows_step_attempts_id_fk": {
+          "name": "workflows_tool_invocations_step_attempt_id_workflows_step_attempts_id_fk",
+          "tableFrom": "workflows_tool_invocations",
+          "tableTo": "workflows_step_attempts",
+          "columnsFrom": ["step_attempt_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflows_tool_invocations_job_execution_id_workflows_job_executions_id_fk": {
+          "name": "workflows_tool_invocations_job_execution_id_workflows_job_executions_id_fk",
+          "tableFrom": "workflows_tool_invocations",
+          "tableTo": "workflows_job_executions",
+          "columnsFrom": ["job_execution_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflows_tool_invocations_step_id_job_execution_id_workflows_steps_fk": {
+          "name": "workflows_tool_invocations_step_id_job_execution_id_workflows_steps_fk",
+          "tableFrom": "workflows_tool_invocations",
+          "tableTo": "workflows_steps",
+          "columnsFrom": ["step_id", "job_execution_id"],
+          "columnsTo": ["id", "job_execution_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflows_tool_invocations_step_attempt_id_step_id_job_execution_id_workflows_step_attempts_fk": {
+          "name": "workflows_tool_invocations_step_attempt_id_step_id_job_execution_id_workflows_step_attempts_fk",
+          "tableFrom": "workflows_tool_invocations",
+          "tableTo": "workflows_step_attempts",
+          "columnsFrom": ["step_attempt_id", "step_id", "job_execution_id"],
+          "columnsTo": ["id", "step_id", "job_execution_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workflows_tool_invocations_step_attempt_id_uq": {
+          "name": "workflows_tool_invocations_step_attempt_id_uq",
+          "nullsNotDistinct": false,
+          "columns": ["step_attempt_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "workflows_tool_invocations_call_index_nonnegative_ck": {
+          "name": "workflows_tool_invocations_call_index_nonnegative_ck",
+          "value": "\"workflows_tool_invocations\".\"call_index\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workflows_workflow_run_attempts": {
+      "name": "workflows_workflow_run_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workflow_run_id": {
+          "name": "workflow_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "workflows_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "rerun_mode": {
+          "name": "rerun_mode",
+          "type": "workflows_rerun_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rerun_by_user_id": {
+          "name": "rerun_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vars": {
+          "name": "vars",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_tool_materialization": {
+          "name": "agent_tool_materialization",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workflows_wra_workflow_run_attempt_unique": {
+          "name": "workflows_wra_workflow_run_attempt_unique",
+          "columns": [
+            {
+              "expression": "workflow_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attempt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_wra_one_active_attempt_unique": {
+          "name": "workflows_wra_one_active_attempt_unique",
+          "columns": [
+            {
+              "expression": "workflow_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"workflows_workflow_run_attempts\".\"status\" not in ('succeeded', 'failed', 'cancelled')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflows_workflow_run_attempts_workflow_run_id_workflows_workflow_runs_id_fk": {
+          "name": "workflows_workflow_run_attempts_workflow_run_id_workflows_workflow_runs_id_fk",
+          "tableFrom": "workflows_workflow_run_attempts",
+          "tableTo": "workflows_workflow_runs",
+          "columnsFrom": ["workflow_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workflows_wra_attempt_positive_ck": {
+          "name": "workflows_wra_attempt_positive_ck",
+          "value": "\"workflows_workflow_run_attempts\".\"attempt\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workflows_workflow_run_counters": {
+      "name": "workflows_workflow_run_counters",
+      "schema": "",
+      "columns": {
+        "definition_id": {
+          "name": "definition_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "next_number": {
+          "name": "next_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "workflows_wrrc_definition_id_unique": {
+          "name": "workflows_wrrc_definition_id_unique",
+          "columns": [
+            {
+              "expression": "definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflows_workflow_runs": {
+      "name": "workflows_workflow_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_name": {
+          "name": "workflow_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "workflows_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'synced'"
+        },
+        "dev_source": {
+          "name": "dev_source",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_attempt": {
+          "name": "current_attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "trigger_provider": {
+          "name": "trigger_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_source": {
+          "name": "trigger_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_event": {
+          "name": "trigger_event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_payload": {
+          "name": "trigger_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_reference": {
+          "name": "trigger_reference",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inputs": {
+          "name": "inputs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_snapshot": {
+          "name": "source_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_idempotency_key": {
+          "name": "trigger_idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timeout_ms": {
+          "name": "timeout_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2592000000
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workflows_wr_trigger_idempotency_key_unique": {
+          "name": "workflows_wr_trigger_idempotency_key_unique",
+          "columns": [
+            {
+              "expression": "trigger_idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_wr_definition_number_unique": {
+          "name": "workflows_wr_definition_number_unique",
+          "columns": [
+            {
+              "expression": "definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_wr_project_created_id_idx": {
+          "name": "workflows_wr_project_created_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_wr_project_origin_created_id_idx": {
+          "name": "workflows_wr_project_origin_created_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "origin",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_wr_project_status_created_id_idx": {
+          "name": "workflows_wr_project_status_created_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_wr_project_definition_created_id_idx": {
+          "name": "workflows_wr_project_definition_created_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_wr_project_trigger_created_id_idx": {
+          "name": "workflows_wr_project_trigger_created_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trigger_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_wr_running_idx": {
+          "name": "workflows_wr_running_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"workflows_workflow_runs\".\"status\" = 'running'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workflows_wr_current_attempt_positive_ck": {
+          "name": "workflows_wr_current_attempt_positive_ck",
+          "value": "\"workflows_workflow_runs\".\"current_attempt\" > 0"
+        },
+        "workflows_wr_origin_ck": {
+          "name": "workflows_wr_origin_ck",
+          "value": "\"workflows_workflow_runs\".\"origin\" in ('synced', 'dev')"
+        },
+        "workflows_wr_dev_source_ck": {
+          "name": "workflows_wr_dev_source_ck",
+          "value": "(\n        (\"workflows_workflow_runs\".\"origin\" = 'synced' and \"workflows_workflow_runs\".\"dev_source\" is null)\n        or (\n          \"workflows_workflow_runs\".\"origin\" = 'dev'\n          and \"workflows_workflow_runs\".\"dev_source\" is not null\n          and jsonb_typeof(\"workflows_workflow_runs\".\"dev_source\") = 'object'\n        )\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.workflows_checkout_renewal_subject_status": {
+      "name": "workflows_checkout_renewal_subject_status",
+      "schema": "public",
+      "values": ["pending", "promoted"]
+    },
+    "public.workflows_job_execution_status": {
+      "name": "workflows_job_execution_status",
+      "schema": "public",
+      "values": ["pending", "running", "succeeded", "failed", "cancelled"]
+    },
+    "public.workflows_job_listener_event_disposition": {
+      "name": "workflows_job_listener_event_disposition",
+      "schema": "public",
+      "values": ["fire", "resolve"]
+    },
+    "public.workflows_job_listener_event_outcome": {
+      "name": "workflows_job_listener_event_outcome",
+      "schema": "public",
+      "values": ["pending", "consumed", "honored", "rejected", "abandoned"]
+    },
+    "public.workflows_job_listener_event_outcome_reason": {
+      "name": "workflows_job_listener_event_outcome_reason",
+      "schema": "public",
+      "values": ["payload_too_large", "until", "timeout", "max_executions", "cancelled"]
+    },
+    "public.workflows_checkout_contents": {
+      "name": "workflows_checkout_contents",
+      "schema": "public",
+      "values": ["read", "write"]
+    },
+    "public.workflows_job_mode": {
+      "name": "workflows_job_mode",
+      "schema": "public",
+      "values": ["one_shot", "listening"]
+    },
+    "public.workflows_job_on_resolve": {
+      "name": "workflows_job_on_resolve",
+      "schema": "public",
+      "values": ["finish", "cancel"]
+    },
+    "public.workflows_job_status": {
+      "name": "workflows_job_status",
+      "schema": "public",
+      "values": ["pending", "running", "succeeded", "failed", "cancelled", "skipped"]
+    },
+    "public.workflows_job_status_reason": {
+      "name": "workflows_job_status_reason",
+      "schema": "public",
+      "values": [
+        "dependency_not_completed",
+        "condition_false",
+        "default_gate_rejected",
+        "condition_rejected",
+        "condition_errored",
+        "user_cancelled",
+        "run_cancelled",
+        "timed_out",
+        "runner_lost",
+        "output_too_large",
+        "step_failed",
+        "unknown",
+        "output_invalid"
+      ]
+    },
+    "public.workflows_listener_status": {
+      "name": "workflows_listener_status",
+      "schema": "public",
+      "values": ["inactive", "listening", "resolved"]
+    },
+    "public.workflows_resolution_reason": {
+      "name": "workflows_resolution_reason",
+      "schema": "public",
+      "values": ["until", "timeout", "max_executions", "cancelled"]
+    },
+    "public.workflows_step_status": {
+      "name": "workflows_step_status",
+      "schema": "public",
+      "values": ["pending", "running", "succeeded", "failed", "cancelled", "skipped"]
+    },
+    "public.workflows_step_status_reason": {
+      "name": "workflows_step_status_reason",
+      "schema": "public",
+      "values": [
+        "default_gate_rejected",
+        "condition_rejected",
+        "condition_errored",
+        "timed_out",
+        "run_cancelled",
+        "runner_lost"
+      ]
+    },
+    "public.workflows_tool_invocation_status": {
+      "name": "workflows_tool_invocation_status",
+      "schema": "public",
+      "values": ["queued", "in_flight", "settled"]
+    },
+    "public.workflows_rerun_mode": {
+      "name": "workflows_rerun_mode",
+      "schema": "public",
+      "values": ["all", "failed"]
+    },
+    "public.workflows_run_status": {
+      "name": "workflows_run_status",
+      "schema": "public",
+      "values": ["waiting", "pending", "running", "succeeded", "failed", "cancelled"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/libs/api/workflows/drizzle/meta/_journal.json
+++ b/libs/api/workflows/drizzle/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1788884361299,
       "tag": "0010_colossal_prism",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1788947365487,
+      "tag": "0011_overrated_adam_warlock",
+      "breakpoints": true
     }
   ]
 }

--- a/libs/api/workflows/src/core/entities/step.ts
+++ b/libs/api/workflows/src/core/entities/step.ts
@@ -22,6 +22,9 @@ export const STEP_STATUS_REASONS = [
   'default_gate_rejected',
   'condition_rejected',
   'condition_errored',
+  'timed_out',
+  'run_cancelled',
+  'runner_lost',
 ] as const;
 
 export type StepStatusReason = (typeof STEP_STATUS_REASONS)[number];

--- a/libs/api/workflows/src/core/job-execution.test.ts
+++ b/libs/api/workflows/src/core/job-execution.test.ts
@@ -1831,6 +1831,7 @@ describe('step attempts', () => {
         attempt: 1,
         status: 'failed',
         logOutcome: 'abandoned',
+        terminalCause: null,
         stepAttemptId: expect.any(String),
       },
     ]);

--- a/libs/api/workflows/src/db/job-listeners.ts
+++ b/libs/api/workflows/src/db/job-listeners.ts
@@ -720,7 +720,11 @@ export async function settleListenerJobExecution(params: {
       launchKind: execution.launchKind,
     });
     await bulkUpdateStepStatuses(
-      {jobExecutionId: params.jobExecutionId, status: params.status},
+      {
+        jobExecutionId: params.jobExecutionId,
+        status: params.status,
+        ...(params.status === 'cancelled' ? {terminalCause: 'run_cancelled' as const} : {}),
+      },
       tx,
     );
     return true;

--- a/libs/api/workflows/src/db/job-listeners.ts
+++ b/libs/api/workflows/src/db/job-listeners.ts
@@ -78,6 +78,7 @@ import {lockWorkflowRun} from './workflow-runs/shared.js';
 import {
   bulkUpdateStepStatuses,
   getDirectDependencyJobContexts,
+  getStepsByJobExecutionIdForUpdate,
   loadReferencedVariables,
   updateJobStatusAtVersion,
   writeJobExecutionTerminatedOutbox,
@@ -686,6 +687,8 @@ export async function settleListenerJobExecution(params: {
   status: Extract<JobExecutionStatus, 'failed' | 'cancelled'>;
 }): Promise<void> {
   const changed = await db().transaction(async (tx) => {
+    await getStepsByJobExecutionIdForUpdate(params.jobExecutionId, tx);
+
     const [execution] = await tx
       .update(jobExecutions)
       .set({

--- a/libs/api/workflows/src/db/workflow-runs/job-executions.test.ts
+++ b/libs/api/workflows/src/db/workflow-runs/job-executions.test.ts
@@ -29,6 +29,7 @@ import {workflowsOutbox} from '../schema/outbox.js';
 import {
   applyStepResult,
   createWorkflowRun,
+  failJobExecutionAsTimedOut,
   finishStepAttempt,
   getFirstJobExecutionByJobId,
   getJobsByWorkflowRunId,
@@ -410,6 +411,81 @@ describe('workflow run job executions', () => {
     });
     expect(await stepAttemptTerminatedEvents(job.id)).toMatchObject([
       expect.objectContaining({terminalCause: 'runner_lost'}),
+    ]);
+  });
+
+  test('atomically times out an execution and its active step before accepting a late result', async () => {
+    const run = await createWorkflowRun({
+      workspaceId,
+      projectId,
+      definitionId,
+      model: buildModel({jobs: {build: {steps: [{run: 'echo build'}]}}}),
+      triggerPayload: {
+        source: 'manual',
+        event: 'fire',
+        subscriptionId: crypto.randomUUID(),
+        userId: crypto.randomUUID(),
+      },
+    });
+    const [job] = await getJobsByWorkflowRunId(run.id);
+    if (!job) throw new Error('Expected workflow job');
+    const execution = await getFirstJobExecutionByJobId(job.id);
+    if (!execution) throw new Error('Expected job execution');
+    const actualAttemptId = await workflowRunAttemptId(run.id);
+    const runningExecution = await updateJobExecutionStatus({
+      jobExecutionId: execution.id,
+      status: 'running',
+      expectedVersion: execution.version,
+    });
+    const [activeStep] = await getStepsByJobId(job.id);
+    if (!activeStep) throw new Error('Expected active step');
+    const runningStep = await db().transaction((tx) =>
+      markStepRunning({jobExecutionId: execution.id, stepId: activeStep.id}, tx),
+    );
+    if (!runningStep) throw new Error('Expected running step');
+
+    await failJobExecutionAsTimedOut({
+      jobExecutionId: execution.id,
+      workflowRunAttemptId: actualAttemptId,
+      expectedVersion: runningExecution.version,
+    });
+    await db().transaction(async (tx) => {
+      await finishStepAttempt(
+        {
+          stepId: runningStep.id,
+          attempt: runningStep.currentAttempt,
+          status: 'succeeded',
+          logOutcome: 'drained',
+        },
+        tx,
+      );
+      await applyStepResult(
+        {
+          jobExecutionId: execution.id,
+          stepId: runningStep.id,
+          status: 'succeeded',
+          error: null,
+        },
+        tx,
+      );
+    });
+
+    expect(await getFirstJobExecutionByJobId(job.id)).toMatchObject({
+      status: 'failed',
+      statusReason: 'timed_out',
+    });
+    expect(
+      (await getStepsByJobId(job.id)).find((step) => step.id === runningStep.id),
+    ).toMatchObject({
+      status: 'failed',
+      statusReason: 'timed_out',
+    });
+    expect(await stepAttemptTerminatedEvents(job.id)).toMatchObject([
+      expect.objectContaining({
+        status: 'failed',
+        logOutcome: 'abandoned',
+        terminalCause: 'timed_out',
+      }),
     ]);
   });
 

--- a/libs/api/workflows/src/db/workflow-runs/job-executions.test.ts
+++ b/libs/api/workflows/src/db/workflow-runs/job-executions.test.ts
@@ -18,6 +18,7 @@ import {
 import {
   buildModel,
   jobExecutionTerminatedEvents,
+  stepAttemptTerminatedEvents,
   template,
   workflowRunAttemptId,
 } from '#test/helpers/workflow-runs.js';
@@ -378,6 +379,11 @@ describe('workflow run job executions', () => {
         launchKind: 'demand',
       },
     });
+    const [activeStep] = await getStepsByJobId(job.id);
+    if (!activeStep) throw new Error('Expected active step');
+    await db().transaction((tx) =>
+      markStepRunning({jobExecutionId: execution.id, stepId: activeStep.id}, tx),
+    );
 
     await resolveJobExecutionAfterLeaseExpiry({
       jobExecutionId: execution.id,
@@ -397,6 +403,13 @@ describe('workflow run job executions', () => {
         providerKind: 'ec2',
         launchKind: 'demand',
       }),
+    ]);
+    expect((await getStepsByJobId(job.id))[0]).toMatchObject({
+      status: 'cancelled',
+      statusReason: 'runner_lost',
+    });
+    expect(await stepAttemptTerminatedEvents(job.id)).toMatchObject([
+      expect.objectContaining({terminalCause: 'runner_lost'}),
     ]);
   });
 

--- a/libs/api/workflows/src/db/workflow-runs/job-executions.ts
+++ b/libs/api/workflows/src/db/workflow-runs/job-executions.ts
@@ -564,7 +564,11 @@ export async function resolveJobExecutionAfterLeaseExpiry(params: {
       if (updated?.changed) {
         changedJobExecution = updated.execution;
         await bulkUpdateStepStatuses(
-          {jobExecutionId: params.jobExecutionId, status: 'cancelled'},
+          {
+            jobExecutionId: params.jobExecutionId,
+            status: 'cancelled',
+            terminalCause: 'runner_lost',
+          },
           tx,
         );
       }

--- a/libs/api/workflows/src/db/workflow-runs/job-executions.ts
+++ b/libs/api/workflows/src/db/workflow-runs/job-executions.ts
@@ -493,6 +493,8 @@ export async function failJobExecutionAsTimedOut(params: {
   secrets?: Pick<SecretsInterModuleClient, 'getVariablesByNamespace'> | undefined;
 }): Promise<JobExecution> {
   const result = await db().transaction(async (tx) => {
+    await getStepsByJobExecutionIdForUpdate(params.jobExecutionId, tx);
+
     const updated = await optimisticLockRetry({
       updateFn: () =>
         updateJobExecutionStatusAtVersion(tx, {

--- a/libs/api/workflows/src/db/workflow-runs/job-executions.ts
+++ b/libs/api/workflows/src/db/workflow-runs/job-executions.ts
@@ -519,6 +519,17 @@ export async function failJobExecutionAsTimedOut(params: {
       failureMessage: `Optimistic lock failure: job execution ${params.jobExecutionId} version ${params.expectedVersion}`,
     });
 
+    if (updated.changed) {
+      await bulkUpdateStepStatuses(
+        {
+          jobExecutionId: params.jobExecutionId,
+          status: 'failed',
+          terminalCause: 'timed_out',
+        },
+        tx,
+      );
+    }
+
     return updated;
   });
 

--- a/libs/api/workflows/src/db/workflow-runs/outbox.ts
+++ b/libs/api/workflows/src/db/workflow-runs/outbox.ts
@@ -1,5 +1,6 @@
 import {
   type LogOutcomeDto,
+  type StepAttemptTerminalCauseDto,
   WORKFLOWS_JOB_EXECUTION_QUEUED,
   WORKFLOWS_JOB_EXECUTION_TERMINATED,
   WORKFLOWS_JOB_STEPS_SETTLED,
@@ -137,6 +138,7 @@ export async function writeStepAttemptTerminatedOutbox(
     attempt: number;
     status: 'succeeded' | 'failed' | 'cancelled';
     logOutcome: LogOutcomeDto;
+    terminalCause?: StepAttemptTerminalCauseDto | undefined;
   },
 ): Promise<void> {
   const identity = await getStepAttemptTerminatedOutboxIdentity(tx, params.stepId);
@@ -153,6 +155,7 @@ export async function writeStepAttemptTerminatedOutbox(
       attempt: params.attempt,
       status: params.status,
       logOutcome: params.logOutcome,
+      terminalCause: params.terminalCause ?? null,
       stepAttemptId: params.stepAttemptId,
     },
   });

--- a/libs/api/workflows/src/db/workflow-runs/run-status.test.ts
+++ b/libs/api/workflows/src/db/workflow-runs/run-status.test.ts
@@ -327,11 +327,15 @@ describe('workflow run queries', () => {
         status: 'skipped',
         statusReason: 'dependency_not_completed',
       });
-      expect((await getStepsByJobId(runningJobExecution.id)).map((step) => step.status)).toEqual([
+      const cancelledSteps = await getStepsByJobId(runningJobExecution.id);
+      expect(cancelledSteps.map((step) => step.status)).toEqual([
         'cancelled',
         'cancelled',
         'cancelled',
       ]);
+      expect(cancelledSteps.filter((step) => step.statusReason === 'run_cancelled')).toHaveLength(
+        1,
+      );
       expect(
         (await getStepsByJobId(skippedJob.id)).every((step) => step.status === 'pending'),
       ).toBe(true);
@@ -358,7 +362,9 @@ describe('workflow run queries', () => {
           statusReason: 'run_cancelled',
         }),
       ]);
-      expect(await stepAttemptTerminatedEvents(runningJobExecution.id)).toHaveLength(1);
+      expect(await stepAttemptTerminatedEvents(runningJobExecution.id)).toMatchObject([
+        expect.objectContaining({terminalCause: 'run_cancelled'}),
+      ]);
       expect(await jobTerminatedEvents(succeededJob.id)).toHaveLength(1);
       expect(await jobTerminatedEvents(skippedJob.id)).toHaveLength(1);
     });

--- a/libs/api/workflows/src/db/workflow-runs/run-status.ts
+++ b/libs/api/workflows/src/db/workflow-runs/run-status.ts
@@ -177,7 +177,11 @@ async function terminateRunAttempt(
         launchKind: jobExecution.launchKind,
       });
       await bulkUpdateStepStatuses(
-        {jobExecutionId: jobExecution.id, status: spec.terminalStatus},
+        {
+          jobExecutionId: jobExecution.id,
+          status: spec.terminalStatus,
+          terminalCause: spec.statusReason,
+        },
         tx,
       );
     }

--- a/libs/api/workflows/src/db/workflow-runs/steps.test.ts
+++ b/libs/api/workflows/src/db/workflow-runs/steps.test.ts
@@ -17,6 +17,7 @@ import {db} from '../db.js';
 import {stepAttempts as stepAttemptsTable} from '../schema/step-attempts.js';
 import {steps as stepsTable} from '../schema/steps.js';
 import {
+  applyStepResult,
   createWorkflowRun,
   finishStepAttempt,
   getFirstJobExecutionByJobId,
@@ -566,10 +567,16 @@ describe('workflow run queries', () => {
       await stripSetupStep(jobId);
       await nextStepForJob(jobId);
 
-      await bulkUpdateJobStepStatuses({jobId, status: 'cancelled'});
+      await bulkUpdateJobStepStatuses({
+        jobId,
+        status: 'failed',
+        terminalCause: 'timed_out',
+      });
 
       const [attempt] = await getStepAttempts(jobId);
-      expect(attempt).toMatchObject({status: 'cancelled', logOutcome: 'abandoned'});
+      const [timedOutStep] = await getStepsByJobId(jobId);
+      expect(timedOutStep).toMatchObject({status: 'failed', statusReason: 'timed_out'});
+      expect(attempt).toMatchObject({status: 'failed', logOutcome: 'abandoned'});
       expect(await stepAttemptTerminatedEvents(jobId)).toMatchObject([
         {
           jobId,
@@ -578,10 +585,37 @@ describe('workflow run queries', () => {
           projectId,
           stepId: attempt?.stepId,
           attempt: 1,
-          status: 'cancelled',
+          status: 'failed',
           logOutcome: 'abandoned',
+          terminalCause: 'timed_out',
         },
       ]);
+
+      await db().transaction(async (tx) => {
+        await finishStepAttempt(
+          {
+            stepId: attempt?.stepId as string,
+            attempt: 1,
+            status: 'succeeded',
+            logOutcome: 'drained',
+          },
+          tx,
+        );
+        await applyStepResult(
+          {
+            jobExecutionId: timedOutStep?.jobExecutionId as string,
+            stepId: attempt?.stepId as string,
+            status: 'succeeded',
+            error: null,
+          },
+          tx,
+        );
+      });
+
+      expect(await getStepsByJobId(jobId)).toMatchObject([
+        expect.objectContaining({status: 'failed', statusReason: 'timed_out'}),
+      ]);
+      expect(await stepAttemptTerminatedEvents(jobId)).toHaveLength(1);
     });
   });
 });

--- a/libs/api/workflows/src/db/workflow-runs/steps.ts
+++ b/libs/api/workflows/src/db/workflow-runs/steps.ts
@@ -341,14 +341,16 @@ export async function bulkUpdateStepStatuses(
     return;
   }
 
+  const terminalStatusReason: StepStatusReason | undefined = params.terminalCause;
+
   await tx
     .update(steps)
     .set({
       status: params.status,
       statusReason:
-        params.terminalCause === undefined
+        terminalStatusReason === undefined
           ? null
-          : sql`case when ${steps.status} = 'running' then ${params.terminalCause}::workflows_step_status_reason else null end`,
+          : sql`case when ${steps.status} = 'running' then ${terminalStatusReason}::workflows_step_status_reason else null end`,
       updatedAt: new Date(),
     })
     .where(and(eq(steps.jobExecutionId, params.jobExecutionId), NON_TERMINAL_STEP_STATUS_FILTER));

--- a/libs/api/workflows/src/db/workflow-runs/steps.ts
+++ b/libs/api/workflows/src/db/workflow-runs/steps.ts
@@ -1,5 +1,6 @@
 import {
   type LogOutcomeDto,
+  type StepAttemptTerminalCauseDto,
   WORKFLOW_DIAGNOSTIC_ERROR_MAX_BYTES,
   WORKFLOW_DIAGNOSTIC_EVALUATION_TRACE_MAX_BYTES,
   WORKFLOW_STEP_CONFIG_INLINE_MAX_BYTES,
@@ -328,6 +329,7 @@ export async function getStepsByJobExecutionId(jobExecutionId: string): Promise<
 export interface BulkUpdateStepStatusesParams {
   jobExecutionId: string;
   status: Extract<StepStatus, 'failed' | 'cancelled'>;
+  terminalCause?: StepAttemptTerminalCauseDto | undefined;
 }
 
 export async function bulkUpdateStepStatuses(
@@ -343,7 +345,10 @@ export async function bulkUpdateStepStatuses(
     .update(steps)
     .set({
       status: params.status,
-      statusReason: null,
+      statusReason:
+        params.terminalCause === undefined
+          ? null
+          : sql`case when ${steps.status} = 'running' then ${params.terminalCause}::workflows_step_status_reason else null end`,
       updatedAt: new Date(),
     })
     .where(and(eq(steps.jobExecutionId, params.jobExecutionId), NON_TERMINAL_STEP_STATUS_FILTER));
@@ -397,6 +402,7 @@ export async function bulkUpdateStepStatuses(
         attempt: attempt.attempt,
         status: params.status,
         logOutcome: attempt.logOutcome ?? 'abandoned',
+        terminalCause: params.terminalCause,
       });
     }
   }

--- a/libs/api/workflows/src/temporal/activities/orchestration-activities.ts
+++ b/libs/api/workflows/src/temporal/activities/orchestration-activities.ts
@@ -2,6 +2,7 @@ import type {AgentInterModuleClient} from '@shipfox/api-agent-dto/inter-module';
 import type {IntegrationsModuleClient} from '@shipfox/api-integration-core-dto/inter-module';
 import type {ProjectsModuleClient} from '@shipfox/api-projects-dto/inter-module';
 import type {SecretsInterModuleClient} from '@shipfox/api-secrets-dto/inter-module';
+import type {StepAttemptTerminalCauseDto} from '@shipfox/api-workflows-dto';
 import {ApplicationFailure} from '@temporalio/common';
 import {defaultJobConditionTrace} from '#core/condition-trace.js';
 import type {JobStatus, JobStatusReason, ResolutionReason} from '#core/entities/job.js';
@@ -189,6 +190,7 @@ export async function setJobExecutionStatus(
 export async function bulkSetStepStatuses(params: {
   jobExecutionId: string;
   status: Extract<StepStatus, 'failed' | 'cancelled'>;
+  terminalCause?: StepAttemptTerminalCauseDto | undefined;
 }): Promise<void> {
   await bulkUpdateStepStatuses(params);
 }

--- a/libs/api/workflows/src/temporal/activities/orchestration-activities.ts
+++ b/libs/api/workflows/src/temporal/activities/orchestration-activities.ts
@@ -2,7 +2,6 @@ import type {AgentInterModuleClient} from '@shipfox/api-agent-dto/inter-module';
 import type {IntegrationsModuleClient} from '@shipfox/api-integration-core-dto/inter-module';
 import type {ProjectsModuleClient} from '@shipfox/api-projects-dto/inter-module';
 import type {SecretsInterModuleClient} from '@shipfox/api-secrets-dto/inter-module';
-import type {StepAttemptTerminalCauseDto} from '@shipfox/api-workflows-dto';
 import {ApplicationFailure} from '@temporalio/common';
 import {defaultJobConditionTrace} from '#core/condition-trace.js';
 import type {JobStatus, JobStatusReason, ResolutionReason} from '#core/entities/job.js';
@@ -190,7 +189,6 @@ export async function setJobExecutionStatus(
 export async function bulkSetStepStatuses(params: {
   jobExecutionId: string;
   status: Extract<StepStatus, 'failed' | 'cancelled'>;
-  terminalCause?: StepAttemptTerminalCauseDto | undefined;
 }): Promise<void> {
   await bulkUpdateStepStatuses(params);
 }

--- a/libs/api/workflows/src/temporal/workflows/job-execution-orchestration.test.ts
+++ b/libs/api/workflows/src/temporal/workflows/job-execution-orchestration.test.ts
@@ -417,7 +417,11 @@ describe('jobExecutionOrchestration', () => {
     expect(finalStatusesFor('job-timeout')).toEqual([]);
     expect(callsNamed('bulkSetStepStatuses')).toContainEqual({
       name: 'bulkSetStepStatuses',
-      params: {jobExecutionId: 'job-timeout', status: 'failed'},
+      params: {
+        jobExecutionId: 'job-timeout',
+        status: 'failed',
+        terminalCause: 'timed_out',
+      },
     });
     expect(callsNamed('resolveLeaseExpiredJobExecutionActivity')).toHaveLength(0);
   });

--- a/libs/api/workflows/src/temporal/workflows/job-execution-orchestration.test.ts
+++ b/libs/api/workflows/src/temporal/workflows/job-execution-orchestration.test.ts
@@ -415,14 +415,7 @@ describe('jobExecutionOrchestration', () => {
     expect(result.status).toBe('failed');
     expect(callsNamed('failJobExecutionAsTimedOutActivity')).toHaveLength(1);
     expect(finalStatusesFor('job-timeout')).toEqual([]);
-    expect(callsNamed('bulkSetStepStatuses')).toContainEqual({
-      name: 'bulkSetStepStatuses',
-      params: {
-        jobExecutionId: 'job-timeout',
-        status: 'failed',
-        terminalCause: 'timed_out',
-      },
-    });
+    expect(callsNamed('bulkSetStepStatuses')).toHaveLength(0);
     expect(callsNamed('resolveLeaseExpiredJobExecutionActivity')).toHaveLength(0);
   });
 

--- a/libs/api/workflows/src/temporal/workflows/job-execution-orchestration.ts
+++ b/libs/api/workflows/src/temporal/workflows/job-execution-orchestration.ts
@@ -34,7 +34,6 @@ const {
   setJobStatus,
   setJobExecutionStatus,
   queueJobExecutionActivity,
-  bulkSetStepStatuses,
   failJobExecutionAsTimedOutActivity,
   resolveLeaseExpiredJobExecutionActivity,
 } = proxyActivities<ReturnType<typeof createOrchestrationActivities>>({
@@ -253,11 +252,6 @@ async function resolveTimedOutJobExecution({
     jobExecutionId: input.jobExecutionId,
     runAttemptId: input.runAttemptId,
     expectedVersion: runningVersion,
-  });
-  await bulkSetStepStatuses({
-    jobExecutionId: input.jobExecutionId,
-    status: 'failed',
-    terminalCause: 'timed_out',
   });
   if (input.resolveJobStatus === false) {
     log.info('job execution terminated', {

--- a/libs/api/workflows/src/temporal/workflows/job-execution-orchestration.ts
+++ b/libs/api/workflows/src/temporal/workflows/job-execution-orchestration.ts
@@ -254,7 +254,11 @@ async function resolveTimedOutJobExecution({
     runAttemptId: input.runAttemptId,
     expectedVersion: runningVersion,
   });
-  await bulkSetStepStatuses({jobExecutionId: input.jobExecutionId, status: 'failed'});
+  await bulkSetStepStatuses({
+    jobExecutionId: input.jobExecutionId,
+    status: 'failed',
+    terminalCause: 'timed_out',
+  });
   if (input.resolveJobStatus === false) {
     log.info('job execution terminated', {
       jobId: input.jobId,

--- a/libs/api/workflows/test/helpers/workflow-runs.ts
+++ b/libs/api/workflows/test/helpers/workflow-runs.ts
@@ -75,9 +75,10 @@ export function shellRef(name: string): string {
 export async function bulkUpdateJobStepStatuses(
   params: Omit<Parameters<typeof bulkUpdateStepStatuses>[0], 'jobExecutionId'> & {jobId: string},
 ) {
-  const jobExecution = await getFirstJobExecutionByJobId(params.jobId);
-  if (!jobExecution) throw new JobNotFoundError(params.jobId);
-  await bulkUpdateStepStatuses({jobExecutionId: jobExecution.id, status: params.status});
+  const {jobId, ...update} = params;
+  const jobExecution = await getFirstJobExecutionByJobId(jobId);
+  if (!jobExecution) throw new JobNotFoundError(jobId);
+  await bulkUpdateStepStatuses({jobExecutionId: jobExecution.id, ...update});
 }
 
 export function createTestRun(scope: {

--- a/libs/client/logs/src/components/index.ts
+++ b/libs/client/logs/src/components/index.ts
@@ -11,5 +11,7 @@ export {
   EndMarker,
   type EndMarkerProps,
   GapMarker,
+  RunCancelledMarker,
   RunnerLostMarker,
+  TimedOutMarker,
 } from './system-markers.js';

--- a/libs/client/logs/src/components/log-group.stories.tsx
+++ b/libs/client/logs/src/components/log-group.stories.tsx
@@ -164,8 +164,9 @@ export const Truncated: Story = {
 };
 
 /**
- * A genuine subtree failure (a `runner_lost`) draws an inset red bar on the header (a
- * border, not a fill). stderr alone never triggers it: stderr is a channel, not an error.
+ * A genuine subtree failure (`timed_out` or `runner_lost`) draws an inset red bar on the
+ * header (a border, not a fill). stderr alone never triggers it: stderr is a channel, not
+ * an error.
  */
 export const ErrorBar: Story = {
   render: () => (

--- a/libs/client/logs/src/components/log-view.test.tsx
+++ b/libs/client/logs/src/components/log-view.test.tsx
@@ -81,6 +81,8 @@ describe('LogView', () => {
 
   test.each([
     {record: {v: 1, ts, type: 'runner_lost'} as const, label: 'Runner disconnected'},
+    {record: {v: 1, ts, type: 'timed_out'} as const, label: 'Execution timed out'},
+    {record: {v: 1, ts, type: 'run_cancelled'} as const, label: 'Run cancelled'},
     {record: {v: 1, ts, type: 'gap', droppedBytes: 2048} as const, label: 'Output missing'},
     {record: {v: 1, ts, type: 'capped'} as const, label: 'Log size limit reached'},
   ])('does not show no-output copy for a $record.type marker-only stream', ({record, label}) => {

--- a/libs/client/logs/src/components/log-view.test.tsx
+++ b/libs/client/logs/src/components/log-view.test.tsx
@@ -108,7 +108,7 @@ describe('LogView', () => {
 
     expect(screen.getByText('Log stream incomplete')).toBeInTheDocument();
     expect(screen.getByText('some final output may be missing')).toBeInTheDocument();
-    expect(screen.queryByText('Running')).not.toBeInTheDocument();
+    expect(screen.getByText('incomplete')).toBeInTheDocument();
   });
 
   test('renders only the incomplete state for an empty truncated stream', () => {

--- a/libs/client/logs/src/components/log-view.test.tsx
+++ b/libs/client/logs/src/components/log-view.test.tsx
@@ -111,6 +111,14 @@ describe('LogView', () => {
     expect(screen.queryByText('Running')).not.toBeInTheDocument();
   });
 
+  test('renders only the incomplete state for an empty truncated stream', () => {
+    render(<LogView truncated records={[]} />);
+
+    expect(screen.getByText('Log stream incomplete')).toBeInTheDocument();
+    expect(screen.queryByText('Step produced no output')).not.toBeInTheDocument();
+    expect(screen.queryByText('No output yet')).not.toBeInTheDocument();
+  });
+
   test('does not duplicate an authoritative terminal marker for a truncated stream', () => {
     render(<LogView truncated records={[{v: 1, ts, type: 'timed_out'}]} />);
 

--- a/libs/client/logs/src/components/log-view.test.tsx
+++ b/libs/client/logs/src/components/log-view.test.tsx
@@ -101,6 +101,23 @@ describe('LogView', () => {
     expect(screen.queryByText('No output yet')).toBeNull();
   });
 
+  test('ends open groups and explains a truncated stream without a terminal marker', () => {
+    render(
+      <LogView truncated records={[groupStart('build', 'Build'), output('partial output\n')]} />,
+    );
+
+    expect(screen.getByText('Log stream incomplete')).toBeInTheDocument();
+    expect(screen.getByText('some final output may be missing')).toBeInTheDocument();
+    expect(screen.queryByText('Running')).not.toBeInTheDocument();
+  });
+
+  test('does not duplicate an authoritative terminal marker for a truncated stream', () => {
+    render(<LogView truncated records={[{v: 1, ts, type: 'timed_out'}]} />);
+
+    expect(screen.getByText('Execution timed out')).toBeInTheDocument();
+    expect(screen.queryByText('Log stream incomplete')).not.toBeInTheDocument();
+  });
+
   test('filters output and session rows by the log search term', () => {
     render(
       <LogView

--- a/libs/client/logs/src/components/log-view.tsx
+++ b/libs/client/logs/src/components/log-view.tsx
@@ -23,7 +23,14 @@ import {
 import {AgentSessionRows} from './agent-session-rows.js';
 import {LogGroup} from './log-group.js';
 import {OutputLogRow} from './output-log-row.js';
-import {CappedMarker, EndMarker, GapMarker, RunnerLostMarker} from './system-markers.js';
+import {
+  CappedMarker,
+  EndMarker,
+  GapMarker,
+  RunCancelledMarker,
+  RunnerLostMarker,
+  TimedOutMarker,
+} from './system-markers.js';
 
 export interface LogViewProps {
   records: readonly LogRecord[];
@@ -354,6 +361,10 @@ function MarkerRow({record, tree}: {record: MarkerLogRecord; tree: LogTree}): Re
       return <GapMarker record={record} />;
     case 'capped':
       return <CappedMarker record={record} />;
+    case 'timed_out':
+      return <TimedOutMarker record={record} />;
+    case 'run_cancelled':
+      return <RunCancelledMarker record={record} />;
     case 'runner_lost':
       return <RunnerLostMarker record={record} />;
     default:

--- a/libs/client/logs/src/components/log-view.tsx
+++ b/libs/client/logs/src/components/log-view.tsx
@@ -38,6 +38,7 @@ export interface LogViewProps {
   wrap?: boolean;
   showLineNumbers?: boolean;
   emptyState?: 'complete' | 'pending';
+  truncated?: boolean | undefined;
   defaultGroupsOpen?: boolean;
   anchorToFailure?: boolean;
   search?: string;
@@ -57,6 +58,7 @@ export function LogView({
   wrap = false,
   showLineNumbers = true,
   emptyState = 'complete',
+  truncated = false,
   defaultGroupsOpen = false,
   anchorToFailure = false,
   search = '',
@@ -65,7 +67,11 @@ export function LogView({
   onScroll,
 }: LogViewProps) {
   const rowsRef = useRef<HTMLDivElement>(null);
-  const tree = useMemo(() => buildLogTree(records), [records]);
+  const recordTree = useMemo(() => buildLogTree(records), [records]);
+  const tree = useMemo(
+    () => (truncated && !recordTree.terminated ? {...recordTree, terminated: true} : recordTree),
+    [recordTree, truncated],
+  );
   const deferredSearch = useDeferredValue(search);
   const normalizedSearch = deferredSearch.trim().toLowerCase();
   const searchIndex = useMemo(() => buildLogSearchIndex(tree.nodes), [tree.nodes]);
@@ -134,8 +140,30 @@ export function LogView({
           Boolean(normalizedSearch),
           resolvedToolCalls,
         )}
+        {truncated && !recordTree.terminated && !normalizedSearch ? <IncompleteLogRow /> : null}
       </LogRows>
     </>
+  );
+}
+
+function IncompleteLogRow() {
+  return (
+    <LogRow lineNumber={null} tone="warning">
+      <LogContent className="text-foreground-contrast-primary">
+        <span className="inline-flex min-w-0 items-center gap-inline">
+          <Icon
+            name="errorWarningLine"
+            className="size-14 flex-none text-tag-warning-icon"
+            aria-hidden="true"
+          />
+          <span className="min-w-0">
+            <span className="font-medium">Log stream incomplete</span>
+            {' · '}
+            <span className="font-normal opacity-80">some final output may be missing</span>
+          </span>
+        </span>
+      </LogContent>
+    </LogRow>
   );
 }
 

--- a/libs/client/logs/src/components/log-view.tsx
+++ b/libs/client/logs/src/components/log-view.tsx
@@ -81,7 +81,9 @@ export function LogView({
     [normalizedSearch, searchIndex, tree.nodes],
   );
   const resolvedToolCalls = useMemo(() => collectResolvedToolCalls(tree.nodes), [tree.nodes]);
-  const noOutputState = normalizedSearch ? null : getNoOutputState(tree, emptyState);
+  const hasIncompleteTerminal = truncated && !recordTree.terminated;
+  const noOutputState =
+    normalizedSearch || hasIncompleteTerminal ? null : getNoOutputState(tree, emptyState);
   const anchorRecordCount = records.length;
   let searchStatus: string | null = null;
   if (normalizedSearch) {
@@ -140,7 +142,7 @@ export function LogView({
           Boolean(normalizedSearch),
           resolvedToolCalls,
         )}
-        {truncated && !recordTree.terminated && !normalizedSearch ? <IncompleteLogRow /> : null}
+        {hasIncompleteTerminal && !normalizedSearch ? <IncompleteLogRow /> : null}
       </LogRows>
     </>
   );

--- a/libs/client/logs/src/components/system-markers.stories.tsx
+++ b/libs/client/logs/src/components/system-markers.stories.tsx
@@ -1,6 +1,13 @@
 import {LogRows} from '@shipfox/react-ui/log';
 import type {Meta, StoryObj} from '@storybook/react';
-import {CappedMarker, EndMarker, GapMarker, RunnerLostMarker} from './system-markers.js';
+import {
+  CappedMarker,
+  EndMarker,
+  GapMarker,
+  RunCancelledMarker,
+  RunnerLostMarker,
+  TimedOutMarker,
+} from './system-markers.js';
 
 const ts = new Date('2026-06-23T10:00:00.000Z').getTime();
 
@@ -34,6 +41,8 @@ export const Variants: Story = {
       <LogRows>
         <GapMarker record={{v: 1, ts, type: 'gap', droppedBytes: 2048}} />
         <CappedMarker record={{v: 1, ts, type: 'capped'}} />
+        <TimedOutMarker record={{v: 1, ts, type: 'timed_out'}} />
+        <RunCancelledMarker record={{v: 1, ts, type: 'run_cancelled'}} />
         <RunnerLostMarker record={{v: 1, ts, type: 'runner_lost'}} />
         <EndMarker
           record={{v: 1, ts, type: 'end', totalBytes: 15_360}}

--- a/libs/client/logs/src/components/system-markers.tsx
+++ b/libs/client/logs/src/components/system-markers.tsx
@@ -5,7 +5,9 @@ import type {
   CappedLogRecord,
   EndLogRecord,
   GapLogRecord,
+  RunCancelledLogRecord,
   RunnerLostLogRecord,
+  TimedOutLogRecord,
 } from '#core/log-tree.js';
 
 type MarkerTone = 'default' | 'warning' | 'error';
@@ -138,6 +140,35 @@ export function CappedMarker({record}: {record: CappedLogRecord}) {
       detail="later output isn't shown; the step kept running"
     >
       Log size limit reached
+    </LogMarkerRow>
+  );
+}
+
+/** The job reached its configured execution limit and interrupted the active stream. */
+export function TimedOutMarker({record}: {record: TimedOutLogRecord}) {
+  return (
+    <LogMarkerRow
+      icon="closeCircleLine"
+      tone="error"
+      timestamp={new Date(record.ts)}
+      detail="the job exceeded its configured execution time and the log may be incomplete"
+      terminalFailure
+    >
+      Execution timed out
+    </LogMarkerRow>
+  );
+}
+
+/** Run cancellation interrupted the active stream intentionally. */
+export function RunCancelledMarker({record}: {record: RunCancelledLogRecord}) {
+  return (
+    <LogMarkerRow
+      icon="forbidLine"
+      tone="default"
+      timestamp={new Date(record.ts)}
+      detail="the active log stream was interrupted and may be incomplete"
+    >
+      Run cancelled
     </LogMarkerRow>
   );
 }

--- a/libs/client/logs/src/core/log-model.ts
+++ b/libs/client/logs/src/core/log-model.ts
@@ -60,6 +60,8 @@ export type LogRecord =
   | (LogRecordBase & {type: 'gap'; droppedBytes: number})
   | (LogRecordBase & {type: 'agent_session'; row: SessionViewRow})
   | (LogRecordBase & {type: 'capped'})
+  | (LogRecordBase & {type: 'timed_out'})
+  | (LogRecordBase & {type: 'run_cancelled'})
   | (LogRecordBase & {type: 'runner_lost'});
 
 export type LogSource = 'inline' | 'presigned';

--- a/libs/client/logs/src/core/log-search.test.ts
+++ b/libs/client/logs/src/core/log-search.test.ts
@@ -71,6 +71,7 @@ describe('filterLogNodes', () => {
     const records: LogRecord[] = [
       output('\u001b[32mSuccess\u001b[0m: compiled'),
       {v: 1, ts: 0, type: 'gap', droppedBytes: 64},
+      {v: 1, ts: 0, type: 'timed_out'},
       {
         v: 1,
         ts: 0,
@@ -91,6 +92,7 @@ describe('filterLogNodes', () => {
 
     expect(filterLogNodes(tree.nodes, '  SUCCESS  ', index)).toHaveLength(1);
     expect(filterLogNodes(tree.nodes, 'output missing', index)).toHaveLength(1);
+    expect(filterLogNodes(tree.nodes, 'execution timed out', index)).toHaveLength(1);
     expect(filterLogNodes(tree.nodes, 'error', index)).toHaveLength(0);
   });
 });

--- a/libs/client/logs/src/core/log-search.ts
+++ b/libs/client/logs/src/core/log-search.ts
@@ -66,7 +66,9 @@ function searchableNodeText(node: LogNode): string {
   }
 }
 
-function markerText(type: 'end' | 'gap' | 'capped' | 'runner_lost'): string {
+function markerText(
+  type: 'end' | 'gap' | 'capped' | 'timed_out' | 'run_cancelled' | 'runner_lost',
+): string {
   switch (type) {
     case 'end':
       return 'End of log';
@@ -74,6 +76,10 @@ function markerText(type: 'end' | 'gap' | 'capped' | 'runner_lost'): string {
       return 'Output missing';
     case 'capped':
       return 'Log size limit reached';
+    case 'timed_out':
+      return 'Execution timed out';
+    case 'run_cancelled':
+      return 'Run cancelled';
     case 'runner_lost':
       return 'Runner disconnected';
     default:

--- a/libs/client/logs/src/core/log-tree.test.ts
+++ b/libs/client/logs/src/core/log-tree.test.ts
@@ -40,6 +40,8 @@ const gap = (droppedBytes = 0, ts = 0): LogRecord => ({
   droppedBytes,
 });
 const capped = (ts = 0): LogRecord => ({v: 1, ts, type: 'capped'});
+const timedOut = (ts = 0): LogRecord => ({v: 1, ts, type: 'timed_out'});
+const runCancelled = (ts = 0): LogRecord => ({v: 1, ts, type: 'run_cancelled'});
 const runnerLost = (ts = 0): LogRecord => ({v: 1, ts, type: 'runner_lost'});
 const agentSession = (
   row: Extract<LogRecord, {type: 'agent_session'}>['row'] = {
@@ -291,6 +293,8 @@ describe('buildLogTree', () => {
 
   test.each([
     ['end', [end()], true],
+    ['timed_out', [timedOut()], true],
+    ['run_cancelled', [runCancelled()], true],
     ['runner_lost', [runnerLost()], true],
     ['capped', [capped()], false],
     ['none', [out('a')], false],
@@ -307,6 +311,18 @@ describe('buildLogTree', () => {
       const group = asGroup(buildLogTree(records).nodes[0]);
 
       expect(group.hasError).toBe(true);
+    });
+
+    test('a timed_out marker is an error while run_cancelled is neutral', () => {
+      const timedOutGroup = asGroup(
+        buildLogTree([gstart('g1', 'Run'), timedOut(), gend('g1')]).nodes[0],
+      );
+      const cancelledGroup = asGroup(
+        buildLogTree([gstart('g1', 'Run'), runCancelled(), gend('g1')]).nodes[0],
+      );
+
+      expect(timedOutGroup.hasError).toBe(true);
+      expect(cancelledGroup.hasError).toBe(false);
     });
 
     test('stderr does NOT set hasError (a channel, not a failure)', () => {

--- a/libs/client/logs/src/core/log-tree.ts
+++ b/libs/client/logs/src/core/log-tree.ts
@@ -18,9 +18,17 @@ export type GroupStartLogRecord = Extract<LogRecord, {type: 'group_start'}>;
 export type EndLogRecord = Extract<LogRecord, {type: 'end'}>;
 export type GapLogRecord = Extract<LogRecord, {type: 'gap'}>;
 export type CappedLogRecord = Extract<LogRecord, {type: 'capped'}>;
+export type TimedOutLogRecord = Extract<LogRecord, {type: 'timed_out'}>;
+export type RunCancelledLogRecord = Extract<LogRecord, {type: 'run_cancelled'}>;
 export type RunnerLostLogRecord = Extract<LogRecord, {type: 'runner_lost'}>;
 export type AgentSessionLogRecord = Extract<LogRecord, {type: 'agent_session'}>;
-export type MarkerLogRecord = EndLogRecord | GapLogRecord | CappedLogRecord | RunnerLostLogRecord;
+export type MarkerLogRecord =
+  | EndLogRecord
+  | GapLogRecord
+  | CappedLogRecord
+  | TimedOutLogRecord
+  | RunCancelledLogRecord
+  | RunnerLostLogRecord;
 
 /**
  * Stable, unique render key in creation order. A natural key is not enough: `group_id`
@@ -50,7 +58,7 @@ export interface GroupLogNode extends LogNodeBase {
   closed: boolean;
   /** `group_end` timestamp when closed by its matching end, else null. */
   endTs: number | null;
-  /** Precomputed: subtree contains a `runner_lost` (a genuine failure). `stderr` is a channel, not an error, so it never sets this. */
+  /** Precomputed: subtree contains a terminal failure. `stderr` is a channel, not an error, so it never sets this. */
   hasError: boolean;
   /** Precomputed output-line count in the subtree, for the collapsed summary. */
   lineCount: number;
@@ -66,7 +74,7 @@ export type LogNode = OutputLogNode | MarkerLogNode | GroupLogNode | SessionLogN
 
 export interface LogTree {
   nodes: LogNode[];
-  /** The stream is closed: the records contain an `end` or a `runner_lost`. */
+  /** The stream is closed: the records contain an `end` or terminal-cause marker. */
   terminated: boolean;
   /** First record's timestamp; the baseline for relative timestamps. Null when empty. */
   originTs: number | null;
@@ -140,10 +148,15 @@ function appendLogRecord(state: LogTreeBuildState, record: LogRecord): void {
       if (record.type === 'end') state.terminated = true;
       childrenOf(state).push({kind: 'marker', seq: state.seq++, record});
       return;
+    case 'timed_out':
     case 'runner_lost':
       state.terminated = true;
       childrenOf(state).push({kind: 'marker', seq: state.seq++, record});
       for (const frame of state.stack) frame.hasError = true;
+      return;
+    case 'run_cancelled':
+      state.terminated = true;
+      childrenOf(state).push({kind: 'marker', seq: state.seq++, record});
       return;
     case 'agent_session':
       childrenOf(state).push({kind: 'session', seq: state.seq++, record});

--- a/libs/client/logs/src/hooks/api/log-mapper.test.ts
+++ b/libs/client/logs/src/hooks/api/log-mapper.test.ts
@@ -32,6 +32,18 @@ describe('parseLogNdjson', () => {
   test('rejects an invalid external record before a snapshot can be merged', () => {
     expect(() => parseLogNdjson('{"v":1,"ts":1,"type":"nope"}\n')).toThrow();
   });
+
+  test('maps every server terminal cause marker', () => {
+    const ndjson = ['timed_out', 'run_cancelled', 'runner_lost']
+      .map((type) => JSON.stringify({v: 1, ts: 1, type}))
+      .join('\n');
+
+    expect(parseLogNdjson(`${ndjson}\n`).map((record) => record.type)).toEqual([
+      'timed_out',
+      'run_cancelled',
+      'runner_lost',
+    ]);
+  });
 });
 
 describe('toLogRead', () => {

--- a/libs/client/logs/src/hooks/api/log-mapper.ts
+++ b/libs/client/logs/src/hooks/api/log-mapper.ts
@@ -61,6 +61,8 @@ export function toLogRecord(record: LogRecordDto): LogRecord {
     case 'agent_session':
       return {...base, type: record.type, row: toSessionViewRow(record.row)};
     case 'capped':
+    case 'timed_out':
+    case 'run_cancelled':
     case 'runner_lost':
       return {...base, type: record.type};
   }

--- a/libs/client/workflows/src/components/job-detail/step-attempt-log-panel.test.tsx
+++ b/libs/client/workflows/src/components/job-detail/step-attempt-log-panel.test.tsx
@@ -40,6 +40,10 @@ function snapshot(records: TestLogRecord[]): StepLogSnapshot {
   };
 }
 
+function truncatedSnapshot(records: TestLogRecord[]): StepLogSnapshot {
+  return {...snapshot(records), truncated: true};
+}
+
 function renderPanel(
   props: Partial<Parameters<typeof StepAttemptLogPanel>[0]> = {},
   options: {queryClient?: QueryClient} = {},
@@ -223,6 +227,29 @@ describe('StepAttemptLogPanel', () => {
     ).toBeInTheDocument();
     expect(screen.queryByRole('status')).not.toBeInTheDocument();
     expect(screen.getByRole('log')).toBeInTheDocument();
+  });
+
+  test('renders the neutral incomplete marker for a cause-free truncated stream', async () => {
+    const body = truncatedSnapshot([outputRecord('partial\n')]);
+    configureApiClient({
+      baseUrl: 'https://api.example.test',
+      fetchImpl: vi.fn(() =>
+        Promise.resolve(
+          jsonResponse({
+            mode: 'inline',
+            ndjson: `${body.records.map((record) => JSON.stringify(record)).join('\n')}\n`,
+            next_cursor: body.nextCursor,
+            has_more: false,
+            state: body.state,
+            truncated: body.truncated,
+          }),
+        ),
+      ),
+    });
+
+    renderPanel({attemptStatus: 'failed'});
+
+    expect(await screen.findByText('Log stream incomplete')).toBeInTheDocument();
   });
 
   test('keeps stale logs visible when a refresh fails', async () => {

--- a/libs/client/workflows/src/components/job-detail/step-attempt-log-panel.tsx
+++ b/libs/client/workflows/src/components/job-detail/step-attempt-log-panel.tsx
@@ -166,6 +166,7 @@ export function StepAttemptLogPanel({
         wrap={wrap}
         showLineNumbers={showLineNumbers}
         emptyState={query.data?.complete ? 'complete' : 'pending'}
+        truncated={query.data?.truncated}
         anchorToFailure={anchorToFailure}
         ariaLive={!search.trim() && attemptStatus === 'running' ? 'polite' : 'off'}
         className={surfaceClassName}


### PR DESCRIPTION
The logs pipeline previously converted every undrained terminal stream into `runner_lost`, which hid whether a job timed out, a run was cancelled, or a runner actually disappeared.

This change carries the authoritative terminal cause from Workflows through step-attempt events and the Logs grace sweep. The active step retains that reason, late runner results cannot overwrite it, and log truncation remains separate from the terminal cause. Logs now emits distinct server tombstones and metrics for timeout, cancellation, and runner loss, while the client renders each state explicitly.

Older Workflows events and Temporal histories retain the existing runner-loss fallback. A generated Workflows enum migration and Changeset cover the new published contracts.

## Validation

- `mise exec -- turbo type --filter=@shipfox/api-workflows-dto --filter=@shipfox/api-workflows --filter=@shipfox/api-logs-dto --filter=@shipfox/api-logs --filter=@shipfox/client-logs --filter=@shipfox/api-agent-access-dto`
- `mise exec -- turbo check --filter=@shipfox/api-workflows-dto --filter=@shipfox/api-workflows --filter=@shipfox/api-logs-dto --filter=@shipfox/api-logs --filter=@shipfox/client-logs --filter=@shipfox/api-agent-access-dto`
- `mise exec -- turbo test --filter=@shipfox/api-workflows-dto --filter=@shipfox/api-workflows --filter=@shipfox/api-logs-dto --filter=@shipfox/api-logs --filter=@shipfox/client-logs --filter=@shipfox/api-agent-access-dto`
- `mise exec -- pnpm check:api-database-boundaries`
- `mise exec -- turbo depcruise --filter=@shipfox/api-workflows --filter=@shipfox/api-logs`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves the real terminal cause when an abandoned log stream is force-closed, so job timeouts, run cancellations, and runner loss are no longer all reported as `runner_lost`.

- Workflows stamps the cause as the step status reason (`timed_out`, `run_cancelled`, `runner_lost`), writing the timeout cause in the same transaction that fails the job execution and only on still-running steps.
- Logs closes abandoned streams with a matching tombstone and per-cause metrics.
- The client renders distinct marker messages; `timed_out` is a terminal error, `run_cancelled` is neutral, and cause-free truncated streams get a neutral incomplete marker.
- Log truncation stays separate from the terminal cause.

**Migration**
- A Drizzle migration adds the three values to the `workflows_step_status_reason` enum.
- Pre-change Workflows events and Temporal histories keep the `runner_lost` fallback.

<sup>Written for commit a453a40a9c024b2081834fd47fc9808d6feafbc9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1757?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

