### PR TITLE
[api-integration-github] Simplify GitHub token provider and local cache

### DIFF
--- a/.changeset/token-cache-cleanup.md
+++ b/.changeset/token-cache-cleanup.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-integration-github": patch
+---
+
+Simplifies the backend GitHub token provider and local cache around one full-grant installation identity.

--- a/libs/api/integration/github/src/api/installation-token-envelope.ts
+++ b/libs/api/integration/github/src/api/installation-token-envelope.ts
@@ -88,7 +88,6 @@ export interface ClassifiedMintError {
 export const GITHUB_INSTALLATION_TOKEN_ENVELOPE_KEY = 'ENVELOPE';
 export const GITHUB_INSTALLATION_TOKEN_GENERATION_KEY = 'GENERATION';
 
-export type GithubInstallationTokenPermissions = Record<string, 'read' | 'write'>;
 export type MintBackoffScope = 'installation' | 'profile';
 
 const installationWideMintErrorReasons = new Set<IntegrationProviderErrorReason>([
@@ -130,20 +129,6 @@ export function githubInstallationTokenBackoffKeys(
   return profileBackoffKey === GITHUB_INSTALLATION_TOKEN_BACKOFF_KEY
     ? [profileBackoffKey]
     : [profileBackoffKey, GITHUB_INSTALLATION_TOKEN_BACKOFF_KEY];
-}
-
-export function githubInstallationTokenPermissionFingerprint(
-  permissions: Readonly<GithubInstallationTokenPermissions>,
-): string {
-  return JSON.stringify(
-    Object.fromEntries(
-      Object.entries(permissions).sort(([first], [second]) => {
-        if (first < second) return -1;
-        if (first > second) return 1;
-        return 0;
-      }),
-    ),
-  );
 }
 
 export function encodeInstallationTokenEnvelope(envelope: InstallationTokenEnvelope): string {

--- a/libs/api/integration/github/src/api/installation-token-provider.test.ts
+++ b/libs/api/integration/github/src/api/installation-token-provider.test.ts
@@ -10,10 +10,12 @@ import {
   GITHUB_COMPATIBILITY_PERMISSION_FINGERPRINT,
   GITHUB_INSTALLATION_TOKEN_GENERATION_KEY,
   githubInstallationTokenKey,
-  githubInstallationTokenPermissionFingerprint,
 } from './installation-token-envelope.js';
 import {createGithubInstallationTokenProvider} from './installation-token-provider.js';
-import type {InstallationTokenSecretStore} from './shared-installation-token-cache.js';
+import type {
+  InstallationTokenCache,
+  InstallationTokenSecretStore,
+} from './shared-installation-token-cache.js';
 
 const GITHUB_INSTALLATION_TOKEN_PATTERN = /^ghs_[A-Za-z0-9._-]{36,}$/u;
 
@@ -61,7 +63,7 @@ describe('GithubInstallationTokenProvider', () => {
     vi.useRealTimers();
   });
 
-  it('mints a broad installation token on a cache miss', async () => {
+  it('mints a full-grant installation token on a cache miss', async () => {
     createInstallationAccessTokenMock.mockResolvedValue({
       data: {
         token: GITHUB_STATELESS_INSTALLATION_TOKEN,
@@ -83,86 +85,28 @@ describe('GithubInstallationTokenProvider', () => {
     });
   });
 
-  it('mints an installation token with the requested permission profile', async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date('2026-06-10T11:00:00.000Z'));
+  it('uses the compatibility identity at the shared-cache boundary', async () => {
     createInstallationAccessTokenMock.mockResolvedValue({
       data: {
         token: GITHUB_STATELESS_INSTALLATION_TOKEN,
         expires_at: '2026-06-10T12:00:00.000Z',
       },
     });
-    const provider = createGithubInstallationTokenProvider();
-    const permissions = {pull_requests: 'read' as const, contents: 'write' as const};
+    const getOrMint = vi.fn((...args: Parameters<InstallationTokenCache['getOrMint']>) =>
+      args[2](),
+    );
+    const provider = createGithubInstallationTokenProvider({cache: {getOrMint}});
 
-    await provider.getInstallationAccessToken(1, undefined, permissions);
-    await provider.getInstallationAccessToken(1, undefined, {
-      contents: 'write',
-      pull_requests: 'read',
-    });
+    await provider.getInstallationAccessToken(1);
 
-    expect(createInstallationAccessTokenMock).toHaveBeenCalledTimes(1);
-    expect(createInstallationAccessTokenMock).toHaveBeenCalledWith({
-      installation_id: 1,
-      permissions,
-    });
-    expect(githubInstallationTokenPermissionFingerprint(permissions)).toBe(
-      '{"contents":"write","pull_requests":"read"}',
+    expect(getOrMint).toHaveBeenCalledWith(
+      1,
+      GITHUB_COMPATIBILITY_PERMISSION_FINGERPRINT,
+      expect.any(Function),
     );
   });
 
-  it('uses byte-stable ordering for permission fingerprints', () => {
-    expect(githubInstallationTokenPermissionFingerprint({é: 'read', z: 'read', a: 'write'})).toBe(
-      '{"a":"write","z":"read","é":"read"}',
-    );
-  });
-
-  it('rejects a permission profile whose explicit fingerprint does not match', async () => {
-    const provider = createGithubInstallationTokenProvider();
-
-    await expect(
-      provider.getInstallationAccessToken(1, 'wrong', {contents: 'read'}),
-    ).rejects.toThrow('permission fingerprint does not match permissions');
-    expect(createInstallationAccessTokenMock).not.toHaveBeenCalled();
-  });
-
-  it('keeps the compatibility and permissions-derived cache profiles separate', async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date('2026-06-10T11:00:00.000Z'));
-    createInstallationAccessTokenMock
-      .mockResolvedValueOnce({
-        data: {
-          token: 'ghs_broad',
-          expires_at: '2026-06-10T12:00:00.000Z',
-        },
-      })
-      .mockResolvedValueOnce({
-        data: {
-          token: 'ghs_narrow',
-          expires_at: '2026-06-10T12:00:00.000Z',
-        },
-      });
-    const provider = createGithubInstallationTokenProvider();
-    const permissions = {contents: 'read' as const};
-
-    const broad = await provider.getInstallationAccessToken(1);
-    const narrow = await provider.getInstallationAccessToken(1, undefined, permissions);
-    const narrowAgain = await provider.getInstallationAccessToken(1, undefined, permissions);
-
-    expect(broad.token).toBe('ghs_broad');
-    expect(narrow.token).toBe('ghs_narrow');
-    expect(narrowAgain.token).toBe('ghs_narrow');
-    expect(createInstallationAccessTokenMock).toHaveBeenCalledTimes(2);
-    expect(createInstallationAccessTokenMock).toHaveBeenNthCalledWith(1, {
-      installation_id: 1,
-    });
-    expect(createInstallationAccessTokenMock).toHaveBeenNthCalledWith(2, {
-      installation_id: 1,
-      permissions,
-    });
-  });
-
-  it('passes through a stateful broad installation token', async () => {
+  it('passes through a stateful full-grant installation token', async () => {
     createInstallationAccessTokenMock.mockResolvedValue({
       data: {
         token: GITHUB_STATEFUL_INSTALLATION_TOKEN,
@@ -260,26 +204,32 @@ describe('GithubInstallationTokenProvider', () => {
     expect(createInstallationAccessTokenMock).not.toHaveBeenCalled();
   });
 
-  it('does not share a cached token between permission profiles', async () => {
+  it('isolates local tokens by installation identity', async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-06-10T11:00:00.000Z'));
     createInstallationAccessTokenMock
       .mockResolvedValueOnce({
-        data: {token: 'ghs_broad', expires_at: '2026-06-10T12:00:00.000Z'},
+        data: {token: 'ghs_first_installation', expires_at: '2026-06-10T12:00:00.000Z'},
       })
       .mockResolvedValueOnce({
-        data: {token: 'ghs_narrow', expires_at: '2026-06-10T12:00:00.000Z'},
+        data: {token: 'ghs_second_installation', expires_at: '2026-06-10T12:00:00.000Z'},
       });
     const provider = createGithubInstallationTokenProvider();
 
-    const broad = await provider.getInstallationAccessToken(1, 'broad');
-    const narrow = await provider.getInstallationAccessToken(1, 'narrow');
-    const broadAgain = await provider.getInstallationAccessToken(1, 'broad');
+    const first = await provider.getInstallationAccessToken(1);
+    const second = await provider.getInstallationAccessToken(2);
+    const firstAgain = await provider.getInstallationAccessToken(1);
 
-    expect(broad.token).toBe('ghs_broad');
-    expect(narrow.token).toBe('ghs_narrow');
-    expect(broadAgain.token).toBe('ghs_broad');
+    expect(first.token).toBe('ghs_first_installation');
+    expect(second.token).toBe('ghs_second_installation');
+    expect(firstAgain.token).toBe('ghs_first_installation');
     expect(createInstallationAccessTokenMock).toHaveBeenCalledTimes(2);
+    expect(createInstallationAccessTokenMock).toHaveBeenNthCalledWith(1, {
+      installation_id: 1,
+    });
+    expect(createInstallationAccessTokenMock).toHaveBeenNthCalledWith(2, {
+      installation_id: 2,
+    });
   });
 
   it('mints a fresh token inside the expiry refresh margin', async () => {

--- a/libs/api/integration/github/src/api/installation-token-provider.ts
+++ b/libs/api/integration/github/src/api/installation-token-provider.ts
@@ -9,10 +9,7 @@ import {type GithubInstallationAccessToken, mapGithubError} from './client.js';
 import {githubInstallationTokenFormatPlugin} from './github-octokit.js';
 import {
   GITHUB_COMPATIBILITY_PERMISSION_FINGERPRINT,
-  type GithubInstallationTokenPermissions,
-  githubInstallationTokenKey,
   githubInstallationTokenNamespace,
-  githubInstallationTokenPermissionFingerprint,
   TOKEN_REFRESH_MARGIN_MS,
 } from './installation-token-envelope.js';
 import {
@@ -26,11 +23,12 @@ import {
 export type {DeleteInstallationOptions};
 
 export interface GithubInstallationTokenProvider {
-  getInstallationAccessToken(
-    installationId: number,
-    permissionFingerprint?: string,
-    permissions?: GithubInstallationTokenPermissions,
-  ): Promise<GithubInstallationAccessToken>;
+  /**
+   * Returns the full GitHub installation grant for backend tool execution.
+   * GitHub determines provider permissions from the installation configuration.
+   * The installation ID is the only cache identity for this provider path.
+   */
+  getInstallationAccessToken(installationId: number): Promise<GithubInstallationAccessToken>;
   deleteInstallation?(installationId: number, options?: DeleteInstallationOptions): Promise<number>;
 }
 
@@ -61,32 +59,12 @@ class OctokitGithubInstallationTokenProvider implements GithubInstallationTokenP
     private readonly getInstallationByInstallationId?: typeof getGithubInstallationByInstallationId,
   ) {}
 
-  async getInstallationAccessToken(
-    installationId: number,
-    permissionFingerprint?: string,
-    permissions?: GithubInstallationTokenPermissions,
-  ): Promise<GithubInstallationAccessToken> {
+  async getInstallationAccessToken(installationId: number): Promise<GithubInstallationAccessToken> {
     await this.assertInstallationIsActive(installationId);
-    const derivedPermissionFingerprint =
-      permissions === undefined
-        ? undefined
-        : githubInstallationTokenPermissionFingerprint(permissions);
-    if (
-      permissionFingerprint !== undefined &&
-      derivedPermissionFingerprint !== undefined &&
-      permissionFingerprint !== derivedPermissionFingerprint
-    ) {
-      throw new TypeError(
-        'GitHub installation token permission fingerprint does not match permissions',
-      );
-    }
-    const effectivePermissionFingerprint =
-      derivedPermissionFingerprint ??
-      permissionFingerprint ??
-      GITHUB_COMPATIBILITY_PERMISSION_FINGERPRINT;
-    const requestedPermissions = permissions === undefined ? undefined : {...permissions};
-    return await this.cache.getOrMint(installationId, effectivePermissionFingerprint, () =>
-      this.mintInstallationAccessToken(installationId, requestedPermissions),
+    return await this.cache.getOrMint(
+      installationId,
+      GITHUB_COMPATIBILITY_PERMISSION_FINGERPRINT,
+      () => this.mintInstallationAccessToken(installationId),
     );
   }
 
@@ -115,13 +93,11 @@ class OctokitGithubInstallationTokenProvider implements GithubInstallationTokenP
 
   private async mintInstallationAccessToken(
     installationId: number,
-    permissions: GithubInstallationTokenPermissions | undefined,
   ): Promise<GithubInstallationAccessToken> {
     const response = await mapGithubError(
       () =>
         this.getApp().octokit.rest.apps.createInstallationAccessToken({
           installation_id: installationId,
-          ...(permissions === undefined ? {} : {permissions}),
         }),
       'installation-not-found',
     );
@@ -180,11 +156,11 @@ class OctokitGithubInstallationTokenProvider implements GithubInstallationTokenP
 
 class InMemoryInstallationTokenCache implements InstallationTokenCache {
   private readonly tokens = new Map<
-    string,
+    number,
     {token: GithubInstallationAccessToken; generation: string | null}
   >();
-  private readonly inFlightMints = new Map<string, Promise<GithubInstallationAccessToken>>();
-  private readonly inFlightEpochs = new Map<string, number>();
+  private readonly inFlightMints = new Map<number, Promise<GithubInstallationAccessToken>>();
+  private readonly inFlightEpochs = new Map<number, number>();
   private readonly generations = new Map<number, string | null>();
   private readonly epochs = new Map<number, number>();
 
@@ -211,13 +187,12 @@ class InMemoryInstallationTokenCache implements InstallationTokenCache {
 
   getOrMint(
     installationId: number,
-    permissionFingerprint: string,
+    _permissionFingerprint: string,
     mint: () => Promise<GithubInstallationAccessToken>,
   ): Promise<GithubInstallationAccessToken> {
-    const cacheKey = installationTokenCacheKey(installationId, permissionFingerprint);
     const epoch = this.epochs.get(installationId) ?? 0;
     const generation = this.generations.get(installationId) ?? null;
-    const cached = this.tokens.get(cacheKey);
+    const cached = this.tokens.get(installationId);
     if (
       cached &&
       cached.generation === generation &&
@@ -227,25 +202,25 @@ class InMemoryInstallationTokenCache implements InstallationTokenCache {
       return Promise.resolve(cached.token);
     }
 
-    const inFlightMint = this.inFlightMints.get(cacheKey);
-    if (inFlightMint && this.inFlightEpochs.get(cacheKey) === epoch) return inFlightMint;
+    const inFlightMint = this.inFlightMints.get(installationId);
+    if (inFlightMint && this.inFlightEpochs.get(installationId) === epoch) return inFlightMint;
 
     const freshToken = mint()
       .then((token) => {
         if ((this.epochs.get(installationId) ?? 0) !== epoch) {
-          return this.getOrMint(installationId, permissionFingerprint, mint);
+          return this.getOrMint(installationId, _permissionFingerprint, mint);
         }
-        this.tokens.set(cacheKey, {token, generation});
+        this.tokens.set(installationId, {token, generation});
         return token;
       })
       .finally(() => {
-        if (this.inFlightMints.get(cacheKey) === freshToken) {
-          this.inFlightMints.delete(cacheKey);
-          this.inFlightEpochs.delete(cacheKey);
+        if (this.inFlightMints.get(installationId) === freshToken) {
+          this.inFlightMints.delete(installationId);
+          this.inFlightEpochs.delete(installationId);
         }
       });
-    this.inFlightMints.set(cacheKey, freshToken);
-    this.inFlightEpochs.set(cacheKey, epoch);
+    this.inFlightMints.set(installationId, freshToken);
+    this.inFlightEpochs.set(installationId, epoch);
     return freshToken;
   }
 
@@ -260,23 +235,12 @@ class InMemoryInstallationTokenCache implements InstallationTokenCache {
 
   private invalidateLocal(installationId: number): number {
     this.epochs.set(installationId, (this.epochs.get(installationId) ?? 0) + 1);
-    const prefix = `${installationId}\u0000`;
-    let deleted = 0;
-    for (const cacheKey of this.tokens.keys()) {
-      if (!cacheKey.startsWith(prefix)) continue;
-      this.tokens.delete(cacheKey);
-      deleted += 1;
-    }
-    return deleted;
+    return this.tokens.delete(installationId) ? 1 : 0;
   }
 
   private isInsideRefreshMargin(expiresAt: Date): boolean {
     return expiresAt.getTime() <= this.options.now().getTime() + this.options.refreshMarginMs;
   }
-}
-
-function installationTokenCacheKey(installationId: number, permissionFingerprint: string): string {
-  return `${installationId}\u0000${githubInstallationTokenKey(permissionFingerprint)}`;
 }
 
 class TieredInstallationTokenCache implements InstallationTokenCache {


### PR DESCRIPTION
GitHub backend token minting now uses the full installation grant configured on GitHub, so callers no longer pass permission profiles. The provider's local cache is keyed only by installation ID, while the shared-cache boundary keeps its compatibility identity and persisted locking and generation behavior.

Checkout-token handling is unchanged.

Closes ENG-2039

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
GitHub backend token minting now uses the full installation grant instead of caller-supplied permission profiles, so tokens are cached by installation ID alone. Callers of `getInstallationAccessToken` no longer pass a permission fingerprint or permissions; the shared-cache boundary keeps its compatibility identity and persisted locking behavior. Checkout-token handling is unchanged. Closes ENG-2039.

**Migration**
- Update `getInstallationAccessToken` calls to pass only the installation ID.
- Remove the now-unused `GithubInstallationTokenPermissions` type and `githubInstallationTokenPermissionFingerprint` helper.

<sup>Written for commit 46804bcacbdf791d2702d8bf2ccbf86f8a49287a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1758?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

