### PR TITLE
[api-integration-github] Simplify backend installation token cache identity

### DIFF
--- a/.changeset/shared-token-backoff.md
+++ b/.changeset/shared-token-backoff.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-integration-github": patch
+---
+
+Collapses backend GitHub installation-token caching and mint backoff to one compatibility identity per installation while preserving generation fences and mixed-version storage compatibility.

--- a/.changeset/shared-token-backoff.md
+++ b/.changeset/shared-token-backoff.md
@@ -3,3 +3,4 @@
 ---
 
 Collapses backend GitHub installation-token caching and mint backoff to one compatibility identity per installation while preserving generation fences and mixed-version storage compatibility.
+Removes the obsolete permission-profile label from the installation-token backoff metric.

--- a/docs/architecture/github-installation-token-invalidation.md
+++ b/docs/architecture/github-installation-token-invalidation.md
@@ -29,9 +29,11 @@ A request that completed its final check before the fence was published may fini
 The default lock retry window is 2 seconds, which is the cache coordination bound for lock contention.
 Secret-store operation latency and GitHub mint latency remain part of the surrounding request SLO.
 
-Permission profiles retain independent token and backoff keys.
-The generation fence covers every profile without merging their permissions.
-Terminal backoff entries remain profile-scoped or installation-scoped according to their existing error classification.
+Backend tools use one persisted compatibility token key and one `BACKOFF` key per installation.
+The generation fence covers this full-grant identity.
+Legacy profile-keyed entries remain distinct and are not read or relabeled by the new backend cache.
+Mint backoff records represent token-mint failures only.
+GitHub operation denials do not write or activate them.
 
 ## Failure and degradation behavior
 
@@ -51,11 +53,14 @@ The caller waits for a fresh mint or receives the existing provider failure.
 
 The cluster guarantee begins only after every API replica that can serve GitHub tokens runs the fence-aware version.
 Older replicas do not read `GENERATION` and can continue serving their local RAM entry until it expires.
-They can also write generation-less envelopes and backoff entries.
-New replicas discard those values or cannot share their backoff, which can cause extra mints and weaker shared backoff until all old replicas drain.
+They can also write generation-less envelopes and profile-specific backoff entries.
+New replicas read only the compatibility token and `BACKOFF` identities.
+Legacy profile entries remain isolated, which can cause extra mints and weaker shared backoff until all old replicas drain.
 Drain older replicas before relying on approval invalidation, or pause permission approvals during the rollout.
 
-The new reader accepts legacy envelopes while the fence is absent.
+The new reader accepts legacy compatibility envelopes while the fence is absent.
+It keeps the fixed `ENVELOPE` fallback for older storage writers.
+It does not treat a narrowed profile entry as a full-grant token.
 After the first new-version invalidation publishes a fence, it rejects those envelopes and mints a fresh token.
 This permits a rolling data migration without persisting an approved-permission snapshot.
 

--- a/libs/api/integration/github/src/api/installation-token-envelope.ts
+++ b/libs/api/integration/github/src/api/installation-token-envelope.ts
@@ -88,16 +88,6 @@ export interface ClassifiedMintError {
 export const GITHUB_INSTALLATION_TOKEN_ENVELOPE_KEY = 'ENVELOPE';
 export const GITHUB_INSTALLATION_TOKEN_GENERATION_KEY = 'GENERATION';
 
-export type MintBackoffScope = 'installation' | 'profile';
-
-const installationWideMintErrorReasons = new Set<IntegrationProviderErrorReason>([
-  'installation-not-found',
-  'malformed-provider-response',
-  'provider-unavailable',
-  'rate-limited',
-  'timeout',
-]);
-
 export function githubInstallationTokenNamespace(installationId: number): string {
   return `system/github/installation-token/${installationId}`;
 }
@@ -112,23 +102,6 @@ export function githubInstallationTokenKey(permissionFingerprint: string): strin
   }
 
   return `TOKEN_${createHash('sha256').update(permissionFingerprint, 'utf8').digest('hex').toUpperCase()}`;
