### PR TITLE
[Workflows] Show effective gate limits and attempt ordinals

### DIFF
--- a/.changeset/clear-gate-attempts.md
+++ b/.changeset/clear-gate-attempts.md
@@ -1,0 +1,7 @@
+---
+"@shipfox/api-workflows-dto": minor
+"@shipfox/api-workflows": minor
+"@shipfox/client-workflows": minor
+---
+
+Shows effective gate limits and chronological attempt numbers in workflow run details.

--- a/.changeset/clear-gate-attempts.md
+++ b/.changeset/clear-gate-attempts.md
@@ -4,4 +4,6 @@
 "@shipfox/client-workflows": minor
 ---
 
-Shows effective gate limits and chronological attempt numbers in workflow run details.
+Adds an optional `gate_max_attempts` field to the compact step summary, and
+shows effective gate restart limits and chronological gate attempt numbers in
+workflow run details.

--- a/libs/api/workflows-dto/src/schemas/workflow-job-detail.test.ts
+++ b/libs/api/workflows-dto/src/schemas/workflow-job-detail.test.ts
@@ -1,0 +1,34 @@
+import {stepSummaryDtoSchema} from './workflow-job-detail.js';
+
+const STEP_ID = '11111111-1111-4111-8111-111111111111';
+
+describe('stepSummaryDtoSchema', () => {
+  test('accepts an effective gate attempt limit', () => {
+    const result = stepSummaryDtoSchema.parse(stepSummary({gate_max_attempts: 5}));
+
+    expect(result.gate_max_attempts).toBe(5);
+  });
+
+  test('keeps the effective gate attempt limit optional', () => {
+    const result = stepSummaryDtoSchema.parse(stepSummary());
+
+    expect(result).not.toHaveProperty('gate_max_attempts');
+  });
+});
+
+function stepSummary(overrides: Record<string, unknown> = {}) {
+  return {
+    id: STEP_ID,
+    key: 'gate',
+    name: 'gate',
+    type: 'run',
+    position: 0,
+    status: 'failed',
+    status_reason: null,
+    source_location: null,
+    current_attempt: 7,
+    error: null,
+    attempts: {items: [], next_cursor: null, total: 0},
+    ...overrides,
+  };
+}

--- a/libs/api/workflows-dto/src/schemas/workflow-job-detail.ts
+++ b/libs/api/workflows-dto/src/schemas/workflow-job-detail.ts
@@ -75,6 +75,7 @@ export const stepSummaryDtoSchema = z.object({
   status_reason: stepStatusReasonSchema.nullable(),
   source_location: stepSourceLocationSchema.nullable(),
   current_attempt: z.number().int().positive(),
+  gate_max_attempts: z.number().int().positive().optional(),
   error: stepErrorDtoSchema,
   attempts: cursorPageSchema(stepAttemptSummaryDtoSchema),
 });

--- a/libs/api/workflows/src/db/workflow-runs/job-detail.ts
+++ b/libs/api/workflows/src/db/workflow-runs/job-detail.ts
@@ -27,6 +27,8 @@ import {
   type StepType,
   toStepStatusReason,
 } from '#core/entities/step.js';
+import {DEFAULT_RESTART_ATTEMPT_CAP} from '#core/step-transition/decide-step-transition.js';
+import {readStepGate} from '#core/step-transition/evaluate-gate.js';
 import {db, type Tx} from '../db.js';
 import {jobExecutions} from '../schema/job-executions.js';
 import {jobListenerEvents} from '../schema/job-listener-events.js';
