### PR TITLE
[expression] Preserve early tool input interpolation

### DIFF
--- a/.changeset/brisk-tools-freeze.md
+++ b/.changeset/brisk-tools-freeze.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/expression": patch
+---
+
+Preserves early workflow context values in staged tool inputs.

--- a/libs/api/workflows/src/core/job-execution.test.ts
+++ b/libs/api/workflows/src/core/job-execution.test.ts
@@ -267,6 +267,45 @@ describe('nextStepForJob', () => {
     ]);
   });
 
+  test('rejects invalid final tool config before queuing an invocation', async () => {
+    const {jobId, steps} = await arrangeJobWithSteps(1);
+    const pending = steps[0];
+    if (!pending) throw new Error('Expected a tool step');
+    await db()
+      .update(stepsTable)
+      .set({
+        type: 'tool',
+        config: {
+          tool: {
+            connection_id: 'connection-1',
+            id: 'issue_read',
+            input_schema: {
+              type: 'object',
+              additionalProperties: false,
+              properties: {owner: {type: 'string'}},
+              required: ['owner'],
+            },
+            with: {owner: 42},
+          },
+        },
+        configPlan: null,
+      })
+      .where(eq(stepsTable.id, pending.id));
+
+    const next = await nextStepForJob(jobId);
+
+    expect(next).toEqual({kind: 'done', status: 'failed'});
+    expect(await getToolInvocationsByJobExecutionId(pending.jobExecutionId)).toEqual([]);
+    expect((await getStepsByJobId(jobId))[0]).toMatchObject({
+      status: 'failed',
+      error: {
+        reason: 'agent_config_invalid',
+        field: 'tool',
+        code: 'tool_config_invalid',
+      },
+    });
+  });
+
   test('after a step succeeds, the next pull returns the next pending step', async () => {
     const {jobId, steps} = await arrangeJobWithSteps(3);
     await nextStepForJob(jobId);

--- a/libs/api/workflows/src/core/step-config/complete-step-dispatch-config.test.ts
+++ b/libs/api/workflows/src/core/step-config/complete-step-dispatch-config.test.ts
@@ -720,6 +720,46 @@ describe('completeStepDispatchConfig', () => {
     );
   });
 
+  it('merges a persisted mixed-array tool input plan', async () => {
+    const configPlan = JSON.parse(
+      JSON.stringify({
+        tool: {
+          with: {
+            items: [undefined, plannedToolField(template('steps.build.outputs.item')).segments],
+          },
+        },
+      }),
+    ) as Step['configPlan'];
+    const pending = step({
+      type: 'tool',
+      config: {
+        tool: {
+          input_schema: {
+            type: 'object',
+            additionalProperties: false,
+            properties: {items: {type: 'array', items: {type: 'string'}}},
+            required: ['items'],
+          },
+          with: {items: ['run-1', null]},
+        },
+      },
+      configPlan,
+    });
+
+    const result = await completeStepDispatchConfig({
+      step: pending,
+      context: {
+        ...context,
+        values: {steps: {build: {outputs: {item: 'late'}}}},
+      },
+      resolveAgentDefaults,
+      definitionId: 'def-1',
+    });
+
+    expect(configPlan?.tool?.with).toMatchObject({items: [null, expect.any(Array)]});
+    expect(result.config.tool).toMatchObject({with: {items: ['run-1', 'late']}});
+  });
+
   it.each([
     {kind: 'scalar', value: 42},
     {kind: 'array', value: ['a', 'b']},

--- a/libs/api/workflows/src/core/step-config/complete-step-dispatch-config.test.ts
+++ b/libs/api/workflows/src/core/step-config/complete-step-dispatch-config.test.ts
@@ -756,7 +756,6 @@ describe('completeStepDispatchConfig', () => {
       definitionId: 'def-1',
     });
 
-    expect(configPlan?.tool?.with).toMatchObject({items: [null, expect.any(Array)]});
     expect(result.config.tool).toMatchObject({with: {items: ['run-1', 'late']}});
   });
 

--- a/libs/api/workflows/src/core/step-config/complete-step-dispatch-config.test.ts
+++ b/libs/api/workflows/src/core/step-config/complete-step-dispatch-config.test.ts
@@ -38,6 +38,15 @@ function plannedSessionField(source: string) {
   return plan.plan.field;
 }
 
+function plannedToolField(source: string) {
+  const plan = planInterpolationField({
+    field: 'tool.with',
+    segments: parseWorkflowTemplate(source),
+  });
+  if (!plan.ok) throw new Error('Expected tool input field plan to be valid');
+  return plan.plan.field;
+}
+
 function template(source: string): string {
   return '$'.concat('{{ ', source, ' }}');
 }
@@ -106,12 +115,25 @@ function checkRunToolInputSchema() {
       method: {type: 'string', enum: ['create', 'update']},
       owner: {type: 'string'},
       repo: {type: 'string'},
+      name: {type: 'string'},
+      head_sha: {type: 'string'},
+      status: {type: 'string'},
+      external_id: {type: 'string'},
       check_run_id: {type: 'integer', minimum: 1},
       conclusion: {type: 'string'},
+      output: {
+        type: 'object',
+        additionalProperties: false,
+        properties: {title: {type: 'string'}, summary: {type: 'string'}},
+        required: ['title', 'summary'],
+      },
     },
     required: ['method', 'owner', 'repo'],
     oneOf: [
-      {properties: {method: {const: 'create'}}, required: []},
+      {
+        properties: {method: {const: 'create'}},
+        required: ['name', 'head_sha', 'status', 'external_id', 'output'],
+      },
       {
         properties: {method: {const: 'update'}},
         required: ['check_run_id', 'conclusion'],
@@ -621,6 +643,80 @@ describe('completeStepDispatchConfig', () => {
         method: 'update',
       },
     });
+  });
+
+  it('merges frozen check-run inputs with a late result before validation and method injection', async () => {
+    const pending = step({
+      type: 'tool',
+      config: {
+        tool: {
+          connection_id: 'connection-1',
+          connection_slug: 'github-main',
+          provider: 'github',
+          id: 'check_run_write',
+          method: 'create',
+          sensitivity: 'write',
+          sensitive: false,
+          required_scope: [{permission: 'checks', access: 'write'}],
+          input_schema: checkRunToolInputSchema(),
+          with: {
+            owner: 'ShipfoxHQ',
+            repo: 'cloud',
+            name: 'Shipfox PR review',
+            head_sha: 'e964e53dd9826c418b65033d0c209737cfe9ef98',
+            status: 'in_progress',
+            external_id: 'shipfox-run-1',
+            output: {title: 'Review in progress'},
+          },
+        },
+      },
+      configPlan: {
+        tool: {
+          with: {
+            output: {
+              summary: plannedToolField(template('steps.review.outputs.summary')).segments,
+            },
+          },
+        },
+      },
+    });
+
+    const result = await completeStepDispatchConfig({
+      step: pending,
+      context: {
+        ...context,
+        values: {
+          ...context.values,
+          steps: {review: {outputs: {summary: 'Shipfox finished the review.'}}},
+        },
+      },
+      resolveAgentDefaults,
+      definitionId: 'def-1',
+    });
+
+    expect(result.config.tool).toMatchObject({
+      with: {
+        method: 'create',
+        owner: 'ShipfoxHQ',
+        repo: 'cloud',
+        name: 'Shipfox PR review',
+        head_sha: 'e964e53dd9826c418b65033d0c209737cfe9ef98',
+        status: 'in_progress',
+        external_id: 'shipfox-run-1',
+        output: {
+          title: 'Review in progress',
+          summary: 'Shipfox finished the review.',
+        },
+      },
+    });
+    expect(result.trace).toContainEqual(
+      expect.objectContaining({
+        expression: 'steps.review.outputs.summary',
+        fillTarget: 'step-dispatch',
+        evaluatedAt: 'step-dispatch',
+        field: 'tool.with',
+      }),
+    );
   });
 
   it.each([

--- a/libs/api/workflows/src/core/step-config/complete-step-dispatch-config.test.ts
+++ b/libs/api/workflows/src/core/step-config/complete-step-dispatch-config.test.ts
@@ -674,7 +674,8 @@ describe('completeStepDispatchConfig', () => {
         tool: {
           with: {
             output: {
-              summary: plannedToolField(template('steps.review.outputs.summary')).segments,
+              summary: plannedToolField(`Run 42: ${template('steps.review.outputs.summary')}`)
+                .segments,
             },
           },
         },
@@ -705,7 +706,7 @@ describe('completeStepDispatchConfig', () => {
         external_id: 'shipfox-run-1',
         output: {
           title: 'Review in progress',
-          summary: 'Shipfox finished the review.',
+          summary: 'Run 42: Shipfox finished the review.',
         },
       },
     });

--- a/libs/api/workflows/src/core/step-config/complete-step-dispatch-config.ts
+++ b/libs/api/workflows/src/core/step-config/complete-step-dispatch-config.ts
@@ -155,7 +155,7 @@ function completeToolConfig(params: {
 
 function mergeToolWith(
   base: unknown,
-  plan: NonNullable<NonNullable<Step['configPlan']>['tool']>['with'] | undefined,
+  plan: NonNullable<NonNullable<Step['configPlan']>['tool']>['with'] | null | undefined,
   params: {
     readonly context: WorkflowEvaluationContext;
     readonly definitionId: string;
@@ -163,7 +163,7 @@ function mergeToolWith(
   },
   field: 'tool.with',
 ): unknown {
-  if (plan === undefined) return base;
+  if (isMissingToolWithPlan(plan)) return base;
   if (isFieldTemplate(plan)) {
     const resolved = completeStepFieldWithTypeAndTrace({
       field,
@@ -194,6 +194,10 @@ function mergeToolWith(
     return values;
   }
   throw new ToolConfigInvalidError('Tool input template plan is invalid');
+}
+
+function isMissingToolWithPlan(plan: unknown): plan is null | undefined {
+  return plan === undefined || plan === null;
 }
 
 function isFieldTemplate(value: unknown): value is readonly ResolvedFieldSegment[] {

--- a/libs/api/workflows/src/core/step-config/materialize-job-execution-steps.test.ts
+++ b/libs/api/workflows/src/core/step-config/materialize-job-execution-steps.test.ts
@@ -838,7 +838,7 @@ describe('materializeJobExecutionSteps', () => {
     });
   });
 
-  it('keeps static siblings when a nested tool input remains deferred', async () => {
+  it('keeps frozen container siblings when a nested tool input remains deferred', async () => {
     const model = workflowModel({
       jobs: {
         call: {
@@ -851,6 +851,7 @@ describe('materializeJobExecutionSteps', () => {
                   static: 'keep me',
                   dynamic: template('steps.previous.outputs.value'),
                 },
+                items: [template('run.id'), template('steps.previous.outputs.value')],
               },
             },
           ],
@@ -866,12 +867,16 @@ describe('materializeJobExecutionSteps', () => {
       context: jobExecutionContext(),
       agentToolContext: githubAgentToolContext(typedToolCatalog()),
     });
+    const persistedStep = JSON.parse(JSON.stringify(steps[1])) as (typeof steps)[number];
 
-    expect(steps[1]?.config.tool).toMatchObject({with: {payload: {static: 'keep me'}}});
-    expect(steps[1]?.configPlan?.tool?.with).toMatchObject({
+    expect(persistedStep.config.tool).toMatchObject({
+      with: {payload: {static: 'keep me'}, items: ['run-1', null]},
+    });
+    expect(persistedStep.configPlan?.tool?.with).toMatchObject({
       payload: {
         dynamic: [expect.objectContaining({kind: 'deferred', roots: ['steps']})],
       },
+      items: [null, [expect.objectContaining({kind: 'deferred', roots: ['steps']})]],
     });
   });
 

--- a/libs/api/workflows/src/core/step-config/materialize-job-execution-steps.test.ts
+++ b/libs/api/workflows/src/core/step-config/materialize-job-execution-steps.test.ts
@@ -635,7 +635,7 @@ describe('materializeJobExecutionSteps', () => {
     ]);
   });
 
-  it('preserves exact typed tool input expressions before dispatch', async () => {
+  it('preserves exact typed tool input expressions as JSON-safe values', async () => {
     const model = workflowModel({
       jobs: {
         call: {
@@ -665,15 +665,24 @@ describe('materializeJobExecutionSteps', () => {
         site: 'step-dispatch',
         values: {
           ...baseContext.values,
-          inputs: {count: 3, enabled: true, options: {mode: 'fast'}},
+          inputs: {
+            count: 3,
+            enabled: true,
+            options: {mode: 'fast', counts: [42n, 9007199254740993n]},
+          },
         },
       },
       agentToolContext: githubAgentToolContext(typedToolCatalog()),
     });
 
     expect(steps[1]?.config.tool).toMatchObject({
-      with: {count: 3, enabled: true, options: {mode: 'fast'}},
+      with: {
+        count: 3,
+        enabled: true,
+        options: {mode: 'fast', counts: [42, '9007199254740993']},
+      },
     });
+    expect(JSON.parse(JSON.stringify(steps[1]?.config))).toEqual(steps[1]?.config);
   });
 
   it.each([

--- a/libs/api/workflows/src/core/step-config/materialize-job-execution-steps.test.ts
+++ b/libs/api/workflows/src/core/step-config/materialize-job-execution-steps.test.ts
@@ -51,6 +51,8 @@ function jobExecutionContext(): WorkflowEvaluationContext {
     values: {
       run: {
         id: 'run-1',
+        number: 42n,
+        attempt: 1n,
         name: 'Reviews',
         definition_id: 'def-1',
         project_id: 'proj-1',
@@ -674,6 +676,40 @@ describe('materializeJobExecutionSteps', () => {
     });
   });
 
+  it('normalizes exact CEL integer tool inputs before persistence', async () => {
+    const model = workflowModel({
+      jobs: {
+        call: {
+          steps: [
+            {
+              tool: 'typed_tool',
+              connection: 'github-main',
+              with: {
+                count: template('run.number'),
+                enabled: true,
+                options: {mode: 'fast'},
+              },
+            },
+          ],
+        },
+      },
+    });
+    const job = model.jobs[0];
+    if (!job) throw new Error('Expected workflow job');
+
+    const steps = await materializeJobExecutionSteps({
+      model,
+      job,
+      context: {...jobExecutionContext(), site: 'run-creation'},
+      agentToolContext: githubAgentToolContext(typedToolCatalog()),
+    });
+
+    expect(steps[1]?.config.tool).toMatchObject({
+      with: {count: 42, enabled: true, options: {mode: 'fast'}},
+    });
+    expect(() => JSON.stringify(steps[1]?.config)).not.toThrow();
+  });
+
   it('freezes documented event and run tool inputs while retaining late nested input', async () => {
     const model = workflowModel({
       jobs: {
@@ -691,7 +727,9 @@ describe('materializeJobExecutionSteps', () => {
                 external_id: `shipfox-${template('run.id')}`,
                 output: {
                   title: 'Review in progress',
-                  summary: template('steps.review.outputs.summary'),
+                  summary: `Run ${template('run.number')}: ${template(
+                    'steps.review.outputs.summary',
+                  )}`,
                 },
               },
             },
@@ -734,6 +772,9 @@ describe('materializeJobExecutionSteps', () => {
     expect(steps[1]?.configPlan?.tool?.with).toMatchObject({
       output: {
         summary: [
+          {kind: 'literal', value: 'Run '},
+          {kind: 'literal', value: '42'},
+          {kind: 'literal', value: ': '},
           expect.objectContaining({
             kind: 'deferred',
             roots: ['steps'],

--- a/libs/api/workflows/src/core/step-config/materialize-job-execution-steps.test.ts
+++ b/libs/api/workflows/src/core/step-config/materialize-job-execution-steps.test.ts
@@ -196,6 +196,28 @@ function typedToolCatalog(): readonly AgentToolCatalogEntry[] {
   ];
 }
 
+function checkRunToolCatalog(): readonly AgentToolCatalogEntry[] {
+  return [
+    {
+      id: 'check_run_write',
+      description: 'Write check runs.',
+      sensitivity: 'write',
+      sensitive: false,
+      requiredScope: [{permission: 'checks', access: 'write'}],
+      inputSchema: {type: 'object'},
+      methods: [
+        {
+          id: 'create',
+          description: 'Create a check run.',
+          sensitivity: 'write',
+          sensitive: false,
+          requiredScope: [{permission: 'checks', access: 'write'}],
+        },
+      ],
+    },
+  ];
+}
+
 describe('materializeJobExecutionSteps', () => {
   it('resolves static job names through the job execution context', async () => {
     const model = workflowModel({
@@ -649,6 +671,114 @@ describe('materializeJobExecutionSteps', () => {
 
     expect(steps[1]?.config.tool).toMatchObject({
       with: {count: 3, enabled: true, options: {mode: 'fast'}},
+    });
+  });
+
+  it('freezes documented event and run tool inputs while retaining late nested input', async () => {
+    const model = workflowModel({
+      jobs: {
+        call: {
+          steps: [
+            {
+              tool: 'check_run_write.create',
+              connection: 'github-main',
+              with: {
+                owner: template('event.repository.owner.login'),
+                repo: template('event.repository.name'),
+                name: 'Shipfox PR review',
+                head_sha: template('event.pull_request.head.sha'),
+                status: 'in_progress',
+                external_id: `shipfox-${template('run.id')}`,
+                output: {
+                  title: 'Review in progress',
+                  summary: template('steps.review.outputs.summary'),
+                },
+              },
+            },
+          ],
+        },
+      },
+    });
+    const job = model.jobs[0];
+    if (!job) throw new Error('Expected workflow job');
+    const baseContext = jobExecutionContext();
+
+    const steps = await materializeJobExecutionSteps({
+      model,
+      job,
+      context: {
+        site: 'run-creation',
+        values: {
+          ...baseContext.values,
+          event: {
+            repository: {owner: {login: 'ShipfoxHQ'}, name: 'cloud'},
+            pull_request: {head: {sha: 'e964e53dd9826c418b65033d0c209737cfe9ef98'}},
+          },
+        },
+      },
+      agentToolContext: githubAgentToolContext(checkRunToolCatalog()),
+    });
+
+    expect(steps[1]?.config.tool).toMatchObject({
+      method: 'create',
+      with: {
+        owner: 'ShipfoxHQ',
+        repo: 'cloud',
+        name: 'Shipfox PR review',
+        head_sha: 'e964e53dd9826c418b65033d0c209737cfe9ef98',
+        status: 'in_progress',
+        external_id: 'shipfox-run-1',
+        output: {title: 'Review in progress'},
+      },
+    });
+    expect(steps[1]?.configPlan?.tool?.with).toMatchObject({
+      output: {
+        summary: [
+          expect.objectContaining({
+            kind: 'deferred',
+            roots: ['steps'],
+            fillTarget: 'step-dispatch',
+          }),
+        ],
+      },
+    });
+    expect(Object.keys(steps[1]?.configPlan?.tool?.with ?? {})).toEqual(['output']);
+  });
+
+  it('reports a missing required event tool input with its source path', async () => {
+    const model = workflowModel({
+      jobs: {
+        call: {
+          steps: [
+            {
+              tool: 'typed_tool',
+              connection: 'github-main',
+              with: {options: template('event.repository.name')},
+            },
+          ],
+        },
+      },
+    });
+    const job = model.jobs[0];
+    if (!job) throw new Error('Expected workflow job');
+    const baseContext = jobExecutionContext();
+
+    const materialize = () =>
+      materializeJobExecutionSteps({
+        model,
+        job,
+        context: {
+          site: 'run-creation',
+          values: {...baseContext.values, event: {repository: {}}},
+        },
+        definitionId: 'def-1',
+        agentToolContext: githubAgentToolContext(typedToolCatalog()),
+      });
+
+    await expect(materialize()).rejects.toMatchObject({
+      name: 'InterpolationUnresolvableError',
+      field: 'tool.with',
+      source: 'event.repository.name',
     });
   });
 

--- a/libs/api/workflows/src/core/step-config/materialize-job-execution-steps.test.ts
+++ b/libs/api/workflows/src/core/step-config/materialize-job-execution-steps.test.ts
@@ -45,13 +45,13 @@ function condition(source: string) {
   return createWorkflowExpression({source, check: {mode: 'syntax'}});
 }
 
-function jobExecutionContext(): WorkflowEvaluationContext {
+function jobExecutionContext(runNumber = 42n): WorkflowEvaluationContext {
   return {
     site: 'execution-creation',
     values: {
       run: {
         id: 'run-1',
-        number: 42n,
+        number: runNumber,
         attempt: 1n,
         name: 'Reviews',
         definition_id: 'def-1',
@@ -676,7 +676,13 @@ describe('materializeJobExecutionSteps', () => {
     });
   });
 
-  it('normalizes exact CEL integer tool inputs before persistence', async () => {
+  it.each([
+    {kind: 'safe', runNumber: 42n, expected: 42},
+    {kind: 'unsafe', runNumber: 9007199254740993n, expected: '9007199254740993'},
+  ])('normalizes $kind exact CEL integer tool inputs before persistence', async ({
+    runNumber,
+    expected,
+  }) => {
     const model = workflowModel({
       jobs: {
         call: {
@@ -700,14 +706,14 @@ describe('materializeJobExecutionSteps', () => {
     const steps = await materializeJobExecutionSteps({
       model,
       job,
-      context: {...jobExecutionContext(), site: 'run-creation'},
+      context: {...jobExecutionContext(runNumber), site: 'run-creation'},
       agentToolContext: githubAgentToolContext(typedToolCatalog()),
     });
 
     expect(steps[1]?.config.tool).toMatchObject({
-      with: {count: 42, enabled: true, options: {mode: 'fast'}},
+      with: {count: expected, enabled: true, options: {mode: 'fast'}},
     });
-    expect(() => JSON.stringify(steps[1]?.config)).not.toThrow();
+    expect(JSON.parse(JSON.stringify(steps[1]?.config))).toEqual(steps[1]?.config);
   });
 
   it('freezes documented event and run tool inputs while retaining late nested input', async () => {

--- a/libs/api/workflows/src/core/step-config/tool.ts
+++ b/libs/api/workflows/src/core/step-config/tool.ts
@@ -111,8 +111,20 @@ function resolveWithField(params: ResolveWithParams): ResolveWithResult {
     definitionId: params.definitionId,
     errorField: 'tool.with',
   });
-  if (resolved.kind === 'frozen') return {value: resolved.value};
-  return {value: undefined, plan: params.tree};
+  if (resolved.kind === 'frozen') return {value: normalizeCelIntegersForJson(resolved.value)};
+  return {value: undefined, plan: resolved.field.segments};
+}
+
+function normalizeCelIntegersForJson(value: unknown): unknown {
+  if (typeof value === 'bigint') {
+    const numberValue = Number(value);
+    return Number.isSafeInteger(numberValue) ? numberValue : value.toString();
+  }
+  if (Array.isArray(value)) return value.map(normalizeCelIntegersForJson);
+  if (value === null || typeof value !== 'object' || value instanceof Date) return value;
+  return Object.fromEntries(
+    Object.entries(value).map(([key, child]) => [key, normalizeCelIntegersForJson(child)]),
+  );
 }
 
 function resolveWithArray(params: ResolveWithParams): ResolveWithResult {

--- a/libs/api/workflows/src/core/step-config/tool.ts
+++ b/libs/api/workflows/src/core/step-config/tool.ts
@@ -135,8 +135,9 @@ function resolveWithArray(params: ResolveWithParams): ResolveWithResult {
     if (child === undefined) return;
     const resolved = resolveWith({...params, value: values[index], tree: child});
     values[index] = resolved.value;
+    if (resolved.plan === undefined) return;
     plans[index] = resolved.plan;
-    hasPlan ||= resolved.plan !== undefined;
+    hasPlan = true;
   });
   return {value: values, ...(hasPlan ? {plan: plans} : {})};
 }

--- a/libs/shared/expression/src/plan/plan-field.test.ts
+++ b/libs/shared/expression/src/plan/plan-field.test.ts
@@ -70,6 +70,33 @@ describe('planInterpolationField', () => {
     });
   });
 
+  it.each([
+    ['event.repository.name', 'event', 'ingest'],
+    ['run.id', 'run', 'run-creation'],
+    ['jobs.build.outputs.sha', 'jobs', 'job-activation'],
+    ['steps.build.outputs.sha', 'steps', 'step-dispatch'],
+  ] as const)('routes tool input %s at its natural availability site', (source, root, fillTarget) => {
+    const segments = parseWorkflowTemplate(templateExpression(source));
+
+    const result = planInterpolationField({field: 'tool.with', segments});
+
+    expect(result).toMatchObject({
+      ok: true,
+      plan: {
+        failurePolicy: 'fail',
+        field: {
+          segments: [
+            {
+              kind: 'deferred',
+              roots: [root],
+              fillTarget,
+            },
+          ],
+        },
+      },
+    });
+  });
+
   it('keeps template segment boundaries while assigning fill targets', () => {
     const segments = parseWorkflowTemplate(
       `${templateExpression(' run.id ')}-${templateExpression(' trigger.event ')}`,

--- a/libs/shared/expression/src/workflow-context/workflow-context.test.ts
+++ b/libs/shared/expression/src/workflow-context/workflow-context.test.ts
@@ -838,7 +838,7 @@ describe('workflow context registry', () => {
     });
 
     it('declares the minimum fill target of every interpolation field', () => {
-      expect(getWorkflowInterpolationFieldMinimumFillTarget('tool.with')).toBe('step-dispatch');
+      expect(getWorkflowInterpolationFieldMinimumFillTarget('tool.with')).toBeUndefined();
       expect(getWorkflowInterpolationFieldMinimumFillTarget('tool.outputs')).toBe('step-report');
       expect(getWorkflowInterpolationFieldMinimumFillTarget('run')).toBeUndefined();
       expect(getWorkflowInterpolationFieldMinimumFillTarget('job.outputs')).toBe(

--- a/libs/shared/expression/src/workflow-context/workflow-context.ts
+++ b/libs/shared/expression/src/workflow-context/workflow-context.ts
@@ -607,7 +607,6 @@ export const workflowInterpolationFieldPolicies: Readonly<
   'tool.with': {
     acceptedHosts: serverOnlyHosts,
     failurePolicy: 'fail',
-    minimumFillTarget: 'step-dispatch',
   },
   'tool.outputs': {
     acceptedHosts: serverOnlyHosts,


### PR DESCRIPTION
Deterministic tool inputs that referenced event.* or run.* were forced to resolve at step dispatch, after those roots had left the available context. This caused the GitHub check-run step in [Cloud run #715](https://app.shipfox.io/w/shipfox/p/cloud/runs/01a087b8-d066-753a-ad70-83cf33822804/jobs/01a087b8-d0ba-70c9-b24b-508982070d1c?runAttempt=1) to fail before provider invocation.

`tool.with` now lets each interpolation root use its natural fill target. Early values are frozen during materialization while late jobs.* and steps.* leaves remain deferred. Final input schema validation and server-owned method injection still happen at step dispatch.

Regression coverage includes the documented GitHub check-run shape, mixed nested and scalar input resolution, JSON-safe CEL integers, missing event path errors, final validation, and the no-invocation failure boundary.

Rollout requires the affected workflow definition to be resynced after this fix is released and deployed, followed by a fresh event. Existing definitions and run attempts retain their persisted interpolation plans and source snapshots.

Validation covered check, type, and test tasks for @shipfox/expression and @shipfox/api-workflows, plus the prose policy and Changeset status.