-}
-
-export function githubInstallationTokenBackoffKey(permissionFingerprint: string): string {
-  if (permissionFingerprint === GITHUB_COMPATIBILITY_PERMISSION_FINGERPRINT) {
-    return GITHUB_INSTALLATION_TOKEN_BACKOFF_KEY;
-  }
-
-  return `BACKOFF_${githubInstallationTokenKey(permissionFingerprint).slice('TOKEN_'.length)}`;
-}
-
-export function githubInstallationTokenBackoffKeys(
-  permissionFingerprint: string,
-): readonly string[] {
-  const profileBackoffKey = githubInstallationTokenBackoffKey(permissionFingerprint);
-  return profileBackoffKey === GITHUB_INSTALLATION_TOKEN_BACKOFF_KEY
-    ? [profileBackoffKey]
-    : [profileBackoffKey, GITHUB_INSTALLATION_TOKEN_BACKOFF_KEY];
 }
 
 export function encodeInstallationTokenEnvelope(envelope: InstallationTokenEnvelope): string {
@@ -208,12 +181,6 @@ export function classifyMintError(error: unknown): ClassifiedMintError {
 
 export function mintErrorClassForReason(reason: IntegrationProviderErrorReason): MintErrorClass {
   return terminalMintErrorReasons.has(reason) ? 'terminal' : 'transient';
-}
-
-export function mintBackoffScopeForReason(
-  reason: IntegrationProviderErrorReason,
-): MintBackoffScope {
-  return installationWideMintErrorReasons.has(reason) ? 'installation' : 'profile';
 }
 
 export function backoffMs(classified: ClassifiedMintError): number {

--- a/libs/api/integration/github/src/api/installation-token-provider.test.ts
+++ b/libs/api/integration/github/src/api/installation-token-provider.test.ts
@@ -85,7 +85,7 @@ describe('GithubInstallationTokenProvider', () => {
     });
   });
 
-  it('uses the compatibility identity at the shared-cache boundary', async () => {
+  it('passes the installation mint callback to the cache boundary', async () => {
     createInstallationAccessTokenMock.mockResolvedValue({
       data: {
         token: GITHUB_STATELESS_INSTALLATION_TOKEN,
@@ -93,17 +93,13 @@ describe('GithubInstallationTokenProvider', () => {
       },
     });
     const getOrMint = vi.fn((...args: Parameters<InstallationTokenCache['getOrMint']>) =>
-      args[2](),
+      args[1](),
     );
     const provider = createGithubInstallationTokenProvider({cache: {getOrMint}});
 
     await provider.getInstallationAccessToken(1);
 
-    expect(getOrMint).toHaveBeenCalledWith(
-      1,
-      GITHUB_COMPATIBILITY_PERMISSION_FINGERPRINT,
-      expect.any(Function),
-    );
+    expect(getOrMint).toHaveBeenCalledWith(1, expect.any(Function));
   });
 
   it('passes through a stateful full-grant installation token', async () => {
@@ -289,11 +285,7 @@ describe('GithubInstallationTokenProvider', () => {
     await githubInstallationFactory.create({installationId: String(installationId), connectionId});
     const values = new Map<string, string>();
     let lockCalls = 0;
-    function withLock<T>(
-      _installationId: number,
-      _permissionFingerprint: string,
-      fn: () => Promise<T>,
-    ) {
+    function withLock<T>(_installationId: number, fn: () => Promise<T>) {
       lockCalls += 1;
       return fn().then((value) => ({acquired: true as const, value}));
     }
@@ -422,7 +414,7 @@ describe('GithubInstallationTokenProvider', () => {
       getIntegrationConnectionById,
       getGithubInstallationByInstallationId,
       secretStore,
-      withLock: <T>(_id: number, _profile: string, fn: () => Promise<T>) =>
+      withLock: <T>(_id: number, fn: () => Promise<T>) =>
         fn().then((value) => ({acquired: true as const, value})),
       now: () => new Date(),
     };

--- a/libs/api/integration/github/src/api/installation-token-provider.ts
+++ b/libs/api/integration/github/src/api/installation-token-provider.ts
@@ -298,7 +298,6 @@ function createInstallationTokenCache(
   const shared = new SharedInstallationTokenCache({
     secretStore: options.secretStore,
     withLock,
-    withBackoffLock: withLock,
     resolveWorkspaceId: createGithubInstallationWorkspaceResolver(
       options.getIntegrationConnectionById,
     ),

--- a/libs/api/integration/github/src/api/installation-token-provider.ts
+++ b/libs/api/integration/github/src/api/installation-token-provider.ts
@@ -8,7 +8,6 @@ import {recordInstallationTokenFormat, recordInstallationTokenLookup} from '#met
 import {type GithubInstallationAccessToken, mapGithubError} from './client.js';
 import {githubInstallationTokenFormatPlugin} from './github-octokit.js';
 import {
-  GITHUB_COMPATIBILITY_PERMISSION_FINGERPRINT,
   githubInstallationTokenNamespace,
   TOKEN_REFRESH_MARGIN_MS,
 } from './installation-token-envelope.js';
@@ -61,10 +60,8 @@ class OctokitGithubInstallationTokenProvider implements GithubInstallationTokenP
 
   async getInstallationAccessToken(installationId: number): Promise<GithubInstallationAccessToken> {
     await this.assertInstallationIsActive(installationId);
-    return await this.cache.getOrMint(
-      installationId,
-      GITHUB_COMPATIBILITY_PERMISSION_FINGERPRINT,
-      () => this.mintInstallationAccessToken(installationId),
+    return await this.cache.getOrMint(installationId, () =>
+      this.mintInstallationAccessToken(installationId),
     );
   }
 
@@ -187,7 +184,6 @@ class InMemoryInstallationTokenCache implements InstallationTokenCache {
 
   getOrMint(
     installationId: number,
-    _permissionFingerprint: string,
     mint: () => Promise<GithubInstallationAccessToken>,
   ): Promise<GithubInstallationAccessToken> {
     const epoch = this.epochs.get(installationId) ?? 0;
@@ -208,7 +204,7 @@ class InMemoryInstallationTokenCache implements InstallationTokenCache {
     const freshToken = mint()
       .then((token) => {
         if ((this.epochs.get(installationId) ?? 0) !== epoch) {
-          return this.getOrMint(installationId, _permissionFingerprint, mint);
+          return this.getOrMint(installationId, mint);
         }
         this.tokens.set(installationId, {token, generation});
         return token;
@@ -251,19 +247,18 @@ class TieredInstallationTokenCache implements InstallationTokenCache {
 
   async getOrMint(
     installationId: number,
-    permissionFingerprint: string,
     mint: () => Promise<GithubInstallationAccessToken>,
   ): Promise<GithubInstallationAccessToken> {
     const generation = await this.readGeneration(installationId);
     this.ram.observeGeneration?.(installationId, generation);
-    const result = await this.ram.getOrMint(installationId, permissionFingerprint, () =>
-      this.shared.getOrMint(installationId, permissionFingerprint, mint),
+    const result = await this.ram.getOrMint(installationId, () =>
+      this.shared.getOrMint(installationId, mint),
     );
     const currentGeneration = await this.readGeneration(installationId);
     if (currentGeneration === generation) return result;
 
     this.ram.observeGeneration?.(installationId, currentGeneration);
-    return await this.getOrMint(installationId, permissionFingerprint, mint);
+    return await this.getOrMint(installationId, mint);
   }
 
   async deleteInstallation(
@@ -304,7 +299,6 @@ function createInstallationTokenCache(
     secretStore: options.secretStore,
     withLock,
     withBackoffLock: withLock,
-    shareCompatibilityLock: true,
     resolveWorkspaceId: createGithubInstallationWorkspaceResolver(
       options.getIntegrationConnectionById,
     ),

--- a/libs/api/integration/github/src/api/shared-installation-token-cache.test.ts
+++ b/libs/api/integration/github/src/api/shared-installation-token-cache.test.ts
@@ -6,9 +6,9 @@ import {
   backoffActive,
   encodeInstallationTokenEnvelope,
   GITHUB_COMPATIBILITY_PERMISSION_FINGERPRINT,
+  GITHUB_INSTALLATION_TOKEN_BACKOFF_KEY,
   GITHUB_INSTALLATION_TOKEN_ENVELOPE_KEY,
   GITHUB_INSTALLATION_TOKEN_GENERATION_KEY,
-  githubInstallationTokenBackoffKey,
   githubInstallationTokenKey,
   needsRefresh,
   stillValid,
@@ -95,14 +95,12 @@ function cache(
     withLock?:
       | (<T>(
           installationId: number,
-          permissionFingerprint: string,
           fn: () => Promise<T>,
         ) => Promise<InstallationTokenLockResult<T>>)
       | undefined;
     withBackoffLock?:
       | (<T>(
           installationId: number,
-          permissionFingerprint: string,
           fn: () => Promise<T>,
         ) => Promise<InstallationTokenLockResult<T>>)
       | undefined;
@@ -113,12 +111,9 @@ function cache(
 ) {
   return new SharedInstallationTokenCache({
     secretStore: options.store ?? createStore(),
-    withLock:
-      options.withLock ??
-      (async (_id, _permissionFingerprint, fn) => ({acquired: true, value: await fn()})),
+    withLock: options.withLock ?? (async (_id, fn) => ({acquired: true, value: await fn()})),
     withBackoffLock:
-      options.withBackoffLock ??
-      (async (_id, _permissionFingerprint, fn) => ({acquired: true, value: await fn()})),
+      options.withBackoffLock ?? (async (_id, fn) => ({acquired: true, value: await fn()})),
     resolveWorkspaceId: options.resolveWorkspaceId ?? (() => Promise.resolve(workspaceId)),
     now: () => options.now ?? new Date('2026-06-10T11:00:00.000Z'),
     sleep: options.sleep ?? (() => Promise.resolve()),
@@ -163,9 +158,10 @@ describe('SharedInstallationTokenCache', () => {
     const mint = vi.fn(() => Promise.resolve(token('ghs_new')));
     const shared = cache({store});
 
-    await expect(
-      shared.getOrMint(installationId, GITHUB_COMPATIBILITY_PERMISSION_FINGERPRINT, mint),
-    ).rejects.toMatchObject({reason: 'rate-limited', status: 429});
+    await expect(shared.getOrMint(installationId, mint)).rejects.toMatchObject({
+      reason: 'rate-limited',
+      status: 429,
+    });
     expect(mint).not.toHaveBeenCalled();
     expect(errorMonitoring.reportError).not.toHaveBeenCalled();
   });
@@ -179,11 +175,7 @@ describe('SharedInstallationTokenCache', () => {
     const mint = vi.fn(() => Promise.resolve(token('ghs_new')));
     const shared = cache({store});
 
-    const result = await shared.getOrMint(
-      installationId,
-      GITHUB_COMPATIBILITY_PERMISSION_FINGERPRINT,
-      mint,
-    );
+    const result = await shared.getOrMint(installationId, mint);
 
     expect(result).toEqual(token('ghs_new'));
     expect(mint).toHaveBeenCalledTimes(1);
@@ -199,7 +191,6 @@ describe('SharedInstallationTokenCache', () => {
     let lockHeld = false;
     const withNonReentrantLock = async <T>(
       _installationId: number,
-      _permissionFingerprint: string,
       fn: () => Promise<T>,
     ): Promise<InstallationTokenLockResult<T>> => {
       if (lockHeld) return {acquired: false};
@@ -217,9 +208,7 @@ describe('SharedInstallationTokenCache', () => {
     });
 
     await expect(
-      shared.getOrMint(installationId, GITHUB_COMPATIBILITY_PERMISSION_FINGERPRINT, () =>
-        Promise.resolve(token('ghs_new')),
-      ),
+      shared.getOrMint(installationId, () => Promise.resolve(token('ghs_new'))),
     ).resolves.toEqual(token('ghs_new'));
     expect(
       store.values.get(
@@ -232,30 +221,33 @@ describe('SharedInstallationTokenCache', () => {
       .fn()
       .mockRejectedValue(new GithubIntegrationProviderError('provider-rejected', 'rejected'));
 
-    await expect(
-      shared.getOrMint(installationId, GITHUB_COMPATIBILITY_PERMISSION_FINGERPRINT, failedMint),
-    ).rejects.toMatchObject({reason: 'provider-rejected'});
+    await expect(shared.getOrMint(installationId, failedMint)).rejects.toMatchObject({
+      reason: 'provider-rejected',
+    });
     expect(
-      store.values.get(
-        `${workspaceId}:${installationId}:${githubInstallationTokenBackoffKey(GITHUB_COMPATIBILITY_PERMISSION_FINGERPRINT)}`,
-      ),
+      store.values.get(`${workspaceId}:${installationId}:${GITHUB_INSTALLATION_TOKEN_BACKOFF_KEY}`),
     ).toContain('provider-rejected');
   });
 
-  it('rejects a legacy envelope after a new invalidation generation is published', async () => {
+  it('does not read or relabel a legacy profile envelope after invalidation', async () => {
     const store = createStore();
-    setEnvelope(store, token('ghs_before-approval'), 'broad');
+    setEnvelope(store, {...token('ghs_before-approval'), generation: 'legacy'}, 'broad');
     await store.writeGeneration?.(workspaceId, installationId, 'generation-after-approval');
     const mint = vi.fn(() => Promise.resolve(token('ghs_after-approval')));
     const shared = cache({store});
 
-    await expect(shared.getOrMint(installationId, 'broad', mint)).resolves.toEqual(
+    await expect(shared.getOrMint(installationId, mint)).resolves.toEqual(
       token('ghs_after-approval'),
     );
     expect(mint).toHaveBeenCalledOnce();
     expect(
       store.values.get(`${workspaceId}:${installationId}:${githubInstallationTokenKey('broad')}`),
-    ).toContain('generation-after-approval');
+    ).toContain('ghs_before-approval');
+    expect(
+      store.values.get(
+        `${workspaceId}:${installationId}:${githubInstallationTokenKey(GITHUB_COMPATIBILITY_PERMISSION_FINGERPRINT)}`,
+      ),
+    ).toContain('ghs_after-approval');
   });
 
   it('fails closed when the generation fence cannot be read', async () => {
@@ -265,7 +257,7 @@ describe('SharedInstallationTokenCache', () => {
     const shared = cache({store});
 
     await expect(
-      shared.getOrMint(installationId, 'broad', () => Promise.resolve(token('ghs_fresh'))),
+      shared.getOrMint(installationId, () => Promise.resolve(token('ghs_fresh'))),
     ).rejects.toMatchObject({reason: 'provider-unavailable'});
   });
 
@@ -289,14 +281,13 @@ describe('SharedInstallationTokenCache', () => {
     });
     const withLock = async <T>(
       _installationId: number,
-      _permissionFingerprint: string,
       fn: () => Promise<T>,
     ): Promise<InstallationTokenLockResult<T>> => ({
       acquired: true,
       value: await fn(),
     });
     const shared = cache({store, withLock});
-    const pending = shared.getOrMint(installationId, 'broad', mint);
+    const pending = shared.getOrMint(installationId, mint);
     await firstMintStarted;
     await shared.deleteInstallation(installationId, {
       workspaceId,
@@ -311,14 +302,16 @@ describe('SharedInstallationTokenCache', () => {
     expect(mint).toHaveBeenCalledTimes(2);
     expect(store.values.get(`${workspaceId}:${installationId}:GENERATION`)).toBeDefined();
     expect(
-      store.values.get(`${workspaceId}:${installationId}:${githubInstallationTokenKey('broad')}`),
+      store.values.get(
+        `${workspaceId}:${installationId}:${githubInstallationTokenKey(GITHUB_COMPATIBILITY_PERMISSION_FINGERPRINT)}`,
+      ),
     ).toContain('ghs_fresh');
   });
 
   it('keeps the invalidation fence after a failed cleanup and retries it', async () => {
     const store = createStore();
     const shared = cache({store});
-    await shared.getOrMint(installationId, 'broad', () => Promise.resolve(token('ghs_old')));
+    await shared.getOrMint(installationId, () => Promise.resolve(token('ghs_old')));
     store.failGenerationWrites = true;
 
     await expect(
@@ -342,131 +335,82 @@ describe('SharedInstallationTokenCache', () => {
       }),
     ).resolves.toBe(1);
     await expect(
-      shared.getOrMint(installationId, 'broad', () => Promise.resolve(token('ghs_new'))),
+      shared.getOrMint(installationId, () => Promise.resolve(token('ghs_new'))),
     ).resolves.toEqual(token('ghs_new'));
   });
 
-  it('isolates profile tokens while allowing different profiles to mint independently', async () => {
+  it('reuses one full-grant token identity per installation', async () => {
     const store = createStore();
     const shared = cache({store});
-    const broadMint = vi.fn(() => Promise.resolve(token('ghs_broad')));
-    const narrowMint = vi.fn(() => Promise.resolve(token('ghs_narrow')));
+    const firstMint = vi.fn(() => Promise.resolve(token('ghs_full_grant')));
+    const secondMint = vi.fn(() => Promise.resolve(token('ghs_unexpected')));
 
-    await expect(shared.getOrMint(installationId, 'broad', broadMint)).resolves.toEqual(
-      token('ghs_broad'),
+    await expect(shared.getOrMint(installationId, firstMint)).resolves.toEqual(
+      token('ghs_full_grant'),
     );
-    await expect(shared.getOrMint(installationId, 'narrow', narrowMint)).resolves.toEqual(
-      token('ghs_narrow'),
-    );
-    await expect(shared.getOrMint(installationId, 'broad', broadMint)).resolves.toEqual(
-      token('ghs_broad'),
-    );
-    await expect(shared.getOrMint(installationId, 'narrow', narrowMint)).resolves.toEqual(
-      token('ghs_narrow'),
+    await expect(shared.getOrMint(installationId, secondMint)).resolves.toEqual(
+      token('ghs_full_grant'),
     );
 
-    expect(broadMint).toHaveBeenCalledTimes(1);
-    expect(narrowMint).toHaveBeenCalledTimes(1);
+    expect(firstMint).toHaveBeenCalledTimes(1);
+    expect(secondMint).not.toHaveBeenCalled();
     expect(
-      store.values.has(`${workspaceId}:${installationId}:${githubInstallationTokenKey('broad')}`),
-    ).toBe(true);
-    expect(
-      store.values.has(`${workspaceId}:${installationId}:${githubInstallationTokenKey('narrow')}`),
+      store.values.has(
+        `${workspaceId}:${installationId}:${githubInstallationTokenKey(GITHUB_COMPATIBILITY_PERMISSION_FINGERPRINT)}`,
+      ),
     ).toBe(true);
   });
 
-  it('isolates profile-specific backoff across permission profile keys', async () => {
+  it('uses one installation backoff key for all mint failures', async () => {
     const store = createStore();
-    const shared = cache({store});
-    const failedMint = vi
-      .fn()
-      .mockRejectedValue(new GithubIntegrationProviderError('provider-rejected', 'rejected'));
-    const siblingMint = vi.fn(() => Promise.resolve(token('ghs_sibling')));
-
-    await expect(shared.getOrMint(installationId, 'broad', failedMint)).rejects.toMatchObject({
-      reason: 'provider-rejected',
-    });
-    await expect(shared.getOrMint(installationId, 'narrow', siblingMint)).resolves.toEqual(
-      token('ghs_sibling'),
-    );
-
-    expect(failedMint).toHaveBeenCalledTimes(1);
-    expect(siblingMint).toHaveBeenCalledTimes(1);
-    expect(
-      store.values.get(
-        `${workspaceId}:${installationId}:${githubInstallationTokenBackoffKey('broad')}`,
-      ),
-    ).toContain('provider-rejected');
-    expect(
-      store.values.get(
-        `${workspaceId}:${installationId}:${githubInstallationTokenBackoffKey('narrow')}`,
-      ),
-    ).toBe('{}');
-  });
-
-  it('shares installation-wide backoff across permission profile keys', async () => {
-    const store = createStore();
-    const lockFingerprints: string[] = [];
     const shared = cache({
       store,
       withLock: async <T>(
         _installationId: number,
-        permissionFingerprint: string,
         fn: () => Promise<T>,
       ): Promise<InstallationTokenLockResult<T>> => {
-        lockFingerprints.push(permissionFingerprint);
         return {acquired: true as const, value: await fn()};
       },
     });
     const failedMint = vi
       .fn()
-      .mockRejectedValue(new GithubIntegrationProviderError('provider-unavailable', 'unavailable'));
+      .mockRejectedValue(new GithubIntegrationProviderError('provider-rejected', 'rejected'));
     const siblingMint = vi.fn(() => Promise.resolve(token('ghs_sibling')));
 
-    await expect(shared.getOrMint(installationId, 'broad', failedMint)).rejects.toMatchObject({
-      reason: 'provider-unavailable',
+    await expect(shared.getOrMint(installationId, failedMint)).rejects.toMatchObject({
+      reason: 'provider-rejected',
     });
-    await expect(shared.getOrMint(installationId, 'narrow', siblingMint)).rejects.toMatchObject({
-      reason: 'provider-unavailable',
+    await expect(shared.getOrMint(installationId, siblingMint)).rejects.toMatchObject({
+      reason: 'provider-rejected',
     });
 
     expect(failedMint).toHaveBeenCalledTimes(1);
     expect(siblingMint).not.toHaveBeenCalled();
-    expect(lockFingerprints).toContain(GITHUB_COMPATIBILITY_PERMISSION_FINGERPRINT);
     expect(
-      store.values.get(
-        `${workspaceId}:${installationId}:${githubInstallationTokenBackoffKey(GITHUB_COMPATIBILITY_PERMISSION_FINGERPRINT)}`,
-      ),
-    ).toContain('provider-unavailable');
+      store.values.get(`${workspaceId}:${installationId}:${GITHUB_INSTALLATION_TOKEN_BACKOFF_KEY}`),
+    ).toContain('provider-rejected');
   });
 
-  it('preserves an active terminal backoff over a later transient backoff', async () => {
+  it('preserves an active terminal backoff for the full-grant identity', async () => {
     const store = createStore();
     setEnvelope(
       store,
       {
         ...token('ghs_existing', '2026-06-10T11:04:30.000Z'),
       },
-      'broad',
+      GITHUB_COMPATIBILITY_PERMISSION_FINGERPRINT,
     );
     store.values.set(
-      `${workspaceId}:${installationId}:${githubInstallationTokenBackoffKey('broad')}`,
+      `${workspaceId}:${installationId}:${GITHUB_INSTALLATION_TOKEN_BACKOFF_KEY}`,
       encodeInstallationTokenEnvelope({
         backoffUntil: new Date('2026-06-10T11:10:00.000Z'),
         backoffReason: 'provider-rejected',
       }),
     );
-    store.values.set(
-      `${workspaceId}:${installationId}:${githubInstallationTokenBackoffKey(GITHUB_COMPATIBILITY_PERMISSION_FINGERPRINT)}`,
-      encodeInstallationTokenEnvelope({
-        backoffUntil: new Date('2026-06-10T11:15:00.000Z'),
-        backoffReason: 'provider-unavailable',
-      }),
-    );
     const mint = vi.fn(() => Promise.resolve(token('ghs_new')));
     const shared = cache({store});
 
-    await expect(shared.getOrMint(installationId, 'broad', mint)).rejects.toMatchObject({
+    await expect(shared.getOrMint(installationId, mint)).rejects.toMatchObject({
       reason: 'provider-rejected',
     });
     expect(mint).not.toHaveBeenCalled();
@@ -483,11 +427,7 @@ describe('SharedInstallationTokenCache', () => {
     const mintStarted = new Promise<void>((resolve) => {
       resolveMintStarted = resolve;
     });
-    const withLock = async <T>(
-      _id: number,
-      _permissionFingerprint: string,
-      fn: () => Promise<T>,
-    ) => {
+    const withLock = async <T>(_id: number, fn: () => Promise<T>) => {
       if (lockHeld) return {acquired: false as const};
       lockHeld = true;
       try {
@@ -509,17 +449,9 @@ describe('SharedInstallationTokenCache', () => {
       pollDelaysMs: [1],
     });
 
-    const first = firstReplica.getOrMint(
-      installationId,
-      GITHUB_COMPATIBILITY_PERMISSION_FINGERPRINT,
-      mint,
-    );
+    const first = firstReplica.getOrMint(installationId, mint);
     await mintStarted;
-    const second = secondReplica.getOrMint(
-      installationId,
-      GITHUB_COMPATIBILITY_PERMISSION_FINGERPRINT,
-      mint,
-    );
+    const second = secondReplica.getOrMint(installationId, mint);
     const results = await Promise.all([first, second]);
 
     expect(results).toEqual([token('ghs_shared'), token('ghs_shared')]);
@@ -532,11 +464,7 @@ describe('SharedInstallationTokenCache', () => {
     const mint = vi.fn(() => Promise.resolve(token('ghs_new')));
     const shared = cache({store});
 
-    const result = await shared.getOrMint(
-      installationId,
-      GITHUB_COMPATIBILITY_PERMISSION_FINGERPRINT,
-      mint,
-    );
+    const result = await shared.getOrMint(installationId, mint);
 
     expect(result).toEqual(token('ghs_cached'));
     expect(mint).not.toHaveBeenCalled();
@@ -550,9 +478,7 @@ describe('SharedInstallationTokenCache', () => {
     const mint = vi.fn(() => Promise.resolve(token('ghs_new')));
     const shared = cache({store, withBackoffLock});
 
-    await expect(
-      shared.getOrMint(installationId, GITHUB_COMPATIBILITY_PERMISSION_FINGERPRINT, mint),
-    ).resolves.toEqual(token('ghs_cached'));
+    await expect(shared.getOrMint(installationId, mint)).resolves.toEqual(token('ghs_cached'));
     expect(mint).not.toHaveBeenCalled();
     expect(withBackoffLock).not.toHaveBeenCalled();
   });
@@ -566,11 +492,7 @@ describe('SharedInstallationTokenCache', () => {
       withLock: () => Promise.resolve({acquired: false}),
     });
 
-    const result = await shared.getOrMint(
-      installationId,
-      GITHUB_COMPATIBILITY_PERMISSION_FINGERPRINT,
-      mint,
-    );
+    const result = await shared.getOrMint(installationId, mint);
 
     expect(result).toEqual(token('ghs_stale_but_valid', '2026-06-10T11:04:30.000Z'));
     expect(mint).not.toHaveBeenCalled();
@@ -591,11 +513,7 @@ describe('SharedInstallationTokenCache', () => {
       },
     });
 
-    const result = await shared.getOrMint(
-      installationId,
-      GITHUB_COMPATIBILITY_PERMISSION_FINGERPRINT,
-      mint,
-    );
+    const result = await shared.getOrMint(installationId, mint);
 
     expect(result).toEqual(token('ghs_committed'));
     expect(mint).not.toHaveBeenCalled();
@@ -610,11 +528,7 @@ describe('SharedInstallationTokenCache', () => {
     });
     const shared = cache({store});
 
-    const result = await shared.getOrMint(
-      installationId,
-      GITHUB_COMPATIBILITY_PERMISSION_FINGERPRINT,
-      () => Promise.resolve(token('ghs_new')),
-    );
+    const result = await shared.getOrMint(installationId, () => Promise.resolve(token('ghs_new')));
 
     expect(result).toEqual(token('ghs_new'));
     expect(
@@ -631,14 +545,10 @@ describe('SharedInstallationTokenCache', () => {
       .mockRejectedValue(new GithubIntegrationProviderError('rate-limited', 'rate limited', 42));
     const shared = cache({store});
 
-    await expect(
-      shared.getOrMint(installationId, GITHUB_COMPATIBILITY_PERMISSION_FINGERPRINT, mint),
-    ).rejects.toMatchObject({
+    await expect(shared.getOrMint(installationId, mint)).rejects.toMatchObject({
       reason: 'rate-limited',
     });
-    await expect(
-      shared.getOrMint(installationId, GITHUB_COMPATIBILITY_PERMISSION_FINGERPRINT, mint),
-    ).rejects.toMatchObject({
+    await expect(shared.getOrMint(installationId, mint)).rejects.toMatchObject({
       reason: 'rate-limited',
       retryAfterSeconds: 42,
     });
@@ -653,14 +563,10 @@ describe('SharedInstallationTokenCache', () => {
       .mockRejectedValue(new GithubIntegrationProviderError('access-denied', 'denied'));
     const shared = cache({store});
 
-    await expect(
-      shared.getOrMint(installationId, GITHUB_COMPATIBILITY_PERMISSION_FINGERPRINT, mint),
-    ).rejects.toMatchObject({
+    await expect(shared.getOrMint(installationId, mint)).rejects.toMatchObject({
       reason: 'access-denied',
     });
-    await expect(
-      shared.getOrMint(installationId, GITHUB_COMPATIBILITY_PERMISSION_FINGERPRINT, mint),
-    ).rejects.toMatchObject({
+    await expect(shared.getOrMint(installationId, mint)).rejects.toMatchObject({
       reason: 'access-denied',
     });
 
@@ -681,16 +587,12 @@ describe('SharedInstallationTokenCache', () => {
       );
     const shared = cache({store});
 
-    await expect(
-      shared.getOrMint(installationId, GITHUB_COMPATIBILITY_PERMISSION_FINGERPRINT, mint),
-    ).rejects.toMatchObject({
+    await expect(shared.getOrMint(installationId, mint)).rejects.toMatchObject({
       reason: 'provider-rejected',
       message: 'commit_id is missing',
       status: 422,
     });
-    await expect(
-      shared.getOrMint(installationId, GITHUB_COMPATIBILITY_PERMISSION_FINGERPRINT, mint),
-    ).rejects.toMatchObject({
+    await expect(shared.getOrMint(installationId, mint)).rejects.toMatchObject({
       reason: 'provider-rejected',
       message: 'commit_id is missing',
       status: 422,
@@ -704,10 +606,8 @@ describe('SharedInstallationTokenCache', () => {
     setEnvelope(store, token('ghs_existing', '2026-06-10T11:04:30.000Z'));
     const shared = cache({store});
 
-    const result = await shared.getOrMint(
-      installationId,
-      GITHUB_COMPATIBILITY_PERMISSION_FINGERPRINT,
-      () => Promise.reject(new GithubIntegrationProviderError('provider-unavailable', 'down')),
+    const result = await shared.getOrMint(installationId, () =>
+      Promise.reject(new GithubIntegrationProviderError('provider-unavailable', 'down')),
     );
 
     expect(result).toEqual(token('ghs_existing', '2026-06-10T11:04:30.000Z'));
@@ -719,7 +619,7 @@ describe('SharedInstallationTokenCache', () => {
     const shared = cache({store});
 
     await expect(
-      shared.getOrMint(installationId, GITHUB_COMPATIBILITY_PERMISSION_FINGERPRINT, () =>
+      shared.getOrMint(installationId, () =>
         Promise.reject(new GithubIntegrationProviderError('access-denied', 'denied')),
       ),
     ).rejects.toMatchObject({reason: 'access-denied'});
@@ -738,9 +638,7 @@ describe('SharedInstallationTokenCache', () => {
     });
 
     await expect(
-      shared.getOrMint(installationId, GITHUB_COMPATIBILITY_PERMISSION_FINGERPRINT, () =>
-        Promise.resolve(token('ghs_new')),
-      ),
+      shared.getOrMint(installationId, () => Promise.resolve(token('ghs_new'))),
     ).rejects.toMatchObject({reason: 'installation-not-found'});
   });
 
@@ -749,11 +647,7 @@ describe('SharedInstallationTokenCache', () => {
     store.failReads = true;
     const shared = cache({store});
 
-    const result = await shared.getOrMint(
-      installationId,
-      GITHUB_COMPATIBILITY_PERMISSION_FINGERPRINT,
-      () => Promise.resolve(token('ghs_new')),
-    );
+    const result = await shared.getOrMint(installationId, () => Promise.resolve(token('ghs_new')));
 
     expect(result).toEqual(token('ghs_new'));
   });
@@ -768,9 +662,7 @@ describe('SharedInstallationTokenCache', () => {
     });
 
     await expect(
-      shared.getOrMint(installationId, GITHUB_COMPATIBILITY_PERMISSION_FINGERPRINT, () =>
-        Promise.resolve(token('ghs_new')),
-      ),
+      shared.getOrMint(installationId, () => Promise.resolve(token('ghs_new'))),
     ).rejects.toMatchObject({reason: 'provider-unavailable'});
 
     expect(errorMonitoring.reportError).toHaveBeenCalledTimes(1);
@@ -781,11 +673,7 @@ describe('SharedInstallationTokenCache', () => {
     store.failWrites = true;
     const shared = cache({store});
 
-    const result = await shared.getOrMint(
-      installationId,
-      GITHUB_COMPATIBILITY_PERMISSION_FINGERPRINT,
-      () => Promise.resolve(token('ghs_new')),
-    );
+    const result = await shared.getOrMint(installationId, () => Promise.resolve(token('ghs_new')));
 
     expect(result).toEqual(token('ghs_new'));
   });
@@ -798,11 +686,7 @@ describe('SharedInstallationTokenCache', () => {
     );
     const shared = cache({store});
 
-    const result = await shared.getOrMint(
-      installationId,
-      GITHUB_COMPATIBILITY_PERMISSION_FINGERPRINT,
-      () => Promise.resolve(token('ghs_new')),
-    );
+    const result = await shared.getOrMint(installationId, () => Promise.resolve(token('ghs_new')));
 
     expect(result).toEqual(token('ghs_new'));
     expect(
@@ -819,9 +703,7 @@ describe('SharedInstallationTokenCache', () => {
     });
 
     await expect(
-      shared.getOrMint(installationId, GITHUB_COMPATIBILITY_PERMISSION_FINGERPRINT, () =>
-        Promise.resolve(token('ghs_new')),
-      ),
+      shared.getOrMint(installationId, () => Promise.resolve(token('ghs_new'))),
     ).rejects.toMatchObject({reason: 'installation-not-found'});
   });
 });

--- a/libs/api/integration/github/src/api/shared-installation-token-cache.test.ts
+++ b/libs/api/integration/github/src/api/shared-installation-token-cache.test.ts
@@ -98,12 +98,6 @@ function cache(
           fn: () => Promise<T>,
         ) => Promise<InstallationTokenLockResult<T>>)
       | undefined;
-    withBackoffLock?:
-      | (<T>(
-          installationId: number,
-          fn: () => Promise<T>,
-        ) => Promise<InstallationTokenLockResult<T>>)
-      | undefined;
     resolveWorkspaceId?: ((installationId: number) => Promise<string>) | undefined;
     sleep?: ((ms: number) => Promise<void>) | undefined;
     pollDelaysMs?: number[] | undefined;
@@ -112,8 +106,6 @@ function cache(
   return new SharedInstallationTokenCache({
     secretStore: options.store ?? createStore(),
     withLock: options.withLock ?? (async (_id, fn) => ({acquired: true, value: await fn()})),
-    withBackoffLock:
-      options.withBackoffLock ?? (async (_id, fn) => ({acquired: true, value: await fn()})),
     resolveWorkspaceId: options.resolveWorkspaceId ?? (() => Promise.resolve(workspaceId)),
     now: () => options.now ?? new Date('2026-06-10T11:00:00.000Z'),
     sleep: options.sleep ?? (() => Promise.resolve()),
@@ -166,6 +158,19 @@ describe('SharedInstallationTokenCache', () => {
     expect(errorMonitoring.reportError).not.toHaveBeenCalled();
   });
 
+  it('reads a fixed-key compatibility token envelope without minting', async () => {
+    const store = createStore();
+    store.values.set(
+      `${workspaceId}:${installationId}:${GITHUB_INSTALLATION_TOKEN_ENVELOPE_KEY}`,
+      encodeInstallationTokenEnvelope(token('ghs_legacy')),
+    );
+    const mint = vi.fn(() => Promise.resolve(token('ghs_new')));
+    const shared = cache({store});
+
+    await expect(shared.getOrMint(installationId, mint)).resolves.toEqual(token('ghs_legacy'));
+    expect(mint).not.toHaveBeenCalled();
+  });
+
   beforeEach(() => {
     errorMonitoring.reportError.mockReset();
   });
@@ -204,7 +209,6 @@ describe('SharedInstallationTokenCache', () => {
     const shared = cache({
       store,
       withLock: withNonReentrantLock,
-      withBackoffLock: withNonReentrantLock,
     });
 
     await expect(
@@ -363,15 +367,7 @@ describe('SharedInstallationTokenCache', () => {
 
   it('uses one installation backoff key for all mint failures', async () => {
     const store = createStore();
-    const shared = cache({
-      store,
-      withLock: async <T>(
-        _installationId: number,
-        fn: () => Promise<T>,
-      ): Promise<InstallationTokenLockResult<T>> => {
-        return {acquired: true as const, value: await fn()};
-      },
-    });
+    const shared = cache({store});
     const failedMint = vi
       .fn()
       .mockRejectedValue(new GithubIntegrationProviderError('provider-rejected', 'rejected'));
@@ -474,13 +470,13 @@ describe('SharedInstallationTokenCache', () => {
     const store = createStore();
     await store.writeGeneration?.(workspaceId, installationId, 'generation-1');
     setEnvelope(store, {...token('ghs_cached'), generation: 'generation-1'});
-    const withBackoffLock = vi.fn(() => Promise.resolve({acquired: false as const}));
+    const withLock = vi.fn(() => Promise.resolve({acquired: false as const}));
     const mint = vi.fn(() => Promise.resolve(token('ghs_new')));
-    const shared = cache({store, withBackoffLock});
+    const shared = cache({store, withLock});
 
     await expect(shared.getOrMint(installationId, mint)).resolves.toEqual(token('ghs_cached'));
     expect(mint).not.toHaveBeenCalled();
-    expect(withBackoffLock).not.toHaveBeenCalled();
+    expect(withLock).not.toHaveBeenCalled();
   });
 
   it('serves a still-valid token on a contended refresh path', async () => {

--- a/libs/api/integration/github/src/api/shared-installation-token-cache.test.ts
+++ b/libs/api/integration/github/src/api/shared-installation-token-cache.test.ts
@@ -274,6 +274,30 @@ describe('SharedInstallationTokenCache', () => {
     ).toContain('ghs_after-approval');
   });
 
+  it('does not read a legacy profile backoff without an invalidation fence', async () => {
+    const store = createStore();
+    const profileTokenKey = githubInstallationTokenKey('broad');
+    store.values.set(
+      `${workspaceId}:${installationId}:BACKOFF_${profileTokenKey.slice('TOKEN_'.length)}`,
+      encodeInstallationTokenEnvelope({
+        backoffUntil: new Date('2026-06-10T11:15:00.000Z'),
+        backoffReason: 'provider-rejected',
+      }),
+    );
+    const mint = vi.fn(() => Promise.resolve(token('ghs_after-approval')));
+    const shared = cache({store});
+
+    await expect(shared.getOrMint(installationId, mint)).resolves.toEqual(
+      token('ghs_after-approval'),
+    );
+    expect(mint).toHaveBeenCalledOnce();
+    expect(
+      store.values.get(
+        `${workspaceId}:${installationId}:${githubInstallationTokenKey(GITHUB_COMPATIBILITY_PERMISSION_FINGERPRINT)}`,
+      ),
+    ).toContain('ghs_after-approval');
+  });
+
   it('fails closed when the generation fence cannot be read', async () => {
     const store = createStore();
     setEnvelope(store, token('ghs_stale'), 'broad');

--- a/libs/api/integration/github/src/api/shared-installation-token-cache.test.ts
+++ b/libs/api/integration/github/src/api/shared-installation-token-cache.test.ts
@@ -171,6 +171,27 @@ describe('SharedInstallationTokenCache', () => {
     expect(mint).not.toHaveBeenCalled();
   });
 
+  it('rejects a generation-less fixed-key envelope after invalidation', async () => {
+    const store = createStore();
+    store.values.set(
+      `${workspaceId}:${installationId}:${GITHUB_INSTALLATION_TOKEN_ENVELOPE_KEY}`,
+      encodeInstallationTokenEnvelope(token('ghs_before-approval')),
+    );
+    await store.writeGeneration?.(workspaceId, installationId, 'generation-after-approval');
+    const mint = vi.fn(() => Promise.resolve(token('ghs_after-approval')));
+    const shared = cache({store});
+
+    await expect(shared.getOrMint(installationId, mint)).resolves.toEqual(
+      token('ghs_after-approval'),
+    );
+    expect(mint).toHaveBeenCalledOnce();
+    expect(
+      store.values.get(
+        `${workspaceId}:${installationId}:${githubInstallationTokenKey(GITHUB_COMPATIBILITY_PERMISSION_FINGERPRINT)}`,
+      ),
+    ).toContain('ghs_after-approval');
+  });
+
   beforeEach(() => {
     errorMonitoring.reportError.mockReset();
   });
@@ -233,10 +254,9 @@ describe('SharedInstallationTokenCache', () => {
     ).toContain('provider-rejected');
   });
 
-  it('does not read or relabel a legacy profile envelope after invalidation', async () => {
+  it('does not read or relabel a legacy profile envelope without an invalidation fence', async () => {
     const store = createStore();
-    setEnvelope(store, {...token('ghs_before-approval'), generation: 'legacy'}, 'broad');
-    await store.writeGeneration?.(workspaceId, installationId, 'generation-after-approval');
+    setEnvelope(store, token('ghs_narrowed'), 'broad');
     const mint = vi.fn(() => Promise.resolve(token('ghs_after-approval')));
     const shared = cache({store});
 
@@ -246,7 +266,7 @@ describe('SharedInstallationTokenCache', () => {
     expect(mint).toHaveBeenCalledOnce();
     expect(
       store.values.get(`${workspaceId}:${installationId}:${githubInstallationTokenKey('broad')}`),
-    ).toContain('ghs_before-approval');
+    ).toContain('ghs_narrowed');
     expect(
       store.values.get(
         `${workspaceId}:${installationId}:${githubInstallationTokenKey(GITHUB_COMPATIBILITY_PERMISSION_FINGERPRINT)}`,
@@ -532,6 +552,9 @@ describe('SharedInstallationTokenCache', () => {
         `${workspaceId}:${installationId}:${githubInstallationTokenKey(GITHUB_COMPATIBILITY_PERMISSION_FINGERPRINT)}`,
       ),
     ).not.toContain('backoff');
+    expect(
+      store.values.get(`${workspaceId}:${installationId}:${GITHUB_INSTALLATION_TOKEN_BACKOFF_KEY}`),
+    ).toBe(encodeInstallationTokenEnvelope({}));
   });
 
   it('records transient backoff and short-circuits the next call with the stored reason', async () => {

--- a/libs/api/integration/github/src/api/shared-installation-token-cache.ts
+++ b/libs/api/integration/github/src/api/shared-installation-token-cache.ts
@@ -17,11 +17,8 @@ import {
   GITHUB_COMPATIBILITY_PERMISSION_FINGERPRINT,
   GITHUB_INSTALLATION_TOKEN_BACKOFF_KEY,
   GITHUB_INSTALLATION_TOKEN_ENVELOPE_KEY,
-  githubInstallationTokenBackoffKey,
-  githubInstallationTokenBackoffKeys,
   githubInstallationTokenKey,
   type InstallationTokenEnvelope,
-  mintBackoffScopeForReason,
   mintErrorClassForReason,
   parseInstallationTokenEnvelope,
   providerErrorFromBackoff,
@@ -40,7 +37,6 @@ export interface DeleteInstallationOptions {
 export interface InstallationTokenCache {
   getOrMint(
     installationId: number,
-    permissionFingerprint: string,
     mint: () => Promise<GithubInstallationAccessToken>,
   ): Promise<GithubInstallationAccessToken>;
   deleteInstallation?(installationId: number, options?: DeleteInstallationOptions): Promise<number>;
@@ -67,7 +63,6 @@ export interface InstallationTokenSecretStore {
 
 type InstallationTokenLock = <T>(
   installationId: number,
-  permissionFingerprint: string,
   fn: () => Promise<T>,
 ) => Promise<InstallationTokenLockResult<T>>;
 
@@ -75,8 +70,6 @@ export interface SharedInstallationTokenCacheOptions {
   secretStore: InstallationTokenSecretStore;
   withLock: InstallationTokenLock;
   withBackoffLock?: InstallationTokenLock | undefined;
-  /** Whether compatibility-lock ownership also covers generation-fenced writes. */
-  shareCompatibilityLock?: boolean | undefined;
   resolveWorkspaceId: (installationId: number) => Promise<string>;
   now?: (() => Date) | undefined;
   sleep?: ((ms: number) => Promise<void>) | undefined;
@@ -91,15 +84,16 @@ const DEFAULT_MINT_TIMEOUT_MS = 30 * 1000;
 type InstallationTokenGeneration = string | null | undefined;
 type InstallationTokenEnvelopeWriteResult = 'written' | 'skipped' | 'contended';
 
+const FULL_GRANT_TOKEN_KEY = githubInstallationTokenKey(
+  GITHUB_COMPATIBILITY_PERMISSION_FINGERPRINT,
+);
+const FULL_GRANT_BACKOFF_KEY = GITHUB_INSTALLATION_TOKEN_BACKOFF_KEY;
+
 interface MintUnderLockParams {
   workspaceId: string;
   installationId: number;
-  profileKey: string;
-  backoffKeys: readonly string[];
-  permissionFingerprint: string;
   mint: () => Promise<GithubInstallationAccessToken>;
   reportReadFailure: (error: unknown) => void;
-  compatibilityLockHeld: boolean;
 }
 type InstallationTokenBackoffResult = {until: Date; persisted: boolean};
 
@@ -110,7 +104,6 @@ export class SharedInstallationTokenCache implements InstallationTokenCache {
   private readonly pollDelaysMs: number[];
   private readonly workspaceCacheTtlMs: number;
   private readonly mintTimeoutMs: number;
-  private readonly shareCompatibilityLock: boolean;
   private readonly generationFenceEnabled: boolean;
 
   constructor(private readonly options: SharedInstallationTokenCacheOptions) {
@@ -119,9 +112,6 @@ export class SharedInstallationTokenCache implements InstallationTokenCache {
     this.pollDelaysMs = options.pollDelaysMs ?? DEFAULT_POLL_DELAYS_MS;
     this.workspaceCacheTtlMs = options.workspaceCacheTtlMs ?? DEFAULT_WORKSPACE_CACHE_TTL_MS;
     this.mintTimeoutMs = options.mintTimeoutMs ?? DEFAULT_MINT_TIMEOUT_MS;
-    this.shareCompatibilityLock =
-      options.shareCompatibilityLock ??
-      (options.withBackoffLock === undefined || options.withBackoffLock === options.withLock);
     this.generationFenceEnabled =
       options.secretStore.readGeneration !== undefined &&
       options.secretStore.writeGeneration !== undefined;
@@ -137,21 +127,17 @@ export class SharedInstallationTokenCache implements InstallationTokenCache {
     }
 
     const workspaceId = options.workspaceId ?? (await this.resolveWorkspaceId(installationId));
-    const result = await this.withBackoffLock(
-      installationId,
-      GITHUB_COMPATIBILITY_PERMISSION_FINGERPRINT,
-      async () => {
-        const generation = randomUUID();
+    const result = await this.withBackoffLock(installationId, async () => {
+      const generation = randomUUID();
+      await this.writeGeneration(workspaceId, installationId, generation);
+      let deleted = 0;
+      try {
+        deleted = options.deleteNamespace ? await options.deleteNamespace(installationId) : 0;
+      } finally {
         await this.writeGeneration(workspaceId, installationId, generation);
-        let deleted = 0;
-        try {
-          deleted = options.deleteNamespace ? await options.deleteNamespace(installationId) : 0;
-        } finally {
-          await this.writeGeneration(workspaceId, installationId, generation);
-        }
-        return deleted;
-      },
-    );
+      }
+      return deleted;
+    });
     if (!result.acquired) {
       throw new GithubIntegrationProviderError(
         'provider-unavailable',
@@ -172,13 +158,9 @@ export class SharedInstallationTokenCache implements InstallationTokenCache {
 
   async getOrMint(
     installationId: number,
-    permissionFingerprint: string,
     mint: () => Promise<GithubInstallationAccessToken>,
   ): Promise<GithubInstallationAccessToken> {
     const workspaceId = await this.resolveWorkspaceId(installationId);
-    const profileKey = githubInstallationTokenKey(permissionFingerprint);
-    const backoffKeys = githubInstallationTokenBackoffKeys(permissionFingerprint);
-    const profileBackoffKey = githubInstallationTokenBackoffKey(permissionFingerprint);
     let readFailureReported = false;
     const reportReadFailure = (error: unknown) => {
       if (readFailureReported) return;
@@ -194,8 +176,6 @@ export class SharedInstallationTokenCache implements InstallationTokenCache {
     const envelope = await this.readEnvelope(
       workspaceId,
       installationId,
-      profileKey,
-      backoffKeys,
       reportReadFailure,
       generation,
     );
@@ -210,23 +190,17 @@ export class SharedInstallationTokenCache implements InstallationTokenCache {
         recordInstallationTokenLookup('db-hit');
         return tokenFromEnvelope(envelope);
       }
-      return await this.getOrMint(installationId, permissionFingerprint, mint);
+      return await this.getOrMint(installationId, mint);
     }
 
     let result: InstallationTokenLockResult<GithubInstallationAccessToken>;
     try {
-      result = await this.options.withLock(installationId, permissionFingerprint, () =>
+      result = await this.options.withLock(installationId, () =>
         this.mintUnderLock({
           workspaceId,
           installationId,
-          profileKey,
-          backoffKeys,
-          permissionFingerprint,
           mint,
           reportReadFailure,
-          compatibilityLockHeld:
-            permissionFingerprint === GITHUB_COMPATIBILITY_PERMISSION_FINGERPRINT &&
-            this.shareCompatibilityLock,
         }),
       );
     } catch (error) {
@@ -234,8 +208,6 @@ export class SharedInstallationTokenCache implements InstallationTokenCache {
       const backoff = await this.recordBackoff({
         workspaceId,
         installationId,
-        profileKey,
-        profileBackoffKey,
         reportReadFailure,
         failure: error,
         generation,
@@ -256,7 +228,6 @@ export class SharedInstallationTokenCache implements InstallationTokenCache {
           {
             installationId,
             expiresAt: error.failureEnvelope.expiresAt?.toISOString(),
-            permissionProfile: profileKey,
             reason: error.providerError.reason,
             backoffUntil: backoff.until.toISOString(),
             backoffPersisted: backoff.persisted,
@@ -270,7 +241,6 @@ export class SharedInstallationTokenCache implements InstallationTokenCache {
       logger().warn(
         {
           installationId,
-          permissionProfile: profileKey,
           reason: error.providerError.reason,
           backoffUntil: backoff.until.toISOString(),
           backoffPersisted: backoff.persisted,
@@ -287,8 +257,6 @@ export class SharedInstallationTokenCache implements InstallationTokenCache {
       await this.clearBackoff({
         workspaceId,
         installationId,
-        profileKey,
-        backoffKeys,
         reportReadFailure,
         generation,
       });
@@ -302,15 +270,12 @@ export class SharedInstallationTokenCache implements InstallationTokenCache {
       ) {
         return result.value;
       }
-      return await this.getOrMint(installationId, permissionFingerprint, mint);
+      return await this.getOrMint(installationId, mint);
     }
 
     return await this.serveStaleOrPoll({
       workspaceId,
       installationId,
-      profileKey,
-      permissionFingerprint,
-      backoffKeys,
       envelope,
       reportReadFailure,
       generation,
@@ -342,8 +307,6 @@ export class SharedInstallationTokenCache implements InstallationTokenCache {
     const envelope = await this.readEnvelope(
       params.workspaceId,
       params.installationId,
-      params.profileKey,
-      params.backoffKeys,
       params.reportReadFailure,
       generation,
     );
@@ -397,10 +360,6 @@ export class SharedInstallationTokenCache implements InstallationTokenCache {
       recordInstallationTokenBackoff({
         reason: failure.reason,
         class: failure.class,
-        profile:
-          params.permissionFingerprint === GITHUB_COMPATIBILITY_PERMISSION_FINGERPRINT
-            ? 'compatibility'
-            : 'scoped',
       });
       throw new InstallationTokenMintFailure(providerError, failure, envelope);
     }
@@ -409,7 +368,7 @@ export class SharedInstallationTokenCache implements InstallationTokenCache {
     if (writeResult === 'skipped') return undefined;
     if (writeResult === 'contended') {
       logger().warn(
-        {installationId: params.installationId, permissionProfile: params.profileKey},
+        {installationId: params.installationId},
         'github installation token cache write lock was contended',
       );
     }
@@ -417,7 +376,6 @@ export class SharedInstallationTokenCache implements InstallationTokenCache {
     logger().info(
       {
         installationId: params.installationId,
-        permissionProfile: params.profileKey,
         expiresAt: token.expiresAt.toISOString(),
       },
       'github installation token minted',
@@ -435,14 +393,14 @@ export class SharedInstallationTokenCache implements InstallationTokenCache {
       return await this.writeEnvelope(
         params.workspaceId,
         params.installationId,
-        params.profileKey,
+        FULL_GRANT_TOKEN_KEY,
         {
           token: token.token,
           expiresAt: token.expiresAt,
           permissions: token.permissions,
         },
         generation,
-        params.compatibilityLockHeld,
+        true,
         params.reportReadFailure,
       );
     } catch (error) {
@@ -462,31 +420,21 @@ export class SharedInstallationTokenCache implements InstallationTokenCache {
   private async recordBackoff(params: {
     workspaceId: string;
     installationId: number;
-    profileKey: string;
-    profileBackoffKey: string;
     reportReadFailure: (error: unknown) => void;
     failure: InstallationTokenMintFailure;
     generation: InstallationTokenGeneration;
   }): Promise<InstallationTokenBackoffResult> {
     const candidateUntil = new Date(this.now().getTime() + backoffMs(params.failure.failure));
-    const backoffScope = mintBackoffScopeForReason(params.failure.failure.reason);
-    const backoffKey =
-      backoffScope === 'installation'
-        ? GITHUB_INSTALLATION_TOKEN_BACKOFF_KEY
-        : params.profileBackoffKey;
     if (params.generation === undefined) return {until: candidateUntil, persisted: false};
 
     try {
-      const result = await this.withBackoffPersistenceLock(
-        params.installationId,
-        GITHUB_COMPATIBILITY_PERMISSION_FINGERPRINT,
-        () => this.persistBackoff({...params, backoffKey, candidateUntil}),
+      const result = await this.withBackoffPersistenceLock(params.installationId, () =>
+        this.persistBackoff({...params, candidateUntil}),
       );
       if (result.acquired) return result.value;
       logger().warn(
         {
           installationId: params.installationId,
-          permissionProfile: params.profileKey,
           reason: params.failure.failure.reason,
         },
         'github installation token backoff lock was contended',
@@ -495,7 +443,6 @@ export class SharedInstallationTokenCache implements InstallationTokenCache {
       logger().warn(
         {
           installationId: params.installationId,
-          permissionProfile: params.profileKey,
           reason: params.failure.failure.reason,
           error,
         },
@@ -513,11 +460,9 @@ export class SharedInstallationTokenCache implements InstallationTokenCache {
   private async persistBackoff(params: {
     workspaceId: string;
     installationId: number;
-    profileKey: string;
     reportReadFailure: (error: unknown) => void;
     failure: InstallationTokenMintFailure;
     generation: InstallationTokenGeneration;
-    backoffKey: string;
     candidateUntil: Date;
   }): Promise<InstallationTokenBackoffResult> {
     const current = await this.readGeneration(
@@ -537,8 +482,6 @@ export class SharedInstallationTokenCache implements InstallationTokenCache {
     const envelope = await this.readEnvelope(
       params.workspaceId,
       params.installationId,
-      params.profileKey,
-      [params.backoffKey],
       reportReadFailure,
       params.generation,
     );
@@ -566,7 +509,7 @@ export class SharedInstallationTokenCache implements InstallationTokenCache {
     const backoffResult = await this.writeEnvelope(
       params.workspaceId,
       params.installationId,
-      params.backoffKey,
+      FULL_GRANT_BACKOFF_KEY,
       selectedBackoff,
       params.generation,
       true,
@@ -577,7 +520,7 @@ export class SharedInstallationTokenCache implements InstallationTokenCache {
         await this.writeEnvelope(
           params.workspaceId,
           params.installationId,
-          params.profileKey,
+          FULL_GRANT_TOKEN_KEY,
           {
             token: envelope?.token,
             expiresAt: envelope?.expiresAt,
@@ -591,14 +534,13 @@ export class SharedInstallationTokenCache implements InstallationTokenCache {
         logger().warn(
           {
             installationId: params.installationId,
-            permissionProfile: params.profileKey,
             error,
           },
-          'github installation token profile cache preservation failed',
+          'github installation token cache preservation failed',
         );
         reportError(error, {
           boundary: 'integration.cache',
-          operation: 'write-profile-envelope',
+          operation: 'write-token-envelope',
           extra: {installationId: params.installationId},
         });
       }
@@ -612,57 +554,45 @@ export class SharedInstallationTokenCache implements InstallationTokenCache {
   private async clearBackoff(params: {
     workspaceId: string;
     installationId: number;
-    profileKey: string;
-    backoffKeys: readonly string[];
     reportReadFailure: (error: unknown) => void;
     generation: InstallationTokenGeneration;
   }): Promise<void> {
     try {
-      await this.withBackoffLock(
-        params.installationId,
-        GITHUB_COMPATIBILITY_PERMISSION_FINGERPRINT,
-        async () => {
-          if (
-            !(await this.generationMatches(
-              params.workspaceId,
-              params.installationId,
-              params.generation,
-              params.reportReadFailure,
-              true,
-            ))
-          )
-            return;
-          let readFailed = false;
-          const envelope = await this.readEnvelope(
+      await this.withBackoffLock(params.installationId, async () => {
+        if (
+          !(await this.generationMatches(
             params.workspaceId,
             params.installationId,
-            params.profileKey,
-            params.backoffKeys,
-            (error) => {
-              readFailed = true;
-              params.reportReadFailure(error);
-            },
             params.generation,
-          );
-          if (readFailed || activeBackoff(envelope, this.now())) return;
-          await Promise.all(
-            params.backoffKeys.map((backoffKey) =>
-              this.writeEnvelope(
-                params.workspaceId,
-                params.installationId,
-                backoffKey,
-                {},
-                params.generation,
-                true,
-                params.reportReadFailure,
-              ),
-            ),
-          );
-        },
-      );
+            params.reportReadFailure,
+            true,
+          ))
+        )
+          return;
+        let readFailed = false;
+        const envelope = await this.readEnvelope(
+          params.workspaceId,
+          params.installationId,
+          (error) => {
+            readFailed = true;
+            params.reportReadFailure(error);
+          },
+          params.generation,
+        );
+        if (readFailed || activeBackoff(envelope, this.now())) return;
+        await this.writeEnvelope(
+          params.workspaceId,
+          params.installationId,
+          FULL_GRANT_BACKOFF_KEY,
+          {},
+          params.generation,
+          true,
+          params.reportReadFailure,
+        );
+      });
     } catch (error) {
       logger().warn(
-        {installationId: params.installationId, permissionProfile: params.profileKey, error},
+        {installationId: params.installationId, error},
         'github installation token backoff clear failed',
       );
       reportError(error, {
@@ -675,15 +605,12 @@ export class SharedInstallationTokenCache implements InstallationTokenCache {
 
   private async withBackoffPersistenceLock<T>(
     installationId: number,
-    permissionFingerprint: string,
     operation: () => Promise<T>,
   ): Promise<InstallationTokenLockResult<T>> {
-    const withLock = this.shareCompatibilityLock
-      ? (this.options.withBackoffLock ?? this.options.withLock)
-      : this.options.withLock;
+    const withLock = this.options.withBackoffLock ?? this.options.withLock;
     for (const delayMs of [0, ...this.pollDelaysMs]) {
       if (delayMs > 0) await this.sleep(delayMs);
-      const result = await withLock(installationId, permissionFingerprint, operation);
+      const result = await withLock(installationId, operation);
       if (result.acquired) return result;
     }
     return {acquired: false};
@@ -691,13 +618,12 @@ export class SharedInstallationTokenCache implements InstallationTokenCache {
 
   private async withBackoffLock<T>(
     installationId: number,
-    permissionFingerprint: string,
     operation: () => Promise<T>,
   ): Promise<InstallationTokenLockResult<T>> {
     const withLock = this.options.withBackoffLock ?? this.options.withLock;
     for (const delayMs of [0, ...this.pollDelaysMs]) {
       if (delayMs > 0) await this.sleep(delayMs);
-      const result = await withLock(installationId, permissionFingerprint, operation);
+      const result = await withLock(installationId, operation);
       if (result.acquired) return result;
     }
     return {acquired: false};
@@ -706,9 +632,6 @@ export class SharedInstallationTokenCache implements InstallationTokenCache {
   private async serveStaleOrPoll(params: {
     workspaceId: string;
     installationId: number;
-    profileKey: string;
-    permissionFingerprint: string;
-    backoffKeys: readonly string[];
     envelope: InstallationTokenEnvelope | undefined;
     reportReadFailure: (error: unknown) => void;
     generation: InstallationTokenGeneration;
@@ -721,7 +644,7 @@ export class SharedInstallationTokenCache implements InstallationTokenCache {
       params.reportReadFailure,
     );
     if (!current) {
-      return await this.getOrMint(params.installationId, params.permissionFingerprint, params.mint);
+      return await this.getOrMint(params.installationId, params.mint);
     }
 
     const initialNow = this.now();
@@ -743,8 +666,6 @@ export class SharedInstallationTokenCache implements InstallationTokenCache {
       const envelope = await this.readEnvelope(
         params.workspaceId,
         params.installationId,
-        params.profileKey,
-        params.backoffKeys,
         params.reportReadFailure,
         params.generation,
       );
@@ -761,11 +682,7 @@ export class SharedInstallationTokenCache implements InstallationTokenCache {
           recordInstallationTokenLookup('contended-poll');
           return tokenFromEnvelope(envelope);
         }
-        return await this.getOrMint(
-          params.installationId,
-          params.permissionFingerprint,
-          params.mint,
-        );
+        return await this.getOrMint(params.installationId, params.mint);
       }
       if (backoffActive(envelope, now)) {
         recordInstallationTokenLookup('backoff');
@@ -801,54 +718,38 @@ export class SharedInstallationTokenCache implements InstallationTokenCache {
   private async readEnvelope(
     workspaceId: string,
     installationId: number,
-    profileKey: string,
-    backoffKeys: readonly string[],
     reportReadFailure: (error: unknown) => void,
     generation: InstallationTokenGeneration,
   ): Promise<InstallationTokenEnvelope | undefined> {
-    const isCompatibilityProfile =
-      profileKey === githubInstallationTokenKey(GITHUB_COMPATIBILITY_PERMISSION_FINGERPRINT);
-    const {profileResult, backoffResults, fixedEnvelopeResult} = await readSecretValues(
+    const {tokenResult, backoffResult, fixedEnvelopeResult} = await readSecretValues(
       this.options.secretStore,
       workspaceId,
       installationId,
-      profileKey,
-      backoffKeys,
+      FULL_GRANT_TOKEN_KEY,
+      FULL_GRANT_BACKOFF_KEY,
     );
-    reportSecretReadFailure(profileResult, reportReadFailure);
-    for (const backoffResult of backoffResults) {
-      reportSecretReadFailure(backoffResult, reportReadFailure);
-    }
+    reportSecretReadFailure(tokenResult, reportReadFailure);
+    reportSecretReadFailure(backoffResult, reportReadFailure);
     reportSecretReadFailure(fixedEnvelopeResult, reportReadFailure);
 
-    const profileRaw = settledRaw(profileResult);
-    const backoffRaws = backoffResults.map(settledRaw);
+    const tokenRaw = settledRaw(tokenResult);
+    const backoffRaw = settledRaw(backoffResult);
     const fixedEnvelopeRaw = settledRaw(fixedEnvelopeResult);
-    let profile = matchesGeneration(parseRawEnvelope(profileRaw, installationId), generation);
-    let backoff = latestBackoff(
-      backoffRaws.map((backoffRaw) =>
-        matchesGeneration(parseRawEnvelope(backoffRaw, installationId), generation),
-      ),
-      this.now(),
-    );
+    let token = matchesGeneration(parseRawEnvelope(tokenRaw, installationId), generation);
+    let backoff = matchesGeneration(parseRawEnvelope(backoffRaw, installationId), generation);
     const fixedEnvelope = matchesGeneration(
       parseRawEnvelope(fixedEnvelopeRaw, installationId),
       generation,
     );
-    if (isCompatibilityProfile && profile === undefined && profileRaw === null) {
-      profile = fixedEnvelope;
+    if (token === undefined && tokenRaw === null) {
+      token = fixedEnvelope;
     }
-    if (
-      isCompatibilityProfile &&
-      backoff === undefined &&
-      backoffRaws.length === 1 &&
-      backoffRaws[0] === null
-    ) {
+    if (backoff === undefined && backoffRaw === null) {
       backoff = fixedEnvelope;
     }
-    if (!profile && !backoff) return undefined;
+    if (!token && !backoff) return undefined;
     return {
-      ...profile,
+      ...token,
       ...(backoff?.generation === undefined ? {} : {generation: backoff.generation}),
       ...(backoff?.backoffUntil === undefined ? {} : {backoffUntil: backoff.backoffUntil}),
       ...(backoff?.backoffReason === undefined ? {} : {backoffReason: backoff.backoffReason}),
@@ -908,11 +809,7 @@ export class SharedInstallationTokenCache implements InstallationTokenCache {
     const read = () =>
       this.generationMatchesDirect(workspaceId, installationId, generation, reportReadFailure);
     if (lockHeld) return await read();
-    const result = await this.withBackoffLock(
-      installationId,
-      GITHUB_COMPATIBILITY_PERMISSION_FINGERPRINT,
-      read,
-    );
+    const result = await this.withBackoffLock(installationId, read);
     if (!result.acquired) {
       throw new GithubIntegrationProviderError(
         'provider-unavailable',
@@ -967,11 +864,7 @@ export class SharedInstallationTokenCache implements InstallationTokenCache {
       return 'written';
     };
     if (!this.generationFenceEnabled || lockHeld) return await write(lockHeld);
-    const result = await this.withBackoffLock(
-      installationId,
-      GITHUB_COMPATIBILITY_PERMISSION_FINGERPRINT,
-      () => write(true),
-    );
+    const result = await this.withBackoffLock(installationId, () => write(true));
     if (!result.acquired) return 'contended';
     return result.value;
   }
@@ -993,8 +886,8 @@ export class SharedInstallationTokenCache implements InstallationTokenCache {
 type SettledSecretRead = PromiseSettledResult<string | null>;
 
 interface InstallationTokenSecretReads {
-  profileResult: SettledSecretRead;
-  backoffResults: readonly SettledSecretRead[];
+  tokenResult: SettledSecretRead;
+  backoffResult: SettledSecretRead;
   fixedEnvelopeResult: SettledSecretRead;
 }
 
@@ -1002,26 +895,24 @@ async function readSecretValues(
   secretStore: InstallationTokenSecretStore,
   workspaceId: string,
   installationId: number,
-  profileKey: string,
-  backoffKeys: readonly string[],
+  tokenKey: string,
+  backoffKey: string,
 ): Promise<InstallationTokenSecretReads> {
-  const profileRead = secretStore.read(workspaceId, installationId, profileKey);
-  const backoffReads = backoffKeys.map((backoffKey) =>
-    secretStore.read(workspaceId, installationId, backoffKey),
-  );
+  const tokenRead = secretStore.read(workspaceId, installationId, tokenKey);
+  const backoffRead = secretStore.read(workspaceId, installationId, backoffKey);
   const fixedEnvelopeRead = secretStore.read(
     workspaceId,
     installationId,
     GITHUB_INSTALLATION_TOKEN_ENVELOPE_KEY,
   );
-  const [profileResult, fixedEnvelopeResult] = await Promise.allSettled([
-    profileRead,
+  const [tokenResult, backoffResult, fixedEnvelopeResult] = await Promise.allSettled([
+    tokenRead,
+    backoffRead,
     fixedEnvelopeRead,
   ]);
-  const backoffResults = await Promise.allSettled(backoffReads);
   return {
-    profileResult,
-    backoffResults,
+    tokenResult,
+    backoffResult,
     fixedEnvelopeResult,
   };
 }
@@ -1059,34 +950,6 @@ function matchesGeneration(
   return envelope.generation === (generation === null ? undefined : generation)
     ? envelope
     : undefined;
-}
-
-function latestBackoff(
-  envelopes: readonly (InstallationTokenEnvelope | undefined)[],
-  now: Date,
-): InstallationTokenEnvelope | undefined {
-  let latest: InstallationTokenEnvelope | undefined;
-  let latestActiveTerminal: InstallationTokenEnvelope | undefined;
-  for (const envelope of envelopes) {
-    if (envelope?.backoffUntil === undefined || envelope.backoffReason === undefined) continue;
-    const latestBackoffUntil = latest?.backoffUntil;
-    if (
-      latest === undefined ||
-      latestBackoffUntil === undefined ||
-      envelope.backoffUntil > latestBackoffUntil
-    ) {
-      latest = envelope;
-    }
-    const latestActiveTerminalUntil = latestActiveTerminal?.backoffUntil;
-    if (
-      envelope.backoffUntil > now &&
-      mintErrorClassForReason(envelope.backoffReason) === 'terminal' &&
-      (latestActiveTerminalUntil === undefined || envelope.backoffUntil > latestActiveTerminalUntil)
-    ) {
-      latestActiveTerminal = envelope;
-    }
-  }
-  return latestActiveTerminal ?? latest;
 }
 
 class InstallationTokenMintFailure extends Error {

--- a/libs/api/integration/github/src/api/shared-installation-token-cache.ts
+++ b/libs/api/integration/github/src/api/shared-installation-token-cache.ts
@@ -69,7 +69,6 @@ type InstallationTokenLock = <T>(
 export interface SharedInstallationTokenCacheOptions {
   secretStore: InstallationTokenSecretStore;
   withLock: InstallationTokenLock;
-  withBackoffLock?: InstallationTokenLock | undefined;
   resolveWorkspaceId: (installationId: number) => Promise<string>;
   now?: (() => Date) | undefined;
   sleep?: ((ms: number) => Promise<void>) | undefined;
@@ -428,7 +427,7 @@ export class SharedInstallationTokenCache implements InstallationTokenCache {
     if (params.generation === undefined) return {until: candidateUntil, persisted: false};
 
     try {
-      const result = await this.withBackoffPersistenceLock(params.installationId, () =>
+      const result = await this.withBackoffLock(params.installationId, () =>
         this.persistBackoff({...params, candidateUntil}),
       );
       if (result.acquired) return result.value;
@@ -603,27 +602,13 @@ export class SharedInstallationTokenCache implements InstallationTokenCache {
     }
   }
 
-  private async withBackoffPersistenceLock<T>(
-    installationId: number,
-    operation: () => Promise<T>,
-  ): Promise<InstallationTokenLockResult<T>> {
-    const withLock = this.options.withBackoffLock ?? this.options.withLock;
-    for (const delayMs of [0, ...this.pollDelaysMs]) {
-      if (delayMs > 0) await this.sleep(delayMs);
-      const result = await withLock(installationId, operation);
-      if (result.acquired) return result;
-    }
-    return {acquired: false};
-  }
-
   private async withBackoffLock<T>(
     installationId: number,
     operation: () => Promise<T>,
   ): Promise<InstallationTokenLockResult<T>> {
-    const withLock = this.options.withBackoffLock ?? this.options.withLock;
     for (const delayMs of [0, ...this.pollDelaysMs]) {
       if (delayMs > 0) await this.sleep(delayMs);
-      const result = await withLock(installationId, operation);
+      const result = await this.options.withLock(installationId, operation);
       if (result.acquired) return result;
     }
     return {acquired: false};

--- a/libs/api/integration/github/src/api/shared-installation-token-cache.ts
+++ b/libs/api/integration/github/src/api/shared-installation-token-cache.ts
@@ -126,7 +126,7 @@ export class SharedInstallationTokenCache implements InstallationTokenCache {
     }
 
     const workspaceId = options.workspaceId ?? (await this.resolveWorkspaceId(installationId));
-    const result = await this.withBackoffLock(installationId, async () => {
+    const result = await this.retryWithInstallationLock(installationId, async () => {
       const generation = randomUUID();
       await this.writeGeneration(workspaceId, installationId, generation);
       let deleted = 0;
@@ -427,7 +427,7 @@ export class SharedInstallationTokenCache implements InstallationTokenCache {
     if (params.generation === undefined) return {until: candidateUntil, persisted: false};
 
     try {
-      const result = await this.withBackoffLock(params.installationId, () =>
+      const result = await this.retryWithInstallationLock(params.installationId, () =>
         this.persistBackoff({...params, candidateUntil}),
       );
       if (result.acquired) return result.value;
@@ -557,7 +557,7 @@ export class SharedInstallationTokenCache implements InstallationTokenCache {
     generation: InstallationTokenGeneration;
   }): Promise<void> {
     try {
-      await this.withBackoffLock(params.installationId, async () => {
+      await this.retryWithInstallationLock(params.installationId, async () => {
         if (
           !(await this.generationMatches(
             params.workspaceId,
@@ -602,7 +602,7 @@ export class SharedInstallationTokenCache implements InstallationTokenCache {
     }
   }
 
-  private async withBackoffLock<T>(
+  private async retryWithInstallationLock<T>(
     installationId: number,
     operation: () => Promise<T>,
   ): Promise<InstallationTokenLockResult<T>> {
@@ -794,7 +794,7 @@ export class SharedInstallationTokenCache implements InstallationTokenCache {
     const read = () =>
       this.generationMatchesDirect(workspaceId, installationId, generation, reportReadFailure);
     if (lockHeld) return await read();
-    const result = await this.withBackoffLock(installationId, read);
+    const result = await this.retryWithInstallationLock(installationId, read);
     if (!result.acquired) {
       throw new GithubIntegrationProviderError(
         'provider-unavailable',
@@ -849,7 +849,7 @@ export class SharedInstallationTokenCache implements InstallationTokenCache {
       return 'written';
     };
     if (!this.generationFenceEnabled || lockHeld) return await write(lockHeld);
-    const result = await this.withBackoffLock(installationId, () => write(true));
+    const result = await this.retryWithInstallationLock(installationId, () => write(true));
     if (!result.acquired) return 'contended';
     return result.value;
   }

--- a/libs/api/integration/github/src/db/installation-token-lock.test.ts
+++ b/libs/api/integration/github/src/db/installation-token-lock.test.ts
@@ -1,22 +1,16 @@
 import {withInstallationTokenLock} from './installation-token-lock.js';
 
 describe('withInstallationTokenLock', () => {
-  it('allows one holder per installation per permission profile and fails same-profile contenders fast', async () => {
+  it('allows one holder per installation and fails contenders fast', async () => {
     const first = holdInstallationTokenLock(9001, 'winner');
 
     await first.ready;
     const contender = await withInstallationTokenLock(9001, async () => 'contender');
-    const differentProfile = await withInstallationTokenLock(
-      9001,
-      'narrow',
-      async () => 'different-profile',
-    );
     const different = await withInstallationTokenLock(9002, async () => 'different');
     first.release();
     const winner = await first.result;
 
     expect(contender).toEqual({acquired: false});
-    expect(differentProfile).toEqual({acquired: true, value: 'different-profile'});
     expect(different).toEqual({acquired: true, value: 'different'});
     expect(winner).toEqual({acquired: true, value: 'winner'});
   });

--- a/libs/api/integration/github/src/db/installation-token-lock.ts
+++ b/libs/api/integration/github/src/db/installation-token-lock.ts
@@ -6,10 +6,6 @@ export type InstallationTokenLockResult<T> = {acquired: true; value: T} | {acqui
 
 export function withInstallationTokenLock<T>(
   installationId: number,
-  fn: () => Promise<T>,
-): Promise<InstallationTokenLockResult<T>>;
-export function withInstallationTokenLock<T>(
-  installationId: number,
   operation: () => Promise<T>,
 ): Promise<InstallationTokenLockResult<T>> {
   const lockKey = installationTokenLockKey(installationId);

--- a/libs/api/integration/github/src/db/installation-token-lock.ts
+++ b/libs/api/integration/github/src/db/installation-token-lock.ts
@@ -1,5 +1,4 @@
 import {sql} from 'drizzle-orm';
-import {GITHUB_COMPATIBILITY_PERMISSION_FINGERPRINT} from '#api/installation-token-envelope.js';
 import {recordInstallationTokenLockWait} from '#metrics/index.js';
 import {db} from './db.js';
 
@@ -11,21 +10,9 @@ export function withInstallationTokenLock<T>(
 ): Promise<InstallationTokenLockResult<T>>;
 export function withInstallationTokenLock<T>(
   installationId: number,
-  permissionFingerprint: string,
-  fn: () => Promise<T>,
-): Promise<InstallationTokenLockResult<T>>;
-export function withInstallationTokenLock<T>(
-  installationId: number,
-  fingerprintOrFn: string | (() => Promise<T>),
-  maybeFn?: () => Promise<T>,
+  operation: () => Promise<T>,
 ): Promise<InstallationTokenLockResult<T>> {
-  const permissionFingerprint =
-    typeof fingerprintOrFn === 'string'
-      ? fingerprintOrFn
-      : GITHUB_COMPATIBILITY_PERMISSION_FINGERPRINT;
-  const operation = typeof fingerprintOrFn === 'function' ? fingerprintOrFn : maybeFn;
-  if (!operation) throw new Error('GitHub installation token lock operation is required');
-  const lockKey = installationTokenLockKey(installationId, permissionFingerprint);
+  const lockKey = installationTokenLockKey(installationId);
   return db().transaction(async (tx) => {
     const startedAt = Date.now();
     const lock = await tx.execute<{acquired: boolean}>(sql`
@@ -46,15 +33,10 @@ export function withInstallationTokenLock<T>(
   });
 }
 
-function installationTokenLockKey(installationId: number, permissionFingerprint: string): string {
+function installationTokenLockKey(installationId: number): string {
   if (!Number.isSafeInteger(installationId) || installationId < 0) {
     throw new Error(`Invalid GitHub installation id for advisory lock: ${installationId}`);
   }
-  if (permissionFingerprint.length === 0) {
-    throw new Error('GitHub installation token permission fingerprint cannot be empty');
-  }
 
-  return permissionFingerprint === GITHUB_COMPATIBILITY_PERMISSION_FINGERPRINT
-    ? String(-BigInt(installationId) - 1n)
-    : `github-installation-token:${installationId}:${permissionFingerprint}`;
+  return String(-BigInt(installationId) - 1n);
 }

--- a/libs/api/integration/github/src/metrics/instance.ts
+++ b/libs/api/integration/github/src/metrics/instance.ts
@@ -52,10 +52,8 @@ const installationTokenLockWaitDuration = meter.createHistogram<Record<string, n
 const installationTokenBackoffCount = meter.createCounter<{
   reason: IntegrationProviderErrorReason;
   class: MintErrorClass;
-  profile: 'compatibility' | 'scoped';
 }>('github_installation_token_backoff', {
-  description:
-    'GitHub installation token mint backoff activations by reason, class, and profile kind',
+  description: 'GitHub installation token mint backoff activations by reason and class',
 });
 
 export type GithubCheckoutTokenLookupOutcome =
@@ -128,7 +126,6 @@ export function recordInstallationTokenLockWait(durationMs: number): void {
 export function recordInstallationTokenBackoff(params: {
   reason: IntegrationProviderErrorReason;
   class: MintErrorClass;
-  profile: 'compatibility' | 'scoped';
 }): void {
   recordMetric(() => installationTokenBackoffCount.add(1, params));
 }


### PR DESCRIPTION
## Summary

Collapse backend GitHub installation-token caching, mint backoff, and advisory-lock coordination to one installation identity. The implementation keeps the persisted full-grant compatibility key, historical lock identity, generation fencing, expiry and refresh behavior, lifecycle invalidation, and fixed-envelope compatibility reads intact.

Legacy profile entries remain isolated and are never relabeled or read as full-grant tokens. Checkout caching remains unchanged. The architecture contract and package Changeset are updated for the completed maintenance reduction.

Validation passed locally with the affected Turbo graph (111 tasks, including 24 GitHub test files and 570 tests) and the API database-boundary verifier.

Closes ENG-2040

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Collapses backend GitHub installation-token caching, mint backoff, and advisory locks to a single installation identity, replacing per-permission-profile keys. This reduces duplication and maintenance while preserving legacy storage compatibility and generation fencing.

**What changed**
- Token and backoff keys are now full-grant identities per installation; legacy profile-keyed entries stay isolated and are never read or relabeled.
- Advisory locks now coordinate per installation, not per permission profile.
- Mint backoff records token-mint failures only; GitHub operation denials no longer write backoff.
- Generation fences, fixed-envelope fallback reads, and lifecycle invalidation remain unchanged.
- Removes the permission-profile label from the installation-token backoff metric.

Closes ENG-2040.

<sup>Written for commit 888bb924421c3e582ee0ae3ba97064ae3470313a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1759?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

