### PR TITLE
Expose restarting gate key in workflow expressions

### DIFF
--- a/.changeset/bright-restart-keys.md
+++ b/.changeset/bright-restart-keys.md
@@ -1,0 +1,6 @@
+---
+"@shipfox/api-workflows": minor
+"@shipfox/expression": minor
+---
+
+Expose the authored restarting gate key on `step.restart.from` for dispatch-time workflow expressions.

--- a/libs/api/definitions/src/core/workflow-model/validate-predicate-expression.test.ts
+++ b/libs/api/definitions/src/core/workflow-model/validate-predicate-expression.test.ts
@@ -157,6 +157,10 @@ describe('validatePredicateExpression', () => {
     ['listener.on', 'trigger.event == "pull_request"'],
     ['listener.until', 'job.key == "await-review"'],
     ['job.if', 'needs.exists(n, n.status == "succeeded")'],
+    [
+      'step.if',
+      'has(step.restart) && has(step.restart.from.key) && step.restart.from.key == "verify"',
+    ],
     ['step.if', 'execution.status == "running"'],
   ] as const)('accepts the runtime context contract for %s', (field, source) => {
     const result = validate({field, source});
@@ -281,6 +285,7 @@ describe('validatePredicateExpression', () => {
 
   it.each([
     ['step.if', 'step.exit_code == 0'],
+    ['step.success', 'step.restart.from.key == "verify"'],
     ['step.success', 'step.attempt > 1'],
     ['job.success', 'executions.exists(e, e.failed)'],
   ] as const)('rejects %s properties absent from its runtime shape: %s', (field, source) => {

--- a/libs/api/workflows/src/core/job-execution.test.ts
+++ b/libs/api/workflows/src/core/job-execution.test.ts
@@ -2207,6 +2207,7 @@ describe('durable gate restart', () => {
     await db()
       .update(stepsTable)
       .set({
+        key: 'reviewer',
         config: {
           run: 'review',
           ...(params.outputs === undefined ? {} : {outputs: params.outputs}),
@@ -2338,7 +2339,7 @@ describe('durable gate restart', () => {
     });
   });
 
-  test('a retried step materializes restart feedback and source attempt output', async () => {
+  test('a retried step materializes restart feedback, source key, and source attempt output', async () => {
     const {jobId, producer, reviewer} = await arrangeGatedJob({
       source: 'step.exit_code == 0',
       feedback: 'failed',
@@ -2350,7 +2351,7 @@ describe('durable gate restart', () => {
         configPlan: {
           run: plannedField(
             'run',
-            `fix \${{ step.is_retry ? step.restart.feedback : 'fresh' }} from \${{ step.is_retry ? step.restart.from.outputs.summary : 'none' }}`,
+            `fix \${{ step.is_retry ? step.restart.feedback : 'fresh' }} from \${{ step.is_retry ? step.restart.from.outputs.summary : 'none' }} (\${{ has(step.restart) && has(step.restart.from.key) ? step.restart.from.key : 'none' }})`,
           ),
         },
       })
@@ -2373,10 +2374,11 @@ describe('durable gate restart', () => {
       step: expect.objectContaining({
         id: producer,
         config: {
-          run: `fix "\${__sf_2}" from "\${__sf_3}"`,
+          run: `fix "\${__sf_3}" from "\${__sf_4}" ("\${__sf_5}")`,
           env: expect.objectContaining({
-            __sf_2: 'failed: unit failed',
-            __sf_3: 'unit failed',
+            __sf_3: 'failed: unit failed',
+            __sf_4: 'unit failed',
+            __sf_5: 'reviewer',
           }),
         },
       }),
@@ -2385,6 +2387,99 @@ describe('durable gate restart', () => {
     const attempts = await getStepAttempts(jobId);
     const reviewerAttempt = attempts.find((attempt) => attempt.stepId === reviewer);
     expect(reviewerAttempt?.restartFeedback).toBe('failed: unit failed');
+  });
+
+  test('pairs the authored source key with verification and independent push recoveries', async () => {
+    const {jobId, steps} = await arrangeJobWithSteps(3);
+    const producer = steps[0];
+    const verification = steps[1];
+    const push = steps[2];
+    if (producer === undefined || verification === undefined || push === undefined) {
+      throw new Error('Expected three gated steps');
+    }
+
+    await db()
+      .update(stepsTable)
+      .set({
+        key: 'producer',
+        configPlan: {
+          run: plannedField(
+            'run',
+            `retry \${{ has(step.restart) && has(step.restart.from.key) ? step.restart.from.key : 'none' }} / \${{ step.is_retry ? step.restart.feedback : 'fresh' }} / \${{ step.is_retry ? step.restart.from.outputs.summary : 'none' }}`,
+          ),
+        },
+      })
+      .where(eq(stepsTable.id, producer.id));
+    await db()
+      .update(stepsTable)
+      .set({
+        key: 'verification',
+        config: {
+          run: 'verify',
+          gate: {
+            success: {language: 'cel', check: 'syntax', source: 'step.exit_code == 0'},
+            on_failure: {restart_from: 'producer', feedback: 'verification feedback'},
+          },
+        },
+      })
+      .where(eq(stepsTable.id, verification.id));
+    await db()
+      .update(stepsTable)
+      .set({
+        key: 'push',
+        config: {
+          run: 'push',
+          gate: {
+            success: {language: 'cel', check: 'syntax', source: 'step.exit_code == 0'},
+            on_failure: {restart_from: 'producer', feedback: 'push feedback'},
+          },
+        },
+      })
+      .where(eq(stepsTable.id, push.id));
+
+    await runStep(jobId, producer.id, 0);
+    await nextStepForJob(jobId);
+    await recordStepResult({
+      jobId,
+      stepId: verification.id,
+      status: 'failed',
+      output: {summary: 'verification output'},
+      exitCode: 1,
+    });
+    const verificationRetry = await nextStepForJob(jobId);
+    if (verificationRetry.kind !== 'step') throw new Error('Expected verification retry step');
+    expect(verificationRetry.dispatched).toBe(true);
+    expect(verificationRetry.step.id).toBe(producer.id);
+    expect(verificationRetry.step.config.run).toBe(
+      `retry "\${__sf_3}" / "\${__sf_4}" / "\${__sf_5}"`,
+    );
+    expect(verificationRetry.step.config.env).toMatchObject({
+      __sf_3: 'verification',
+      __sf_4: 'verification feedback',
+      __sf_5: 'verification output',
+    });
+
+    await recordStepResult({jobId, stepId: producer.id, status: 'succeeded', exitCode: 0});
+    await nextStepForJob(jobId);
+    await recordStepResult({jobId, stepId: verification.id, status: 'succeeded', exitCode: 0});
+    await nextStepForJob(jobId);
+    await recordStepResult({
+      jobId,
+      stepId: push.id,
+      status: 'failed',
+      output: {summary: 'push output'},
+      exitCode: 1,
+    });
+    const pushRetry = await nextStepForJob(jobId);
+    if (pushRetry.kind !== 'step') throw new Error('Expected push retry step');
+    expect(pushRetry.dispatched).toBe(true);
+    expect(pushRetry.step.id).toBe(producer.id);
+    expect(pushRetry.step.config.run).toBe(`retry "\${__sf_6}" / "\${__sf_7}" / "\${__sf_8}"`);
+    expect(pushRetry.step.config.env).toMatchObject({
+      __sf_6: 'push',
+      __sf_7: 'push feedback',
+      __sf_8: 'push output',
+    });
   });
 
   test('a passing rerun after a restart completes the job', async () => {

--- a/libs/api/workflows/src/core/step-config/assemble-run-context.test.ts
+++ b/libs/api/workflows/src/core/step-config/assemble-run-context.test.ts
@@ -2170,6 +2170,22 @@ describe('assembleStepDispatchContext', () => {
     });
   });
 
+  it('short-circuits a guarded restart source-key predicate on the first dispatch', () => {
+    const targetStep = step({id: 'step-1', key: 'producer'});
+    const context = assembleStepDispatchContext({
+      steps: [targetStep],
+      attempts: [],
+      targetStepId: targetStep.id,
+    });
+    const expression = createWorkflowExpression({
+      source:
+        'has(step.restart) && has(step.restart.from.key) && step.restart.from.key == "reviewer"',
+      check: {mode: 'syntax'},
+    });
+
+    expect(evaluateWorkflowExpression(expression, context.values)).toBe(false);
+  });
+
   it('assembles restart provenance from the latest restart covering the target step', () => {
     const targetStep = step({
       id: 'step-1',
@@ -2218,6 +2234,7 @@ describe('assembleStepDispatchContext', () => {
       is_retry: true,
       restart: {
         from: {
+          key: 'reviewer',
           status: 'failed',
           exit_code: 1n,
           outputs: {summary: 'tests failed'},
@@ -2234,6 +2251,104 @@ describe('assembleStepDispatchContext', () => {
         feedback: 'failed: tests failed',
       },
     });
+  });
+
+  it('keeps the selected failure identity paired across gates sharing a restart target', () => {
+    const targetStep = step({
+      id: 'step-1',
+      key: 'producer',
+      status: 'pending',
+      currentAttempt: 2,
+      position: 1,
+    });
+    const verifyStep = step({id: 'step-2', key: 'verify', position: 2});
+    const pushStep = step({id: 'step-3', key: 'push', position: 3});
+    const context = assembleStepDispatchContext({
+      steps: [targetStep, verifyStep, pushStep],
+      attempts: [
+        attempt({
+          id: 'verify-attempt',
+          stepId: verifyStep.id,
+          executionOrder: 1,
+          status: 'failed',
+          output: {summary: 'verification failed'},
+          exitCode: 1,
+          gateResult: {passed: false, source: 'verify', exit_code: 1},
+          config: {gate: {on_failure: {restart_from: 'producer'}}},
+          restartFeedback: 'verify feedback',
+        }),
+        attempt({
+          id: 'push-attempt',
+          stepId: pushStep.id,
+          executionOrder: 2,
+          status: 'failed',
+          output: {summary: 'push failed'},
+          exitCode: 1,
+          gateResult: {passed: false, source: 'push', exit_code: 1},
+          config: {gate: {on_failure: {restart_from: 'producer'}}},
+          restartFeedback: 'push feedback',
+        }),
+      ],
+      targetStepId: targetStep.id,
+    });
+
+    expect(context.values.step).toMatchObject({
+      restart: {
+        from: {
+          key: 'push',
+          outputs: {summary: 'push failed'},
+          gate: {source: 'push'},
+        },
+        feedback: 'push feedback',
+      },
+    });
+  });
+
+  it('omits the key for an unkeyed newest source without inheriting an older key', () => {
+    const targetStep = step({
+      id: 'step-1',
+      key: 'producer',
+      status: 'pending',
+      currentAttempt: 2,
+      position: 1,
+    });
+    const verifyStep = step({id: 'step-2', key: 'verify', position: 2});
+    const unkeyedStep = step({id: 'step-3', key: null, position: 3});
+    const context = assembleStepDispatchContext({
+      steps: [targetStep, verifyStep, unkeyedStep],
+      attempts: [
+        attempt({
+          id: 'verify-attempt',
+          stepId: verifyStep.id,
+          executionOrder: 1,
+          status: 'failed',
+          output: {summary: 'verification failed'},
+          exitCode: 1,
+          config: {gate: {on_failure: {restart_from: 'producer'}}},
+          restartFeedback: 'verify feedback',
+        }),
+        attempt({
+          id: 'unkeyed-attempt',
+          stepId: unkeyedStep.id,
+          executionOrder: 2,
+          status: 'failed',
+          output: {summary: 'unkeyed failed'},
+          exitCode: 1,
+          config: {gate: {on_failure: {restart_from: 'producer'}}},
+          restartFeedback: 'unkeyed feedback',
+        }),
+      ],
+      targetStepId: targetStep.id,
+    });
+
+    const restart = (context.values.step as Record<string, unknown>).restart as Record<
+      string,
+      unknown
+    >;
+    const from = restart.from as Record<string, unknown>;
+    expect(from).not.toHaveProperty('key');
+    expect(from).toMatchObject({outputs: {summary: 'unkeyed failed'}});
+    expect(restart.feedback).toBe('unkeyed feedback');
   });
 
   it('omits response for run steps so response resolves as a missing path', () => {

--- a/libs/api/workflows/src/core/step-config/assemble-run-context.test.ts
+++ b/libs/api/workflows/src/core/step-config/assemble-run-context.test.ts
@@ -2348,6 +2348,14 @@ describe('assembleStepDispatchContext', () => {
     const from = restart.from as Record<string, unknown>;
     expect(from).not.toHaveProperty('key');
     expect(from).toMatchObject({outputs: {summary: 'unkeyed failed'}});
+
+    const expression = createWorkflowExpression({
+      source:
+        'has(step.restart) && has(step.restart.from.key) && step.restart.from.key == "reviewer"',
+      check: {mode: 'syntax'},
+    });
+    expect(evaluateWorkflowExpression(expression, context.values)).toBe(false);
+
     expect(restart.feedback).toBe('unkeyed feedback');
   });
 

--- a/libs/api/workflows/src/core/step-config/assemble-run-context.ts
+++ b/libs/api/workflows/src/core/step-config/assemble-run-context.ts
@@ -933,9 +933,11 @@ function buildStepAttemptContext(params: {
   readonly stepsContext: Record<string, Record<string, unknown>>;
   readonly stepsFailed: boolean;
   readonly orderedAttempts: readonly StepAttempt[];
+  readonly stepsById: ReadonlyMap<string, Step>;
   readonly stepsByKey: ReadonlyMap<string, Step>;
   readonly terminalAttemptsByStepId: ReadonlyMap<string, readonly StepAttempt[]>;
 } {
+  const stepsById = new Map(params.steps.map((step) => [step.id, step] as const));
   const stepsByKey = new Map(
     params.steps.flatMap((step) => (step.key === null ? [] : [[step.key, step] as const])),
   );
@@ -968,6 +970,7 @@ function buildStepAttemptContext(params: {
     stepsContext,
     stepsFailed: params.steps.some((step) => step.status === 'failed'),
     orderedAttempts,
+    stepsById,
     stepsByKey,
     terminalAttemptsByStepId,
   };
@@ -989,6 +992,7 @@ export function assembleStepDispatchContext(params: {
       : restartProvenance({
           targetStep,
           orderedAttempts: stepAttemptContext.orderedAttempts,
+          stepsById: stepAttemptContext.stepsById,
           stepsByKey: stepAttemptContext.stepsByKey,
           terminalAttemptsByStepId: stepAttemptContext.terminalAttemptsByStepId,
         });
@@ -1023,6 +1027,7 @@ export function assembleStepDispatchContext(params: {
 function restartProvenance(params: {
   readonly targetStep: Step;
   readonly orderedAttempts: readonly StepAttempt[];
+  readonly stepsById: ReadonlyMap<string, Step>;
   readonly stepsByKey: ReadonlyMap<string, Step>;
   readonly terminalAttemptsByStepId: ReadonlyMap<string, readonly StepAttempt[]>;
 }): Record<string, unknown> | undefined {
@@ -1036,9 +1041,11 @@ function restartProvenance(params: {
       continue;
     }
 
+    const sourceStepKey = params.stepsById.get(attempt.stepId)?.key;
     const gatingAttempts = params.terminalAttemptsByStepId.get(attempt.stepId) ?? [];
     return {
       from: {
+        ...(sourceStepKey === null || sourceStepKey === undefined ? {} : {key: sourceStepKey}),
         ...attemptFields(attempt),
         attempts: gatingAttempts.map(attemptFields),
       },

--- a/libs/shared/expression/src/workflow-context/workflow-context-docs.ts
+++ b/libs/shared/expression/src/workflow-context/workflow-context-docs.ts
@@ -179,7 +179,7 @@ export const workflowContextDocs = [
       is_retry: 'Whether this is a repeat attempt. Not readable in `gate.success`.',
       restart: 'Set when a gate restarted this step. Not readable in `gate.success`.',
       'restart.from':
-        'The step whose gate restarted this attempt, with the properties of a `steps` entry. Not readable in `gate.success`.',
+        'The failed gate step that restarted this attempt, with the properties of a `steps` entry and its optional authored `key`. The key names the failing gate, not the restart target. Not readable in `gate.success`.',
       'restart.feedback': 'Feedback the restarting gate produced. Not readable in `gate.success`.',
       exit_code: 'Exit code the step reported. Readable in `gate.success` only.',
       status: 'Status the step reported. Readable in `gate.success` only.',

--- a/libs/shared/expression/src/workflow-context/workflow-context.test.ts
+++ b/libs/shared/expression/src/workflow-context/workflow-context.test.ts
@@ -1002,7 +1002,7 @@ describe('workflow context registry', () => {
   it('type-checks step restart provenance expressions', () => {
     const restartExpression = createWorkflowExpression({
       source:
-        'step.restart.feedback != "" && step.restart.from.outputs.summary != "" && step.restart.from.gate.passed == false',
+        'has(step.restart) && has(step.restart.from.key) && step.restart.from.key == "reviewer" && step.restart.feedback != "" && step.restart.from.outputs.summary != "" && step.restart.from.gate.passed == false',
       check: {
         mode: 'typed',
         typeEnvironment: workflowContextDefinitions.step.typeEnvironment,

--- a/libs/shared/expression/src/workflow-context/workflow-context.ts
+++ b/libs/shared/expression/src/workflow-context/workflow-context.ts
@@ -260,6 +260,14 @@ const stepEntityType = {
   },
 } as const;
 
+const stepRestartFromType = {
+  kind: 'object',
+  fields: {
+    key: 'string',
+    ...stepEntityType.fields,
+  },
+} as const;
+
 const stepDispatchTypeEnvironment = {
   step: {
     kind: 'object',
@@ -269,7 +277,7 @@ const stepDispatchTypeEnvironment = {
       restart: {
         kind: 'object',
         fields: {
-          from: stepEntityType,
+          from: stepRestartFromType,
           feedback: 'string',
         },
       },


### PR DESCRIPTION
## Summary

Expose the authored source key of the failed gate as `step.restart.from.key` in dispatch-time workflow expressions. Resolve it from the same selected failure that supplies restart feedback and results, preserving verification/push retry routing and unkeyed behavior. Report-time gate expressions cannot access this dispatch-only field.

Add expression type/docs and Definitions validation coverage, plus end-to-end recovery coverage for verification followed by independent push recovery.

## Validation

- `mise exec -- turbo test --filter=@shipfox/api-workflows` — 85 files, 1,327 tests
- `mise exec -- turbo type --filter=@shipfox/api-workflows... --filter=@shipfox/api-definitions... --filter=@shipfox/expression...`
- `mise exec -- turbo check --filter=@shipfox/api-workflows... --filter=@shipfox/api-definitions... --filter=@shipfox/expression...`
- `mise exec -- turbo build --filter=@shipfox/api-workflows... --filter=@shipfox/api-definitions... --filter=@shipfox/expression...`
- `mise exec -- pnpm --dir apps/docs exec tsx --conditions=workspace-source scripts/check-contexts.mjs`
- `mise exec -- git diff --check`

Closes ENG-2068

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exposes the authored key of the failing gate as `step.restart.from.key` in dispatch-time workflow expressions, so retries can route by which gate triggered the restart. Closes ENG-2068.

- Resolves the key from the same selected failure that supplies `step.restart.feedback` and `step.restart.from` outputs, preserving verification/push retry routing.
- Omits the key when the failing gate has no authored key, without inheriting an older keyed gate's key.
- Report-time gate expressions cannot access this dispatch-only field.
- Adds expression type/docs updates, Definitions validation coverage, and end-to-end recovery tests for verification followed by independent push recovery.

<sup>Written for commit 3eaf04117381e061f6d017f6e2bb60d5c341c1fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1763?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