@@ -112,6 +114,7 @@ export interface WorkflowStepSummaryRead {
   statusReason: StepStatusReason | null;
   sourceLocation: StepSourceLocation | null;
   currentAttempt: number;
+  gateMaxAttempts: number | undefined;
   error: Record<string, unknown> | null;
   attempts: {
     items: WorkflowStepAttemptSummaryRead[];
@@ -1017,6 +1020,7 @@ interface StepRow {
   statusReason: StepStatusReason | null;
   sourceLocation: StepSourceLocation | null;
   currentAttempt: number;
+  config: Record<string, unknown>;
   error: Record<string, unknown> | null;
 }
 
@@ -1215,6 +1219,7 @@ async function loadStepPage(
       statusReason: steps.statusReason,
       sourceLocation: steps.sourceLocation,
       currentAttempt: steps.currentAttempt,
+      config: steps.config,
       error: steps.error,
     })
     .from(steps)
@@ -1360,6 +1365,7 @@ function toStepSummary(
   row: StepRow,
   attempts: WorkflowStepSummaryRead['attempts'],
 ): WorkflowStepSummaryRead {
+  const gateOnFailure = readStepGate(row.config)?.onFailure;
   return {
     id: row.id,
     key: row.key,
@@ -1370,6 +1376,10 @@ function toStepSummary(
     statusReason: toStepStatusReason(row.statusReason),
     sourceLocation: row.sourceLocation,
     currentAttempt: row.currentAttempt,
+    gateMaxAttempts:
+      gateOnFailure === undefined
+        ? undefined
+        : (gateOnFailure.maxAttempts ?? DEFAULT_RESTART_ATTEMPT_CAP),
     error: (row.error as Record<string, unknown> | null) ?? null,
     attempts,
   };

--- a/libs/api/workflows/src/db/workflow-runs/job-detail.ts
+++ b/libs/api/workflows/src/db/workflow-runs/job-detail.ts
@@ -1219,7 +1219,9 @@ async function loadStepPage(
       statusReason: steps.statusReason,
       sourceLocation: steps.sourceLocation,
       currentAttempt: steps.currentAttempt,
-      config: steps.config,
+      config: sql<Record<string, unknown>>`jsonb_build_object(
+        'gate', ${steps.config} -> 'gate'
+      )`,
       error: steps.error,
     })
     .from(steps)
@@ -1377,7 +1379,7 @@ function toStepSummary(
     sourceLocation: row.sourceLocation,
     currentAttempt: row.currentAttempt,
     gateMaxAttempts:
-      gateOnFailure === undefined
+      row.type === 'tool' || gateOnFailure === undefined
         ? undefined
         : (gateOnFailure.maxAttempts ?? DEFAULT_RESTART_ATTEMPT_CAP),
     error: (row.error as Record<string, unknown> | null) ?? null,

--- a/libs/api/workflows/src/presentation/dto/workflow-job-detail.ts
+++ b/libs/api/workflows/src/presentation/dto/workflow-job-detail.ts
@@ -102,6 +102,7 @@ function toStepSummaryDto(step: WorkflowStepSummaryRead): StepSummaryDto {
         }
       : null,
     current_attempt: step.currentAttempt,
+    ...(step.gateMaxAttempts === undefined ? {} : {gate_max_attempts: step.gateMaxAttempts}),
     error: toStepErrorDto(step.error, step.type),
     attempts: toStepAttemptPageDto(step.attempts, step.type),
   };

--- a/libs/api/workflows/src/presentation/routes/workflow-job-detail.test.ts
+++ b/libs/api/workflows/src/presentation/routes/workflow-job-detail.test.ts
@@ -147,6 +147,29 @@ describe('selected workflow job routes', () => {
     expect(response.json().selected_execution.steps.items[0].gate_max_attempts).toBe(3);
   });
 
+  test('omits the gate attempt limit for tool steps that cannot restart', async () => {
+    const fixture = await createFixture();
+    await db()
+      .update(steps)
+      .set({
+        type: 'tool',
+        config: {
+          gate: {on_failure: {restart_from: 'implement', max_attempts: 5}},
+        },
+      })
+      .where(eq(steps.id, fixture.stepIds[0] as string));
+
+    const response = await app.inject({
+      method: 'GET',
+      url: `/api/workflows/runs/jobs/${fixture.jobIds[0]}`,
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json().selected_execution.steps.items[0]).not.toHaveProperty(
+      'gate_max_attempts',
+    );
+  });
+
   test('loads diagnostic context only from the selected execution', async () => {
     const fixture = await createFixture({jobs: 2, executionsPerJob: 2, stepsPerExecution: 1});
     const jobId = fixture.jobIds[0] as string;
@@ -416,6 +439,7 @@ describe('selected workflow job routes', () => {
 
     expect(detail.statusCode).toBe(200);
     expect(embeddedAttempts.items).toHaveLength(10);
+    expect(embeddedAttempts.total).toBe(12);
     expect(embeddedAttempts.items.map((item: {attempt: number}) => item.attempt)).toEqual([
       12, 11, 10, 9, 8, 7, 6, 5, 4, 3,
     ]);

--- a/libs/api/workflows/src/presentation/routes/workflow-job-detail.test.ts
+++ b/libs/api/workflows/src/presentation/routes/workflow-job-detail.test.ts
@@ -107,6 +107,7 @@ describe('selected workflow job routes', () => {
     expect(body.selected_execution.steps.items[0].attempts.total).toBe(2);
     expect(body.selected_execution).not.toHaveProperty('runner');
     expect(body.selected_execution.steps.items[0]).not.toHaveProperty('config');
+    expect(body.selected_execution.steps.items[0]).not.toHaveProperty('gate_max_attempts');
   });
 
   test('returns the configured gate attempt limit without exposing step config', async () => {

--- a/libs/api/workflows/src/presentation/routes/workflow-job-detail.test.ts
+++ b/libs/api/workflows/src/presentation/routes/workflow-job-detail.test.ts
@@ -109,6 +109,44 @@ describe('selected workflow job routes', () => {
     expect(body.selected_execution.steps.items[0]).not.toHaveProperty('config');
   });
 
+  test('returns the configured gate attempt limit without exposing step config', async () => {
+    const fixture = await createFixture();
+    await db()
+      .update(steps)
+      .set({
+        config: {
+          gate: {on_failure: {restart_from: 'implement', max_attempts: 5}},
+        },
+      })
+      .where(eq(steps.id, fixture.stepIds[0] as string));
+
+    const response = await app.inject({
+      method: 'GET',
+      url: `/api/workflows/runs/jobs/${fixture.jobIds[0]}`,
+    });
+
+    expect(response.statusCode).toBe(200);
+    const step = response.json().selected_execution.steps.items[0];
+    expect(step.gate_max_attempts).toBe(5);
+    expect(step).not.toHaveProperty('config');
+  });
+
+  test('returns the legacy gate attempt limit when materialized config omits it', async () => {
+    const fixture = await createFixture();
+    await db()
+      .update(steps)
+      .set({config: {gate: {on_failure: {restart_from: 'implement'}}}})
+      .where(eq(steps.id, fixture.stepIds[0] as string));
+
+    const response = await app.inject({
+      method: 'GET',
+      url: `/api/workflows/runs/jobs/${fixture.jobIds[0]}`,
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json().selected_execution.steps.items[0].gate_max_attempts).toBe(3);
+  });
+
   test('loads diagnostic context only from the selected execution', async () => {
     const fixture = await createFixture({jobs: 2, executionsPerJob: 2, stepsPerExecution: 1});
     const jobId = fixture.jobIds[0] as string;

--- a/libs/client/workflows/src/components/job-detail/job-detail-view.stories.tsx
+++ b/libs/client/workflows/src/components/job-detail/job-detail-view.stories.tsx
@@ -1466,6 +1466,7 @@ function storyStepDto(step: Step) {
     error: storyStepErrorDto(step),
     position: step.position,
     current_attempt: step.currentAttempt,
+    ...(step.gateMaxAttempts === undefined ? {} : {gate_max_attempts: step.gateMaxAttempts}),
     exit_code: null,
     outputs: null,
     response: null,

--- a/libs/client/workflows/src/components/job-detail/job-detail-view.tsx
+++ b/libs/client/workflows/src/components/job-detail/job-detail-view.tsx
@@ -625,11 +625,10 @@ function useSelectedJobDetailPresentation({
       ],
     ]);
   }, [attemptsResourceIsNewer, attemptsStep?.attempts.items, attemptsStepId, loadedAttempts]);
-  const presentedAttemptPageTotal = attemptsQuery.data?.pages.find(
-    (page) => page.total !== undefined,
-  )?.total;
-  const presentedAttemptTotal =
-    typeof presentedAttemptPageTotal === 'number' ? presentedAttemptPageTotal : undefined;
+  const presentedAttemptTotal = attemptsQuery.data?.pages.reduce<number | undefined>(
+    (total, page) => (typeof page.total === 'number' ? Math.max(total ?? 0, page.total) : total),
+    undefined,
+  );
   const presentedAttemptTotalsByStepId = useMemo(
     () =>
       attemptsStepId === undefined || presentedAttemptTotal === undefined

--- a/libs/client/workflows/src/components/job-detail/job-detail-view.tsx
+++ b/libs/client/workflows/src/components/job-detail/job-detail-view.tsx
@@ -231,14 +231,13 @@ export function JobDetailView({
     logIsFetching,
     showRetargetNotice,
     succeededSummary,
+    stepListModel,
   } = detailState;
   const stepLabels = new Map(
     (selectedJobExecution?.steps ?? []).map((step) => [step.id, step.name] as const),
   );
   const stepAttemptLabels = new Map(
-    (selectedJobExecution?.steps ?? []).flatMap((step) =>
-      step.attempts.map((attempt) => [attempt.id, String(attempt.attempt)] as const),
-    ),
+    stepListModel.entries.map((entry) => [entry.id, String(entry.attemptOrdinal)] as const),
   );
 
   function selectExecution(jobExecutionId: string) {
@@ -345,7 +344,7 @@ export function JobDetailView({
               <Panel data-job-log-panel className="min-w-0">
                 <JobLogPanelHeader
                   stepLabel={expandedLogSelection?.stepLabel}
-                  attempt={selectedLogAttempt?.attempt}
+                  attempt={expandedLogSelection?.attemptOrdinal}
                   status={selectedLogStatus}
                   search={logSearch}
                   onSearchChange={setLogSearch}
@@ -626,6 +625,18 @@ function useSelectedJobDetailPresentation({
       ],
     ]);
   }, [attemptsResourceIsNewer, attemptsStep?.attempts.items, attemptsStepId, loadedAttempts]);
+  const presentedAttemptPageTotal = attemptsQuery.data?.pages.find(
+    (page) => page.total !== undefined,
+  )?.total;
+  const presentedAttemptTotal =
+    typeof presentedAttemptPageTotal === 'number' ? presentedAttemptPageTotal : undefined;
+  const presentedAttemptTotalsByStepId = useMemo(
+    () =>
+      attemptsStepId === undefined || presentedAttemptTotal === undefined
+        ? undefined
+        : new Map([[attemptsStepId, presentedAttemptTotal]]),
+    [attemptsStepId, presentedAttemptTotal],
+  );
 
   useEffect(() => {
     if (
@@ -661,7 +672,11 @@ function useSelectedJobDetailPresentation({
   );
 
   const detailPresentation: WorkflowJobDetailPresentationOptions | undefined = selectedJobDetail
-    ? {steps: presentedSteps, attemptsByStepId: presentedAttemptsByStepId}
+    ? {
+        steps: presentedSteps,
+        attemptsByStepId: presentedAttemptsByStepId,
+        attemptTotalsByStepId: presentedAttemptTotalsByStepId,
+      }
     : undefined;
 
   return {
@@ -688,25 +703,40 @@ function StepAttemptHistoryControl({
   attemptsQuery: ReturnType<typeof useWorkflowStepAttemptsInfiniteQuery>;
   onRequest: (stepId: string) => void;
 }) {
+  const gateMaxAttempts = step.gateMaxAttempts;
   const hasMoreAttempts =
     attemptsStepId === step.id
       ? attemptsQuery.hasNextPage || attemptsQuery.isError
       : Boolean(stepSummary?.attempts.nextCursor);
-  if (!hasMoreAttempts) return null;
+  if (!hasMoreAttempts && gateMaxAttempts === undefined) return null;
 
   const isLoading = attemptsStepId === step.id && attemptsQuery.isFetchingNextPage;
   const hasError = attemptsStepId === step.id && attemptsQuery.isError;
   return (
-    <div className="flex justify-center border-t border-border-neutral-base py-row">
-      <Button
-        type="button"
-        size="sm"
-        variant="secondary"
-        isLoading={isLoading}
-        onClick={() => onRequest(step.id)}
-      >
-        {hasError ? 'Retry loading older attempts' : 'Load older attempts'}
-      </Button>
+    <div
+      className={
+        gateMaxAttempts === undefined
+          ? 'flex justify-center border-t border-border-neutral-base py-row'
+          : 'flex flex-wrap items-center justify-between gap-inline border-t border-border-neutral-base px-row py-row'
+      }
+    >
+      {gateMaxAttempts === undefined ? null : (
+        <Text size="xs" className="text-foreground-neutral-muted">
+          Up to {gateMaxAttempts} {gateMaxAttempts === 1 ? 'attempt' : 'attempts'}, including the
+          first execution.
+        </Text>
+      )}
+      {hasMoreAttempts ? (
+        <Button
+          type="button"
+          size="sm"
+          variant="secondary"
+          isLoading={isLoading}
+          onClick={() => onRequest(step.id)}
+        >
+          {hasError ? 'Retry loading older attempts' : 'Load older attempts'}
+        </Button>
+      ) : null}
     </div>
   );
 }
@@ -769,7 +799,7 @@ function ExpandedStep({
     <section
       role="region"
       tabIndex={0}
-      aria-label={`${context.stepLabel} output, attempt ${context.attempt}`}
+      aria-label={`${context.stepLabel} output, attempt ${context.attemptOrdinal}`}
       className="flex min-w-0 flex-col border-t border-border-neutral-base bg-background-contrast-base outline-none focus-visible:shadow-border-interactive-with-active"
     >
       <StepAttemptLogPanel
@@ -1011,7 +1041,14 @@ function findExpandedLogSelection(
     const match = findAttempt(jobExecution, attemptId);
     const attempt = match?.step.attempts.find((candidate) => candidate.id === attemptId);
     const entry = model.entries.find((candidate) => candidate.id === attemptId);
-    if (match && attempt && entry) return {step: match.step, attempt, stepLabel: entry.step.label};
+    if (match && attempt && entry) {
+      return {
+        step: match.step,
+        attempt,
+        stepLabel: entry.step.label,
+        attemptOrdinal: entry.attemptOrdinal,
+      };
+    }
   }
 
   return undefined;
@@ -1088,6 +1125,7 @@ function resolveJobDetailState({
     logIsFetching,
     showRetargetNotice,
     succeededSummary,
+    stepListModel,
   };
 }
 

--- a/libs/client/workflows/src/components/job-detail/step-troubleshooting.stories.tsx
+++ b/libs/client/workflows/src/components/job-detail/step-troubleshooting.stories.tsx
@@ -39,9 +39,37 @@ export const FailedStep: Story = {
   render: () => <FailedStepStory />,
 };
 
+export const GateAttemptLimitReached: Story = {
+  render: () => <GateAttemptLimitReachedStory />,
+};
+
 export const ToolStep: Story = {
   render: ({toolOutcome}) => <ToolStepStory outcome={toolOutcome} />,
 };
+
+function GateAttemptLimitReachedStory() {
+  const [queryClient] = useState(
+    () => new QueryClient({defaultOptions: {queries: {staleTime: Number.POSITIVE_INFINITY}}}),
+  );
+  const entry = gateAttemptLimitEntry();
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      <main className="min-h-screen bg-background-neutral-base p-16">
+        <StepInspectorSheet
+          entry={entry}
+          open
+          onOpenChange={() => undefined}
+          workspaceSlug="acme"
+          projectSlug="platform"
+          workflowRunId="11111111-1111-4111-8111-111111111111"
+          runAttempt={1}
+          jobId="44444444-4444-4444-8444-000000000003"
+        />
+      </main>
+    </QueryClientProvider>
+  );
+}
 
 function ToolStepStory({outcome}: {outcome: ToolStepOutcome}) {
   const entry = toolStepEntry(outcome);
@@ -166,6 +194,64 @@ function failedStepEntry(): StepListEntryModel {
 
   const entry = buildStepListModel({job, jobExecution: execution}).entries[0];
   if (!entry) throw new Error('Story fixture is missing a step attempt.');
+
+  return entry;
+}
+
+function gateAttemptLimitEntry(): StepListEntryModel {
+  const jobId = '44444444-4444-4444-8444-000000000003';
+  const executionId = '77777777-7777-4777-8777-000000000003';
+  const stepId = '55555555-5555-4555-8555-000000000003';
+  const attempts = [2, 4, 7, 9, 12].map((attempt, index) =>
+    workflowStepAttemptDto({
+      id: `66666666-6666-4666-8666-${String(index + 3).padStart(12, '0')}`,
+      step_id: stepId,
+      attempt,
+      execution_order: index + 1,
+      status: 'failed',
+      exit_code: 1,
+      gate_result: {kind: 'failed', passed: false, source: 'step.exit_code == 0', exit_code: 1},
+      finished_at: `2026-09-10T09:0${index}:30.000Z`,
+    }),
+  );
+  const error = {
+    message: 'The gate did not pass after 5 attempts.',
+    reason: 'restart_exhausted' as const,
+    attempt_count: 5,
+    max_attempts: 5,
+    restart_from: 'implement',
+  };
+  const job = workflowJob({
+    id: jobId,
+    name: 'implementation',
+    key: 'implementation',
+    status: 'failed',
+    job_executions: [
+      workflowJobExecutionDto({
+        id: executionId,
+        job_id: jobId,
+        status: 'failed',
+        steps: [
+          workflowStepDto({
+            id: stepId,
+            job_execution_id: executionId,
+            name: 'Verify implementation',
+            key: 'verify',
+            status: 'failed',
+            status_reason: 'restart_exhausted',
+            gate_max_attempts: 5,
+            error,
+            attempts,
+          }),
+        ],
+      }),
+    ],
+  });
+  const execution = job.jobExecutions[0];
+  if (!execution) throw new Error('Story fixture is missing a job execution.');
+
+  const entry = buildStepListModel({job, jobExecution: execution}).entries.at(-1);
+  if (!entry) throw new Error('Story fixture is missing a gate attempt.');
 
   return entry;
 }

--- a/libs/client/workflows/src/components/job-detail/step-troubleshooting.test.tsx
+++ b/libs/client/workflows/src/components/job-detail/step-troubleshooting.test.tsx
@@ -621,7 +621,7 @@ describe('StepInspectorSheet', () => {
     expect(await screen.findByText('Gate attempt limit reached')).toBeInTheDocument();
     expect(
       screen.getByText(
-        'The step failed after 3 attempts and reached the configured limit of 3 attempts, including the first execution. Review the failed result. To allow more attempts, update gate.on_failure.max_attempts and start a new run.',
+        'The step failed after 3 attempts and reached the gate attempt limit of 3 attempts, including the first execution. Review the failed result. To allow more attempts, set gate.on_failure.max_attempts to a higher value and start a new run.',
       ),
     ).toBeInTheDocument();
   });
@@ -643,7 +643,7 @@ describe('StepInspectorSheet', () => {
     expect(await screen.findByText('Gate attempt limit reached')).toBeInTheDocument();
     expect(
       screen.getByText(
-        'The success condition did not pass after 5 attempts and reached the configured limit of 5 attempts, including the first execution. Review the failed result and gate.success condition. To allow more attempts, update gate.on_failure.max_attempts and start a new run.',
+        'The success condition did not pass after 5 attempts and reached the gate attempt limit of 5 attempts, including the first execution. Review the failed result and gate.success condition. To allow more attempts, set gate.on_failure.max_attempts to a higher value and start a new run.',
       ),
     ).toBeInTheDocument();
   });
@@ -663,7 +663,7 @@ describe('StepInspectorSheet', () => {
 
     expect(
       await screen.findByText(
-        'The success condition did not pass after 5 attempts and reached the configured limit of 5 attempts, including the first execution. Review the failed result and gate.success condition. To allow more attempts, update gate.on_failure.max_attempts and start a new run.',
+        'The success condition did not pass after 5 attempts and reached the gate attempt limit of 5 attempts, including the first execution. Review the failed result and gate.success condition. To allow more attempts, set gate.on_failure.max_attempts to a higher value and start a new run.',
       ),
     ).toBeInTheDocument();
   });

--- a/libs/client/workflows/src/components/job-detail/step-troubleshooting.test.tsx
+++ b/libs/client/workflows/src/components/job-detail/step-troubleshooting.test.tsx
@@ -618,10 +618,32 @@ describe('StepInspectorSheet', () => {
     });
     await user.click(screen.getByRole('button', {name: INSPECTOR_TRIGGER_NAME}));
 
-    expect(await screen.findByText('Attempt limit reached')).toBeInTheDocument();
+    expect(await screen.findByText('Gate attempt limit reached')).toBeInTheDocument();
     expect(
       screen.getByText(
-        'The step failed after 3 attempts. The restart attempt cap is fixed. Fix the failed result before starting a new run.',
+        'The step failed after 3 attempts and reached the configured limit of 3 attempts, including the first execution. Review the failed result. To allow more attempts, update gate.on_failure.max_attempts and start a new run.',
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('explains success-gate exhaustion with the structured count and limit', async () => {
+    const user = userEvent.setup();
+    configureApiClient({fetchImpl: vi.fn(() => new Promise<Response>(() => undefined))});
+
+    await renderPanel({
+      entry: stepEntry('restart_exhausted', undefined, {
+        message: 'The gate did not pass after 5 attempts.',
+        attempt_count: 5,
+        max_attempts: 5,
+        restart_from: 'producer',
+      }),
+    });
+    await user.click(screen.getByRole('button', {name: INSPECTOR_TRIGGER_NAME}));
+
+    expect(await screen.findByText('Gate attempt limit reached')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'The success condition did not pass after 5 attempts and reached the configured limit of 5 attempts, including the first execution. Review the failed result and gate.success condition. To allow more attempts, update gate.on_failure.max_attempts and start a new run.',
       ),
     ).toBeInTheDocument();
   });

--- a/libs/client/workflows/src/components/job-detail/step-troubleshooting.test.tsx
+++ b/libs/client/workflows/src/components/job-detail/step-troubleshooting.test.tsx
@@ -648,6 +648,41 @@ describe('StepInspectorSheet', () => {
     ).toBeInTheDocument();
   });
 
+  it('uses the effective gate limit for a legacy exhaustion error', async () => {
+    const user = userEvent.setup();
+    configureApiClient({fetchImpl: vi.fn(() => new Promise<Response>(() => undefined))});
+    const entry = stepEntry('restart_exhausted', undefined, {
+      message: 'The gate did not pass after 5 attempts.',
+      attempt_count: 5,
+      restart_from: 'producer',
+    });
+    entry.step.gateMaxAttempts = 5;
+
+    await renderPanel({entry});
+    await user.click(screen.getByRole('button', {name: INSPECTOR_TRIGGER_NAME}));
+
+    expect(
+      await screen.findByText(
+        'The success condition did not pass after 5 attempts and reached the configured limit of 5 attempts, including the first execution. Review the failed result and gate.success condition. To allow more attempts, update gate.on_failure.max_attempts and start a new run.',
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('keeps useful fallback copy for an unknown future reason', async () => {
+    const user = userEvent.setup();
+    configureApiClient({fetchImpl: vi.fn(() => new Promise<Response>(() => undefined))});
+
+    await renderPanel({entry: stepEntry('future_failure' as StepErrorReason)});
+    await user.click(screen.getByRole('button', {name: INSPECTOR_TRIGGER_NAME}));
+
+    expect(await screen.findByText('Step failed')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Future Failure. Review the details below and re-run after resolving the cause.',
+      ),
+    ).toBeInTheDocument();
+  });
+
   it('keeps non-tool failure chips keyed to their stable reason', async () => {
     const user = userEvent.setup();
     configureApiClient({fetchImpl: vi.fn(() => new Promise<Response>(() => undefined))});

--- a/libs/client/workflows/src/components/job-detail/step-troubleshooting.tsx
+++ b/libs/client/workflows/src/components/job-detail/step-troubleshooting.tsx
@@ -83,7 +83,7 @@ export function StepInspectorSheet({
           <SheetTitle>{entry.step.label}</SheetTitle>
           <div className="flex min-w-0 flex-wrap items-center gap-inline">
             <SheetDescription>
-              Attempt #{entry.attempt} · {humanizeStatus(entry.statusVisual.kind)}
+              Attempt #{entry.attemptOrdinal} · {humanizeStatus(entry.statusVisual.kind)}
             </SheetDescription>
             {entry.step.toolConfig?.sensitivity === 'write' ? (
               <Badge variant="warning" size="2xs" radius="rounded">
@@ -135,7 +135,8 @@ function StepFailureCallout({
   const reason = error?.reason ?? step.statusReason ?? 'unknown';
   const toolGuidance = toolFailureGuidance(reason, step, attempt, error);
   const title = toolGuidance?.title ?? failureTitle(reason);
-  const description = toolGuidance?.description ?? failureDescription(reason, step, error);
+  const description =
+    toolGuidance?.description ?? failureDescription(reason, step, error, step.gateMaxAttempts);
   const failureCode = step.type === 'tool' ? (error?.code ?? reason) : reason;
   const sourceLink = sourceLinkForFailure(reason) && step.sourceLocation;
 
@@ -919,7 +920,7 @@ function failureTitle(reason: string | JobStatusReason): string {
     case 'restart_unresolved':
       return 'Gate restart target could not be resolved';
     case 'restart_exhausted':
-      return 'Attempt limit reached';
+      return 'Gate attempt limit reached';
     case 'runner_lost':
       return 'Runner stopped responding';
     case 'output_too_large':
@@ -949,24 +950,35 @@ function failureTitle(reason: string | JobStatusReason): string {
   }
 }
 
-function restartExhaustionDescription(error: StepError | null): string {
+function restartExhaustionDescription(
+  error: StepError | null,
+  effectiveMaxAttempts: number | undefined,
+): string {
   const attemptCount = error?.attemptCount;
+  const maxAttempts = error?.maxAttempts ?? effectiveMaxAttempts;
   const hasNoSuccessGateDiagnostic = error?.message.startsWith('The step failed after ') ?? false;
-  if (attemptCount !== undefined) {
-    const attemptLabel = attemptCount === 1 ? 'attempt' : 'attempts';
-    return hasNoSuccessGateDiagnostic
-      ? `The step failed after ${attemptCount} ${attemptLabel}. The restart attempt cap is fixed. Fix the failed result before starting a new run.`
-      : `The success condition did not pass after ${attemptCount} ${attemptLabel}. The restart attempt cap is fixed. Fix the failed result or gate.success condition before starting a new run.`;
-  }
-  return hasNoSuccessGateDiagnostic
-    ? 'The restart attempt cap is fixed. Fix the failed result before starting a new run.'
-    : 'The restart attempt cap is fixed. Fix the failed result or gate.success condition before starting a new run.';
+  const subject = hasNoSuccessGateDiagnostic
+    ? 'The step failed'
+    : 'The success condition did not pass';
+  const countCopy =
+    attemptCount === undefined
+      ? subject
+      : `${subject} after ${attemptCount} ${attemptCount === 1 ? 'attempt' : 'attempts'}`;
+  const limitCopy =
+    maxAttempts === undefined
+      ? 'and reached the gate attempt limit.'
+      : `and reached the configured limit of ${maxAttempts} ${maxAttempts === 1 ? 'attempt' : 'attempts'}, including the first execution.`;
+  const recovery = hasNoSuccessGateDiagnostic
+    ? 'Review the failed result.'
+    : 'Review the failed result and gate.success condition.';
+  return `${countCopy} ${limitCopy} ${recovery} To allow more attempts, update gate.on_failure.max_attempts and start a new run.`;
 }
 
 function failureDescription(
   reason: string | JobStatusReason,
   step: Step,
   error: StepError | null,
+  gateMaxAttempts?: number | undefined,
 ): string {
   switch (reason) {
     case 'checkout_auth_failed':
@@ -1014,7 +1026,7 @@ function failureDescription(
     case 'restart_unresolved':
       return 'Shipfox could not resolve the configured restart target. Review gate.on_failure.restart_from before trying again.';
     case 'restart_exhausted':
-      return restartExhaustionDescription(error);
+      return restartExhaustionDescription(error, gateMaxAttempts);
     case 'runner_lost':
       return 'The runner stopped responding before the step completed.';
     case 'output_too_large':

--- a/libs/client/workflows/src/components/job-detail/step-troubleshooting.tsx
+++ b/libs/client/workflows/src/components/job-detail/step-troubleshooting.tsx
@@ -967,11 +967,11 @@ function restartExhaustionDescription(
   const limitCopy =
     maxAttempts === undefined
       ? 'and reached the gate attempt limit.'
-      : `and reached the configured limit of ${maxAttempts} ${maxAttempts === 1 ? 'attempt' : 'attempts'}, including the first execution.`;
+      : `and reached the gate attempt limit of ${maxAttempts} ${maxAttempts === 1 ? 'attempt' : 'attempts'}, including the first execution.`;
   const recovery = hasNoSuccessGateDiagnostic
     ? 'Review the failed result.'
     : 'Review the failed result and gate.success condition.';
-  return `${countCopy} ${limitCopy} ${recovery} To allow more attempts, update gate.on_failure.max_attempts and start a new run.`;
+  return `${countCopy} ${limitCopy} ${recovery} To allow more attempts, set gate.on_failure.max_attempts to a higher value and start a new run.`;
 }
 
 function failureDescription(

--- a/libs/client/workflows/src/components/step-list/step-list-model.test.ts
+++ b/libs/client/workflows/src/components/step-list/step-list-model.test.ts
@@ -287,6 +287,26 @@ describe('buildStepListModel', () => {
     expect(result.entries.map((entry) => entry.attemptOrdinal)).toEqual([3, 4]);
   });
 
+  test('preserves stored attempt numbers for a non-gate step after rewinds', () => {
+    const job = makeJob({
+      steps: [
+        makeStep({
+          attempts: [
+            makeAttempt({attempt: 4, execution_order: 1}),
+            makeAttempt({attempt: 7, execution_order: 2}),
+          ],
+        }),
+      ],
+    });
+    const step = job.jobExecutions[0]?.steps[0];
+    if (!step) throw new Error('Expected a step fixture');
+    step.attemptTotal = undefined;
+
+    const result = buildStepListModel({job});
+
+    expect(result.entries.map((entry) => entry.attemptOrdinal)).toEqual([4, 7]);
+  });
+
   test('orders flattened attempts by backend execution order', () => {
     const step1 = makeStep({
       name: 'step-1',

--- a/libs/client/workflows/src/components/step-list/step-list-model.test.ts
+++ b/libs/client/workflows/src/components/step-list/step-list-model.test.ts
@@ -250,6 +250,43 @@ describe('buildStepListModel', () => {
     });
   });
 
+  test('numbers gate attempts by their displayed position instead of stored attempt', () => {
+    const step = makeStep({
+      gate_max_attempts: 5,
+      attempts: [
+        makeAttempt({attempt: 4, execution_order: 1}),
+        makeAttempt({attempt: 7, execution_order: 2}),
+      ],
+    });
+
+    const result = buildStepListModel({job: makeJob({steps: [step]})});
+
+    expect(result.entries.map((entry) => entry.attempt)).toEqual([4, 7]);
+    expect(result.entries.map((entry) => entry.attemptOrdinal)).toEqual([1, 2]);
+  });
+
+  test('uses the authoritative page total when numbering a partial gate attempt page', () => {
+    const job = makeJob({
+      steps: [
+        makeStep({
+          gate_max_attempts: 5,
+          attempts: [
+            makeAttempt({attempt: 9, execution_order: 3}),
+            makeAttempt({attempt: 12, execution_order: 4}),
+          ],
+        }),
+      ],
+    });
+    const step = job.jobExecutions[0]?.steps[0];
+    if (!step) throw new Error('Expected a step fixture');
+    step.attemptTotal = 4;
+
+    const result = buildStepListModel({job});
+
+    expect(result.entries.map((entry) => entry.attempt)).toEqual([9, 12]);
+    expect(result.entries.map((entry) => entry.attemptOrdinal)).toEqual([3, 4]);
+  });
+
   test('orders flattened attempts by backend execution order', () => {
     const step1 = makeStep({
       name: 'step-1',

--- a/libs/client/workflows/src/components/step-list/step-list-model.ts
+++ b/libs/client/workflows/src/components/step-list/step-list-model.ts
@@ -18,6 +18,7 @@ export interface StepStatusVisual extends Omit<WorkflowStatusVisual, 'kind'> {
 }
 
 export interface StepAttemptModel extends StepAttempt {
+  attemptOrdinal: number;
   displayDuration: StepAttemptDisplayDuration | null;
   statusVisual: StepStatusVisual;
   carriedOver: boolean;
@@ -117,8 +118,15 @@ export function humanizeStatus(status: string): string {
 }
 
 function toStepModel(step: Step, index: number): StepModel {
-  const attempts = [...step.attempts].sort(compareAttempts).map((attempt) => ({
+  const sortedAttempts = [...step.attempts].sort(compareAttempts);
+  const gateAttemptOffset =
+    step.gateMaxAttempts === undefined
+      ? undefined
+      : Math.max(0, (step.attemptTotal ?? sortedAttempts.length) - sortedAttempts.length);
+  const attempts = sortedAttempts.map((attempt, attemptIndex) => ({
     ...attempt,
+    attemptOrdinal:
+      gateAttemptOffset === undefined ? attempt.attempt : gateAttemptOffset + attemptIndex + 1,
     displayDuration: attempt.displayDuration,
     statusVisual: getStepStatusVisual(attempt.status),
     carriedOver: false,
@@ -158,6 +166,7 @@ function toStepEntries(step: StepModel, carriedOverJob: boolean): StepListEntryM
       stepId: step.id,
       jobExecutionId: step.jobExecutionId,
       attempt: step.currentAttempt,
+      attemptOrdinal: step.currentAttempt,
       executionOrder: step.position,
       status: step.status,
       exitCode: null,

--- a/libs/client/workflows/src/components/step-list/step-list.test.tsx
+++ b/libs/client/workflows/src/components/step-list/step-list.test.tsx
@@ -532,6 +532,32 @@ describe('StepList', () => {
     expect(screen.queryByText('Gate failed')).not.toBeInTheDocument();
   });
 
+  test('renders gate attempt ordinals without replacing stored attempt identifiers', () => {
+    render(
+      <StepList
+        job={makeJob({
+          steps: [
+            makeStep({
+              name: 'gate',
+              gate_max_attempts: 5,
+              attempts: [
+                makeAttempt({attempt: 4, execution_order: 1, status: 'failed'}),
+                makeAttempt({attempt: 7, execution_order: 2, status: 'failed'}),
+              ],
+            }),
+          ],
+        })}
+      />,
+    );
+
+    expect(screen.getByRole('button', {name: 'gate, Failed, attempt 1'})).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'gate, Failed, attempt 2'})).toBeInTheDocument();
+    expect(screen.getByText('#1')).toBeInTheDocument();
+    expect(screen.getByText('#2')).toBeInTheDocument();
+    expect(screen.queryByText('#4')).not.toBeInTheDocument();
+    expect(screen.queryByText('#7')).not.toBeInTheDocument();
+  });
+
   test('renders a step footer only after the final non-contiguous attempt', () => {
     const buildFirstAttempt = makeAttempt({
       id: 'build-attempt-first',

--- a/libs/client/workflows/src/components/step-list/step-list.tsx
+++ b/libs/client/workflows/src/components/step-list/step-list.tsx
@@ -41,6 +41,7 @@ export interface StepExpandedContext {
   stepLabel: string;
   sourceLocation: StepSourceLocation | null;
   attempt: number;
+  attemptOrdinal: number;
   attemptId: string;
   attemptStartedAt: string;
   attemptError: Record<string, unknown> | null;
@@ -297,6 +298,7 @@ function StepListContent({
                             stepLabel: entry.step.label,
                             sourceLocation: entry.step.sourceLocation,
                             attempt: entry.attempt,
+                            attemptOrdinal: entry.attemptOrdinal,
                             attemptId: entry.id,
                             attemptStartedAt: entry.startedAt,
                             attemptError: entry.error,
@@ -460,7 +462,7 @@ function StepRow({
             <TooltipTrigger asChild>
               <button
                 type="button"
-                aria-label={`Inspect ${entry.step.label}, attempt ${entry.attempt}`}
+                aria-label={`Inspect ${entry.step.label}, attempt ${entry.attemptOrdinal}`}
                 onClick={onInspect}
                 className="flex size-28 shrink-0 items-center justify-center rounded-4 bg-transparent text-foreground-neutral-muted outline-none transition-colors hover:bg-transparent hover:text-foreground-neutral-base active:bg-transparent focus-visible:shadow-button-neutral-focus"
               >
@@ -581,14 +583,14 @@ function StepAttemptChip({attempt}: {attempt: StepAttemptModel}) {
           attemptChipClasses[attempt.statusVisual.badge ?? 'neutral'],
         )}
       >
-        #{attempt.attempt}
+        #{attempt.attemptOrdinal}
       </span>
     </div>
   );
 }
 
 function entryAccessibleLabel(entry: StepListEntryModel): string {
-  const parts = [entry.step.label, entry.statusVisual.label, `attempt ${entry.attempt}`];
+  const parts = [entry.step.label, entry.statusVisual.label, `attempt ${entry.attemptOrdinal}`];
   if (entry.step.toolConfig?.provider) {
     const provider = entry.step.toolConfig.provider;
     parts.push(

--- a/libs/client/workflows/src/core/entities/step.ts
+++ b/libs/client/workflows/src/core/entities/step.ts
@@ -126,6 +126,8 @@ export interface Step {
   error: StepError | null;
   position: number;
   currentAttempt: number;
+  gateMaxAttempts?: number | undefined;
+  attemptTotal?: number | undefined;
   createdAt: string;
   updatedAt: string;
   attempts: StepAttempt[];

--- a/libs/client/workflows/src/core/entities/workflow-job-detail.ts
+++ b/libs/client/workflows/src/core/entities/workflow-job-detail.ts
@@ -51,6 +51,7 @@ export interface WorkflowJobStepSummary {
   statusReason: string | null;
   sourceLocation: StepSourceLocation | null;
   currentAttempt: number;
+  gateMaxAttempts?: number | undefined;
   error: StepError | null;
   attempts: WorkflowJobPage<WorkflowJobStepAttemptSummary>;
 }

--- a/libs/client/workflows/src/hooks/api/workflow-job-detail-mapper.ts
+++ b/libs/client/workflows/src/hooks/api/workflow-job-detail-mapper.ts
@@ -129,6 +129,7 @@ export function toWorkflowJobStepSummary(
       ? {startLine: dto.source_location.start_line, endLine: dto.source_location.end_line}
       : null,
     currentAttempt: dto.current_attempt,
+    ...(dto.gate_max_attempts === undefined ? {} : {gateMaxAttempts: dto.gate_max_attempts}),
     error: toWorkflowJobStepError(dto.error),
     attempts: {
       items: dto.attempts.items.map((attempt) =>
@@ -163,6 +164,7 @@ export function toWorkflowJobStepAttemptSummary(
 export interface WorkflowJobDetailPresentationOptions {
   steps?: readonly WorkflowJobStepSummary[] | undefined;
   attemptsByStepId?: ReadonlyMap<string, readonly WorkflowJobStepAttemptSummary[]> | undefined;
+  attemptTotalsByStepId?: ReadonlyMap<string, number> | undefined;
 }
 
 export function mergeWorkflowJobStepSummaries(
@@ -239,7 +241,12 @@ function toJobExecutionForJobDetail(
     createdAt: detail.updatedAt,
     updatedAt: detail.updatedAt,
     steps: steps.map((step) =>
-      toStepForJobDetail(step, detail.updatedAt, presentation.attemptsByStepId?.get(step.id)),
+      toStepForJobDetail(
+        step,
+        detail.updatedAt,
+        presentation.attemptsByStepId?.get(step.id),
+        presentation.attemptTotalsByStepId?.get(step.id),
+      ),
     ),
   });
 }
@@ -248,10 +255,13 @@ function toStepForJobDetail(
   step: WorkflowJobStepSummary,
   fallbackUpdatedAt: string,
   presentedAttempts: readonly WorkflowJobStepAttemptSummary[] | undefined,
+  presentedAttemptTotal: number | undefined,
 ): Step {
   const attempts = presentedAttempts ?? step.attempts.items;
   const firstAttempt = attempts[0];
   const updatedAt = firstAttempt?.finishedAt ?? firstAttempt?.startedAt ?? fallbackUpdatedAt;
+  const sourceAttemptTotal = presentedAttemptTotal ?? step.attempts.total;
+  const attemptTotal = typeof sourceAttemptTotal === 'number' ? sourceAttemptTotal : undefined;
   return {
     id: step.id,
     jobExecutionId: step.jobExecutionId,
@@ -268,6 +278,8 @@ function toStepForJobDetail(
     error: step.error,
     position: step.position,
     currentAttempt: step.currentAttempt,
+    ...(step.gateMaxAttempts === undefined ? {} : {gateMaxAttempts: step.gateMaxAttempts}),
+    ...(attemptTotal === undefined ? {} : {attemptTotal}),
     createdAt: firstAttempt?.startedAt ?? fallbackUpdatedAt,
     updatedAt,
     attempts: attempts.map((attempt) => toStepAttemptForJobDetail(attempt, step.jobExecutionId)),

--- a/libs/client/workflows/src/hooks/api/workflow-job-detail-mapper.ts
+++ b/libs/client/workflows/src/hooks/api/workflow-job-detail-mapper.ts
@@ -260,8 +260,12 @@ function toStepForJobDetail(
   const attempts = presentedAttempts ?? step.attempts.items;
   const firstAttempt = attempts[0];
   const updatedAt = firstAttempt?.finishedAt ?? firstAttempt?.startedAt ?? fallbackUpdatedAt;
-  const sourceAttemptTotal = presentedAttemptTotal ?? step.attempts.total;
-  const attemptTotal = typeof sourceAttemptTotal === 'number' ? sourceAttemptTotal : undefined;
+  const embeddedAttemptTotal =
+    typeof step.attempts.total === 'number' ? step.attempts.total : undefined;
+  const attemptTotal =
+    presentedAttemptTotal === undefined
+      ? embeddedAttemptTotal
+      : Math.max(presentedAttemptTotal, embeddedAttemptTotal ?? 0);
   return {
     id: step.id,
     jobExecutionId: step.jobExecutionId,

--- a/libs/client/workflows/src/hooks/api/workflow-job-detail.test.tsx
+++ b/libs/client/workflows/src/hooks/api/workflow-job-detail.test.tsx
@@ -85,7 +85,9 @@ describe('selected-job API hooks', () => {
       selectedExecution: {
         id: EXECUTION_ID,
         jobId: JOB_ID,
-        steps: {items: [{id: STEP_ID, jobExecutionId: EXECUTION_ID}]},
+        steps: {
+          items: [{id: STEP_ID, jobExecutionId: EXECUTION_ID, gateMaxAttempts: 5}],
+        },
       },
     });
     expect(detail.selectedExecution).not.toHaveProperty('runner');
@@ -93,6 +95,10 @@ describe('selected-job API hooks', () => {
     expect(mappedDetail.selectedExecution?.steps.items[0]?.attempts.items[0]?.gateResult).toEqual({
       kind: 'unknown',
       data: {},
+    });
+    expect(toJobForJobDetail(mappedDetail).jobExecutions[0]?.steps[0]).toMatchObject({
+      gateMaxAttempts: 5,
+      attemptTotal: 1,
     });
   });
 
@@ -362,6 +368,7 @@ describe('selected-job API hooks', () => {
       attemptsByStepId: new Map([
         [firstStep.id, mergeWorkflowJobStepAttempts([[...firstStep.attempts.items, olderAttempt]])],
       ]),
+      attemptTotalsByStepId: new Map([[firstStep.id, 4]]),
     });
 
     expect(presentedJob.jobExecutions[0]?.steps.map((step) => step.id)).toEqual([
@@ -369,6 +376,7 @@ describe('selected-job API hooks', () => {
       SECOND_STEP_ID,
     ]);
     expect(presentedJob.jobExecutions[0]?.steps[0]?.attempts).toHaveLength(2);
+    expect(presentedJob.jobExecutions[0]?.steps[0]?.attemptTotal).toBe(4);
 
     const fetchImpl = vi.fn(() => {
       throw new Error('Embedded step pages should not fetch on mount');
@@ -427,6 +435,7 @@ function selectedJobDetailResponseDto(): WorkflowJobDetailDto {
     key: 'tests',
     name: 'tests',
     status: 'succeeded',
+    gate_max_attempts: 5,
     attempts: [
       workflowStepAttemptDto({
         id: ATTEMPT_ID,

--- a/libs/client/workflows/src/hooks/api/workflow-job-detail.test.tsx
+++ b/libs/client/workflows/src/hooks/api/workflow-job-detail.test.tsx
@@ -394,6 +394,20 @@ describe('selected-job API hooks', () => {
     expect(fetchImpl).not.toHaveBeenCalled();
   });
 
+  test('preserves a newer embedded attempt total when the attempts resource is stale', () => {
+    const response = selectedJobDetailResponseDto();
+    const step = response.selected_execution?.steps.items[0];
+    if (!step) throw new Error('Expected an embedded step');
+    step.attempts.total = 4;
+
+    const job = toJobForJobDetail(toWorkflowJobDetail(response), {
+      attemptTotalsByStepId: new Map([[step.id, 3]]),
+    });
+
+    expect(job.jobExecutions[0]?.steps[0]?.attempts).toHaveLength(1);
+    expect(job.jobExecutions[0]?.steps[0]?.attemptTotal).toBe(4);
+  });
+
   test('prefers refreshed resource summaries over embedded selected-job summaries', () => {
     const detail = toWorkflowJobDetail(selectedJobDetailResponseDto());
     const selectedExecution = detail.selectedExecution;

--- a/libs/client/workflows/src/pages/workflow-job-detail-page.test.tsx
+++ b/libs/client/workflows/src/pages/workflow-job-detail-page.test.tsx
@@ -313,8 +313,9 @@ describe('WorkflowJobDetailPage', () => {
     await user.click(await screen.findByRole('button', {name: 'Load older attempts'}));
     await waitFor(() => expect(resourceRequests).toHaveLength(1));
     expect(
-      await screen.findByRole('button', {name: 'tests, Succeeded, attempt 1'}),
+      await screen.findByRole('button', {name: 'tests, Succeeded, attempt 3'}),
     ).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'tests, Succeeded, attempt 4'})).toBeInTheDocument();
 
     await user.click(screen.getByRole('button', {name: 'Load older steps'}));
     expect(
@@ -749,13 +750,14 @@ function olderAttemptPageResponseDto() {
       workflowStepAttemptDto({
         id: OLDER_ATTEMPT_ID,
         step_id: STEP_ID,
-        attempt: 1,
+        attempt: 9,
+        execution_order: 1,
         status: 'succeeded',
         gate_result: {kind: 'unknown', data: {}},
       }),
     ],
     next_cursor: null,
-    total: 2,
+    total: 4,
   };
 }
 
@@ -775,7 +777,15 @@ function paginatedSelectedJobDetailFetch(input: RequestInfo | URL, resourceReque
     if (response.selected_execution) {
       response.selected_execution.steps.next_cursor = 'step-cursor';
       const firstStep = response.selected_execution.steps.items[0];
-      if (firstStep) firstStep.attempts.next_cursor = 'attempt-cursor';
+      if (firstStep) {
+        firstStep.gate_max_attempts = 5;
+        firstStep.attempts.next_cursor = 'attempt-cursor';
+        const firstAttempt = firstStep.attempts.items[0];
+        if (firstAttempt) {
+          firstAttempt.attempt = 12;
+          firstAttempt.execution_order = 2;
+        }
+      }
     }
     return Promise.resolve(jsonResponse(response));
   }

--- a/libs/client/workflows/src/pages/workflow-job-detail-page.test.tsx
+++ b/libs/client/workflows/src/pages/workflow-job-detail-page.test.tsx
@@ -326,6 +326,27 @@ describe('WorkflowJobDetailPage', () => {
     ]);
   });
 
+  test('shows the effective gate attempt policy with the first-execution semantics', async () => {
+    configureApiClient({
+      fetchImpl: vi.fn((input: RequestInfo | URL) => {
+        const url = new URL((input as Request).url);
+        if (url.pathname === `/workflows/runs/jobs/${JOB_ID}`) {
+          const response = workflowJobDetailResponseDto({detail: jobDetailDto(), jobId: JOB_ID});
+          const step = response.selected_execution?.steps.items[0];
+          if (step) step.gate_max_attempts = 5;
+          return Promise.resolve(jsonResponse(response));
+        }
+        return jobDetailFetch(input);
+      }),
+    });
+
+    renderJobPath();
+
+    expect(
+      await screen.findByText('Up to 5 attempts, including the first execution.'),
+    ).toBeInTheDocument();
+  });
+
   test('shows a retarget notice when polling advances to the next running step', async () => {
     const fetchImpl = liveJobDetailFetch({
       jobId: LIVE_JOB_ID,

--- a/libs/client/workflows/test/fixtures/workflow-model-mapper.ts
+++ b/libs/client/workflows/test/fixtures/workflow-model-mapper.ts
@@ -22,6 +22,7 @@ import {
 } from '#hooks/api/workflow-model-mapper.js';
 
 export type WorkflowStepModelDto = StepDto & {
+  gate_max_attempts?: number;
   exit_code: number | null;
   outputs: Record<string, unknown> | null;
   response: string | null;
@@ -140,6 +141,8 @@ export function toWorkflowStepModel(dto: WorkflowStepModelDto): Step {
     error: toWorkflowJobStepError(dto.error),
     position: dto.position,
     currentAttempt: dto.current_attempt,
+    ...(dto.gate_max_attempts === undefined ? {} : {gateMaxAttempts: dto.gate_max_attempts}),
+    attemptTotal: dto.attempts.length,
     createdAt: dto.created_at,
     updatedAt: dto.updated_at,
     attempts: dto.attempts.map((attempt) =>

--- a/libs/client/workflows/test/fixtures/workflow-run.ts
+++ b/libs/client/workflows/test/fixtures/workflow-run.ts
@@ -525,6 +525,9 @@ function compactJobExecutionDto(
         status_reason: step.status_reason,
         source_location: step.source_location,
         current_attempt: step.current_attempt,
+        ...(step.gate_max_attempts === undefined
+          ? {}
+          : {gate_max_attempts: step.gate_max_attempts}),
         error: step.error,
         attempts: {
           items: step.attempts.map((attempt) => ({


### PR DESCRIPTION
## Summary

Expose each step's effective gate restart limit without returning its full materialized configuration. Run details now show the configured policy and number gate attempts by their chronological position while retaining persisted attempt IDs for queries and CEL semantics.

Add dedicated exhaustion guidance with the structured attempt count and limit, plus focused DTO, API, component, pagination, and deterministic Storybook coverage.

## Validation

- Changed Workflows DTO, Workflows API, and client Workflows packages: 195/195 check, type, build, and test tasks passed.
- Changed packages and dependents: 312/312 tasks passed.
- Chromium Storybook tests, Changeset status, and diff checks passed.

## Review note

The deterministic Storybook state is included and its Chromium tests pass. This Conductor workspace had no connected browser surface, so manual desktop and mobile visual inspection remains for review.

Closes ENG-2033

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exposes each step's effective gate restart limit without exposing full step configuration, and shows gate attempts by their chronological position instead of stored attempt numbers. Persisted attempt IDs and CEL semantics (`step.attempt`, `step.is_retry`) remain unchanged.

- Adds optional `gate_max_attempts` to the compact step summary DTO and client entity, omitting it for tool steps and falling back to the default cap for legacy configs.
- Derives displayed attempt ordinals from the attempt list position, using the page total when available and keeping totals monotonic across live polling; non-gate steps keep stored attempt numbers.
- Updates exhaustion guidance to use the structured attempt count and configured limit, falling back to the effective limit for legacy errors.
- Adds focused DTO, API, component, and Storybook coverage for the new behavior.

<sup>Written for commit b1dc242f1cfb2ca3c0e8aacb0099221e89ee2bec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1772?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

