### PR TITLE
[docs] Explain source-based feedback loop routing

### DIFF
--- a/apps/docs/content/docs/how-to/author-workflows/build-feedback-loop.mdx
+++ b/apps/docs/content/docs/how-to/author-workflows/build-feedback-loop.mdx
@@ -1,16 +1,20 @@
 ---
 title: "Build an Agent Feedback Loop in Shipfox"
 sidebarTitle: "Build a Feedback Loop"
-description: "Pair an agent with an objective check and restart it with useful feedback until the check passes or the attempt bound is reached."
+description: "Route two objective checks to independent recovery steps until both checks pass or an attempt bound is reached."
 ---
 
-This guide builds a workflow where an agent fixes failing tests and `npm test`
-decides whether another attempt is needed.
+This guide builds one job with test and lint feedback loops. Each failed check
+routes to its own recovery step by the checking step's key.
 
 ## Before you begin
 
-The repository needs a safe failure in its `npm test` command that the agent can
-repair.
+You need:
+
+- A repository with `npm test` and `npm run lint` commands.
+- Configured agent defaults for the project.
+- A safe branch where an agent can edit test and lint failures.
+- A Shipfox validator and runtime that support `step.restart.from.key`.
 
 ## Add the workflow
 
@@ -26,42 +30,90 @@ triggers:
     source: manual
 
 jobs:
-  fix:
+  improve:
     execution_timeout: "30m"
     steps:
-      - key: fix
+      - key: implement
         prompt: >
-          Fix the failing tests in this repository.
-          Previous check: ${{ step.is_retry
-            ? step.restart.feedback
-            : "No previous check. Run the tests and inspect the failures." }}
+          Fix the failing tests and lint errors in this repository.
+          Run both checks before finishing.
+
+      - key: test_failure_handler
+        if: '${{ has(step.restart) && has(step.restart.from.key) && step.restart.from.key == "test" }}'
+        prompt: >
+          Fix the test failure. Reproduce it and correct its cause.
+          Check feedback: ${{ step.restart.feedback }}
 
       - key: test
         run: npm test
         gate:
           success: step.exit_code == 0
           on_failure:
-            restart_from: fix
+            restart_from: test_failure_handler
             feedback: The tests still fail. Run them again and fix the cause.
+
+      - key: lint_failure_handler
+        if: '${{ has(step.restart) && has(step.restart.from.key) && step.restart.from.key == "lint" }}'
+        prompt: >
+          Fix the lint failure without weakening the rules.
+          Check feedback: ${{ step.restart.feedback }}
+
+      - key: lint
+        run: npm run lint
+        gate:
+          success: step.exit_code == 0
+          on_failure:
+            restart_from: lint_failure_handler
+            feedback: Lint still fails. Run it again and fix the reported issues.
 ```
 
-Replace `npm test` with the command that proves the work is correct in your
-repository.
+Replace the two check commands with commands that prove the required results.
+Keep an authored key on each checking step. The keys provide source identity
+for their recovery predicates.
 
 ## Run and inspect it
 
 1. Commit and push the workflow to the project's default branch.
 2. Wait for its definition to sync.
 3. Open the workflow and select **Run**.
-4. Open the `fix` job in the run detail.
-5. If the check fails, confirm that a new `fix` step attempt receives the gate
-   feedback.
-6. Confirm that the job finishes when the check passes or the restart bound is
-   exhausted.
+4. Open the `improve` job in the run detail.
+5. Confirm both recovery steps skip before their matching check fails.
+6. If `test` fails, confirm only `test_failure_handler` runs.
+7. After `test` passes, confirm `lint_failure_handler` stays skipped.
+8. If `lint` fails, confirm only `lint_failure_handler` runs.
+9. Confirm the job finishes after both checks pass.
 
-The `key` on `fix` is required because `restart_from` targets step keys. The
-target must appear before the gated step in the same job. Exact gate fields and
-validation rules live in [Gate fields](/reference/workflow-schema#gate-fields).
+The test cause stays visible after `test` passes. The lint handler still skips
+because its predicate compares the source key. `step.is_retry` cannot make this
+distinction.
+
+Exact gate fields and validation rules live in [Gate
+fields](/reference/workflow-schema#gate-fields). The [Contexts
+reference](/reference/contexts#context-properties) owns the exact restart field
+shape and availability.
+
+## Migrate from feedback-prefix routing
+
+Confirm the deployed validator and runtime support `step.restart.from.key`
+before adopting the new predicates. A merged change or green CI is not runtime
+deployment evidence.
+
+For each existing route:
+
+1. Add an authored `key` to the checking step that owns the gate.
+2. Replace the handler's feedback-prefix test with the guarded source-key test.
+3. Keep useful diagnostic text in `gate.on_failure.feedback`.
+4. Remove the machine-readable prefix after no consumer parses it.
+
+For example, replace a `verification_retry:` prefix check with this predicate
+on the existing verification recovery step:
+
+```text
+has(step.restart) && has(step.restart.from.key) && step.restart.from.key == "verify"
+```
+
+The `verify` key belongs on the failing check. It does not belong on the
+`restart_from` target.
 
 The job timeout is an outer wall-clock bound. The gate also has its own attempt
 limit. See [Limits](/reference/limits). For the evaluation model, see

--- a/apps/docs/content/docs/reference/contexts.mdx
+++ b/apps/docs/content/docs/reference/contexts.mdx
@@ -27,16 +27,11 @@ reads `step` and `vars`.
 A field cannot read the value it sets. For example, `run_name` cannot read
 `run.name`.
 
-The `result` context exists only while a tool step maps its outputs, after the
-provider returns. The `outputs` mapping of a tool step reads `result` and
-`vars`. Every other field reads the stored value as
-`steps.<step_key>.outputs.result`. See [Tool step
-fields](/reference/workflow-schema#tool-step-fields).
-
-Reading a context the table does not list for the field fails the sync, with an
-error that names the context. The workflow never runs with an empty value in its
-place. See [Correct a context that is not
-available](/how-to/run-and-troubleshoot/workflow-sync#correct-a-context-that-is-not-available).
+Workflow sync fails when a field uses an unavailable context. The error
+identifies the context. Shipfox does not substitute an empty value. See [Correct
+a context that is not
+available](/how-to/run-and-troubleshoot/workflow-sync#correct-a-context-that-is-not-available)
+for recovery steps.
 
 ## Context properties
 

--- a/apps/docs/content/docs/understand/data-and-templating.mdx
+++ b/apps/docs/content/docs/understand/data-and-templating.mdx
@@ -7,49 +7,33 @@ description: "Understand when run data becomes available, how outputs move it be
 **Context** is the data a workflow can read while it runs. It starts with the
 event or the manual inputs. It grows as jobs and steps produce results.
 
-Timing matters. A workflow can't read a result before the work that creates it
-has finished. Shipfox resolves each value once enough context exists. A value
-that depends on later work waits for that work to finish.
+## How interpolation works
 
-## When each kind of data becomes available
+Interpolation reads a value from context and inserts it into a workflow field.
+Wrap the expression in `${{ }}`. For example, `Hello ${{ inputs.name }}` adds
+the `name` input after `Hello`.
 
-Context is a flow, not one global object. Data joins it at five points:
+Use interpolation to add data to text or settings. It does not decide whether
+work runs.
 
-1. **Run creation** adds the run identity, the trigger, the event, and the
-   inputs.
-2. **Job readiness** adds the outputs of upstream jobs that have finished.
-3. **Listening execution** adds the event batch that started that execution.
-4. **Step dispatch** adds earlier step outputs and retry context.
-5. **Runner execution** resolves secret bindings for the command that needs
-   them. The secret value never enters the run plan.
+A predicate is a yes-or-no check. For example, `step.exit_code == 0` passes a
+gate when the command succeeds. Filters, conditions, gates, and job success
+rules use predicates.
 
-A tool step adds one short-lived value. Its provider response is readable as
-`result` only while that step maps its outputs, right after the call returns.
-Later steps read the stored value as `steps.<key>.outputs.result`.
+The [Expressions reference](/reference/expressions) defines the exact syntax
+and available fields.
 
-Workspace variables and project settings hold long-lived configuration. Events
-and outputs describe this run. Secrets grant access and follow a stricter path.
+## When data becomes available
 
-The [Contexts reference](/reference/contexts#context-availability) is the
-canonical table of which contexts each field can read.
+A workflow gains data as the run progresses:
 
-## Two kinds of expression: templates and predicates
+- Run details, trigger data, inputs, and variables are available from the start.
+- Step outputs become available after the step finishes.
+- Job outputs become available after an upstream job finishes.
+- Restart feedback becomes available when a gate repeats steps.
 
-A `${{ }}` template puts a value into text or into a setting. It can put an
-issue title in a prompt. It can also bind a job output to an environment
-variable.
-
-A predicate returns true or false. Filters, conditions, gates, and job success
-rules use predicates. They decide whether work starts, continues, or passes.
-
-The two roles stay separate, which makes policy easier to inspect. A template
-never decides control flow. A predicate can't run a command or change outside
-state. The same saved context therefore always produces the same decision.
-
-Use a template to move a known value. Use a predicate when the workflow needs a
-yes-or-no rule. The [Expressions
-reference](/reference/expressions) defines the exact syntax and the available
-fields.
+The [Contexts reference](/reference/contexts#context-availability) lists the
+exact availability of these values, tool results, listening events, and secrets.
 
 ## How outputs move results between jobs
 

--- a/apps/docs/content/docs/understand/feedback-loops.mdx
+++ b/apps/docs/content/docs/understand/feedback-loops.mdx
@@ -73,14 +73,20 @@ job continue.
 The [Gate fields
 reference](/reference/workflow-schema#gate-fields) defines the exact fields.
 
+## Route several loops by their checking step
+
+One job execution can contain several feedback loops. Shipfox records which
+checking step caused a restart. The workflow can identify the relevant loop
+and run its matching recovery step.
+
+[Build a feedback
+loop](/how-to/author-workflows/build-feedback-loop) shows a complete two-loop
+workflow and how to route each failure.
+
 ## Give the next attempt useful feedback
 
 A retry without new evidence can repeat the same mistake. Useful feedback names
 the failed property and points the repeated step to evidence it can inspect.
-
-Static guidance is enough when the step can run the check again and read its
-output. A checking step can also publish a small result for the feedback
-message. Keep large logs in the run instead of copying them into every prompt.
 
 Feedback isn't a new event. It belongs to the restart decision, and only the
 repeated attempt can read it. [Context and
@@ -97,9 +103,6 @@ The loop stops in one of two states:
 
 - The check passes.
 - The attempt limit runs out and the job fails.
-
-Don't weaken the check to make the loop finish. A failure after the limit is
-evidence that the task needs another approach or a person.
 
 [Limits](/reference/limits) lists the exact attempt limits. The [run
 history](/understand/workflows-and-runs) keeps each step attempt and its
@@ -124,5 +127,4 @@ creating a new one on every attempt.
 A loop can repeat a bad side effect as easily as it can improve code. Don't use
 it to retry a deploy or an external write that has no check in front of it.
 
-Use [Build a feedback
-loop](/how-to/author-workflows/build-feedback-loop) for the authoring task.
+Use the linked authoring guide to add this pattern to a workflow.

--- a/libs/shared/expression/src/workflow-context/workflow-context-docs.ts
+++ b/libs/shared/expression/src/workflow-context/workflow-context-docs.ts
@@ -176,10 +176,12 @@ export const workflowContextDocs = [
     summary: 'The current step. Its properties depend on the field that reads it.',
     fields: {
       attempt: 'Attempt number of the step, starting at one. Not readable in `gate.success`.',
-      is_retry: 'Whether this is a repeat attempt. Not readable in `gate.success`.',
-      restart: 'Set when a gate restarted this step. Not readable in `gate.success`.',
+      is_retry:
+        'Whether the current step ran before. This does not identify which gate failed. Not readable in `gate.success`.',
+      restart:
+        'Set when a gate failure causes Shipfox to run this step again. It remains set for later steps after the gate passes. A later gate restart replaces it. Not readable in `gate.success`.',
       'restart.from':
-        'The failed gate step that restarted this attempt, with the properties of a `steps` entry and its optional authored `key`. The key names the failing gate, not the restart target. Not readable in `gate.success`.',
+        'The gate step whose failure caused the restart. It includes the properties of a `steps` entry and its optional authored `key`. The key identifies the failed gate, not the restart target. Not readable in `gate.success`.',
       'restart.feedback': 'Feedback the restarting gate produced. Not readable in `gate.success`.',
       exit_code: 'Exit code the step reported. Readable in `gate.success` only.',
       status: 'Status the step reported. Readable in `gate.success` only.',


### PR DESCRIPTION
Documents how authors route independent feedback loops using the failed gate's authored key. The guide now provides a complete test-and-lint workflow, explains guarded source matching, and directs exact context behavior to the generated reference table.

The surrounding explanation now introduces interpolation and data availability in end-user language.

Validation: `mise exec -- turbo check --filter=@shipfox/docs...` and `mise exec -- turbo test --filter=@shipfox/docs...`.

Closes ENG-2069

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents source-based feedback loop routing so one job can recover from multiple independent check failures. The build-feedback-loop guide now uses the failed gate's authored key in guarded predicates instead of feedback-prefix routing.

**Migration**
- Confirm the deployed validator and runtime support `step.restart.from.key` before adopting the new predicates.
- `step.is_retry` does not identify which gate failed; use `step.restart.from.key` for that.

<sup>Written for commit c7b6396cbd9a4659c73593246ce2a728ee788674. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1774?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

