### PR TITLE
[api-workflows] Re-materialize step config on reruns

### DIFF
--- a/.changeset/fresh-reruns-attempt.md
+++ b/.changeset/fresh-reruns-attempt.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-workflows": patch
+---
+
+Refreshes run-creation step expressions for each workflow rerun.

--- a/libs/api/workflows/src/core/step-config/materialize-job-execution-steps.ts
+++ b/libs/api/workflows/src/core/step-config/materialize-job-execution-steps.ts
@@ -34,6 +34,9 @@ export interface MaterializeJobExecutionStepsParams {
   readonly job: WorkflowModelJob;
   readonly context: WorkflowEvaluationContext;
   readonly resolveAgentDefaults?: AgentDefaultsResolver | undefined;
+  readonly resolveAgentDefaultsForStep?:
+    | ((stepPosition: number) => AgentDefaultsResolver | undefined)
+    | undefined;
   readonly definitionId?: string | undefined;
   readonly agentToolContext?: AgentToolMaterializationContext | undefined;
   readonly agentToolSnapshot?: AgentToolMaterializationSnapshot | null | undefined;
@@ -61,6 +64,7 @@ export async function materializeJobExecutionSteps(
     job,
     context,
     resolveAgentDefaults,
+    resolveAgentDefaultsForStep,
     definitionId = model.name,
     agentToolContext,
     agentToolSnapshot,
@@ -83,7 +87,7 @@ export async function materializeJobExecutionSteps(
           jobEnvTemplates: job.templates?.env,
           context: stepContext,
           site: context.site,
-          resolveAgentDefaults,
+          resolveAgentDefaults: resolveAgentDefaultsForStep?.(stepPosition) ?? resolveAgentDefaults,
           definitionId,
           agentToolContext,
           agentToolSnapshot,

--- a/libs/api/workflows/src/db/workflow-runs/run-rerun.test.ts
+++ b/libs/api/workflows/src/db/workflow-runs/run-rerun.test.ts
@@ -183,7 +183,7 @@ describe('workflow run queries', () => {
       await expect(getStepsByJobId(rerunJob.id)).resolves.toEqual([]);
     });
 
-    test('re-materializes run-creation step config for the new attempt', async () => {
+    test('re-materializes run-creation step fields for the new attempt', async () => {
       const source = await createWorkflowRun({
         workspaceId,
         projectId,
@@ -194,6 +194,7 @@ describe('workflow run queries', () => {
               steps: [
                 {
                   key: 'publish',
+                  name: `Publish attempt ${template('run.attempt')}`,
                   run: 'echo publish',
                   env: {BRANCH: `publish-${template('run.id')}-${template('run.attempt')}`},
                 },
@@ -215,6 +216,7 @@ describe('workflow run queries', () => {
         (step) => step.key === 'publish',
       );
       if (!sourceStep) throw new Error('Missing source publish step');
+      expect(sourceStep.name).toBe('Publish attempt 1');
       await updateWorkflowRunStatus({
         workflowRunId: source.id,
         status: 'failed',
@@ -230,6 +232,7 @@ describe('workflow run queries', () => {
       const [rerunJob] = await getJobsByWorkflowRunId(rerun.id);
       if (!rerunJob) throw new Error('Missing rerun publish job');
       const rerunStep = (await getStepsByJobId(rerunJob.id)).find((step) => step.key === 'publish');
+      expect(rerunStep?.name).toBe('Publish attempt 2');
       expect(rerunStep?.config).toMatchObject({
         env: {BRANCH: `publish-${source.id}-2`},
       });

--- a/libs/api/workflows/src/db/workflow-runs/run-rerun.test.ts
+++ b/libs/api/workflows/src/db/workflow-runs/run-rerun.test.ts
@@ -1,6 +1,7 @@
+import type {IntegrationsModuleClient} from '@shipfox/api-integration-core-dto/inter-module';
+import type {ProjectsModuleClient} from '@shipfox/api-projects-dto/inter-module';
 import {eq, inArray} from 'drizzle-orm';
 import type {AgentDefaultsResolver} from '#core/agent-defaults.js';
-import type {AgentToolMaterializationSnapshot} from '#core/agent-tools.js';
 import {NoFailedJobsError, RunNotTerminalError, SourceRunNotFoundError} from '#core/errors.js';
 import {nextStepForJob, recordStepResult} from '#core/job-execution.js';
 import {assembleWorkflowRunContext} from '#core/step-config/assemble-run-context.js';
@@ -9,6 +10,7 @@ import {stripSetupStep} from '#test/fixtures/strip-setup-step.js';
 import {listTestRunAttempts} from '#test/helpers/run-attempts.js';
 import {
   buildModel,
+  expression,
   runAttemptCreatedEvents,
   stepOutputField,
   template,
@@ -17,7 +19,6 @@ import {db} from '../db.js';
 import {jobExecutions} from '../schema/job-executions.js';
 import {jobs} from '../schema/jobs.js';
 import {steps as stepsTable} from '../schema/steps.js';
-import {workflowRunAttempts} from '../schema/workflow-run-attempts.js';
 import {
   createRerunWorkflowRun,
   createWorkflowRun,
@@ -139,6 +140,346 @@ describe('workflow run queries', () => {
       }
     });
 
+    test('re-materializes run-creation step config for the new attempt', async () => {
+      const source = await createWorkflowRun({
+        workspaceId,
+        projectId,
+        definitionId,
+        model: buildModel({
+          jobs: {
+            publish: {
+              steps: [
+                {
+                  key: 'publish',
+                  run: 'echo publish',
+                  env: {BRANCH: `publish-${template('run.id')}-${template('run.attempt')}`},
+                },
+              ],
+            },
+          },
+        }),
+        triggerPayload: {
+          source: 'manual',
+          event: 'fire',
+          subscriptionId: crypto.randomUUID(),
+          userId: crypto.randomUUID(),
+        },
+      });
+      const [sourceJob] = await getJobsByWorkflowRunId(source.id);
+      if (!sourceJob) throw new Error('Missing source publish job');
+      await markJob([sourceJob], 'publish', 'failed');
+      const sourceStep = (await getStepsByJobId(sourceJob.id)).find(
+        (step) => step.key === 'publish',
+      );
+      if (!sourceStep) throw new Error('Missing source publish step');
+      await updateWorkflowRunStatus({
+        workflowRunId: source.id,
+        status: 'failed',
+        expectedVersion: 1,
+      });
+
+      const rerun = await createRerunWorkflowRun({
+        workflowRunId: source.id,
+        mode: 'failed',
+        actorUserId: crypto.randomUUID(),
+      });
+
+      const [rerunJob] = await getJobsByWorkflowRunId(rerun.id);
+      if (!rerunJob) throw new Error('Missing rerun publish job');
+      const rerunStep = (await getStepsByJobId(rerunJob.id)).find((step) => step.key === 'publish');
+      expect(rerunStep?.config).toMatchObject({
+        env: {BRANCH: `publish-${source.id}-2`},
+      });
+      expect(rerunStep?.configPlan?.trace).toContainEqual(
+        expect.objectContaining({
+          expression: 'run.attempt',
+          fillTarget: 'run-creation',
+          evaluatedAt: 'run-creation',
+          field: 'env',
+          envKey: 'BRANCH',
+          value: '2',
+        }),
+      );
+      expect(
+        (await getStepsByJobId(sourceJob.id)).find((step) => step.id === sourceStep.id),
+      ).toEqual(sourceStep);
+    });
+
+    test('re-materializes agent prompts while preserving resolved defaults and session intent', async () => {
+      const resolveAgentDefaults = vi.fn<AgentDefaultsResolver>().mockReturnValue({
+        harness: 'pi',
+        provider: 'openai',
+        model: 'gpt-5.5-pro',
+        thinking: 'medium',
+      });
+      const source = await createWorkflowRun({
+        workspaceId,
+        projectId,
+        definitionId,
+        model: buildModel({
+          jobs: {
+            fix: {
+              steps: [
+                {
+                  prompt: `Fix workflow attempt ${template('run.attempt')}.`,
+                  session: {key: 'implementation', mode: 'resume'},
+                },
+              ],
+            },
+          },
+        }),
+        triggerPayload: {
+          source: 'manual',
+          event: 'fire',
+          subscriptionId: crypto.randomUUID(),
+          userId: crypto.randomUUID(),
+        },
+        resolveAgentDefaults,
+      });
+      const [sourceJob] = await getJobsByWorkflowRunId(source.id);
+      if (!sourceJob) throw new Error('Missing source fix job');
+      await markJob([sourceJob], 'fix', 'failed');
+      await updateWorkflowRunStatus({
+        workflowRunId: source.id,
+        status: 'failed',
+        expectedVersion: 1,
+      });
+
+      const rerun = await createRerunWorkflowRun({
+        workflowRunId: source.id,
+        mode: 'failed',
+        actorUserId: crypto.randomUUID(),
+      });
+
+      const [rerunJob] = await getJobsByWorkflowRunId(rerun.id);
+      if (!rerunJob) throw new Error('Missing rerun fix job');
+      const agentStep = (await getStepsByJobId(rerunJob.id)).find((step) => step.type === 'agent');
+      expect(resolveAgentDefaults).toHaveBeenCalledTimes(1);
+      expect(agentStep?.config).toMatchObject({
+        harness: 'pi',
+        provider: 'openai',
+        model: 'gpt-5.5-pro',
+        thinking: 'medium',
+        prompt: 'Fix workflow attempt 2.',
+        session: {key: 'implementation', mode: 'resume'},
+      });
+    });
+
+    test('re-materializes attempt-scoped config across consecutive reruns', async () => {
+      const source = await createWorkflowRun({
+        workspaceId,
+        projectId,
+        definitionId,
+        model: buildModel({
+          jobs: {
+            publish: {
+              steps: [
+                {
+                  key: 'publish',
+                  run: 'echo publish',
+                  env: {IDENTIFIER: `${template('run.id')}-${template('run.attempt')}`},
+                },
+              ],
+            },
+          },
+        }),
+        triggerPayload: {
+          source: 'manual',
+          event: 'fire',
+          subscriptionId: crypto.randomUUID(),
+          userId: crypto.randomUUID(),
+        },
+      });
+      const [sourceJob] = await getJobsByWorkflowRunId(source.id);
+      if (!sourceJob) throw new Error('Missing source publish job');
+      await markJob([sourceJob], 'publish', 'failed');
+      await updateWorkflowRunStatus({
+        workflowRunId: source.id,
+        status: 'failed',
+        expectedVersion: 1,
+      });
+
+      const second = await createRerunWorkflowRun({
+        workflowRunId: source.id,
+        mode: 'all',
+        actorUserId: crypto.randomUUID(),
+      });
+      const [secondJob] = await getJobsByWorkflowRunId(second.id);
+      if (!secondJob) throw new Error('Missing second-attempt publish job');
+      await markJob([secondJob], 'publish', 'failed');
+      await updateWorkflowRunStatus({
+        workflowRunId: second.id,
+        status: 'failed',
+        expectedVersion: 1,
+      });
+
+      const third = await createRerunWorkflowRun({
+        workflowRunId: second.id,
+        mode: 'all',
+        actorUserId: crypto.randomUUID(),
+      });
+
+      const secondStep = (await getStepsByJobId(secondJob.id)).find(
+        (step) => step.key === 'publish',
+      );
+      const [thirdJob] = await getJobsByWorkflowRunId(third.id);
+      if (!thirdJob) throw new Error('Missing third-attempt publish job');
+      const thirdStep = (await getStepsByJobId(thirdJob.id)).find((step) => step.key === 'publish');
+      expect(second).toMatchObject({id: source.id, currentAttempt: 2});
+      expect(third).toMatchObject({id: source.id, currentAttempt: 3});
+      expect(secondStep?.config).toMatchObject({env: {IDENTIFIER: `${source.id}-2`}});
+      expect(thirdStep?.config).toMatchObject({env: {IDENTIFIER: `${source.id}-3`}});
+    });
+
+    test('keeps the workflow attempt stable across a step restart', async () => {
+      const source = await createWorkflowRun({
+        workspaceId,
+        projectId,
+        definitionId,
+        model: buildModel({
+          jobs: {
+            publish: {
+              steps: [
+                {
+                  key: 'producer',
+                  run: 'echo publish',
+                  env: {ATTEMPT: template('run.attempt')},
+                },
+                {
+                  key: 'review',
+                  run: 'exit 1',
+                  gate: {
+                    success: expression('step.exit_code == 0'),
+                    onFailure: {restartFrom: 'producer'},
+                  },
+                },
+              ],
+            },
+          },
+        }),
+        triggerPayload: {
+          source: 'manual',
+          event: 'fire',
+          subscriptionId: crypto.randomUUID(),
+          userId: crypto.randomUUID(),
+        },
+      });
+      const [sourceJob] = await getJobsByWorkflowRunId(source.id);
+      if (!sourceJob) throw new Error('Missing source publish job');
+      await stripSetupStep(sourceJob.id);
+      await markJob([sourceJob], 'publish', 'failed');
+      await updateWorkflowRunStatus({
+        workflowRunId: source.id,
+        status: 'failed',
+        expectedVersion: 1,
+      });
+
+      const rerun = await createRerunWorkflowRun({
+        workflowRunId: source.id,
+        mode: 'all',
+        actorUserId: crypto.randomUUID(),
+      });
+      const [rerunJob] = await getJobsByWorkflowRunId(rerun.id);
+      if (!rerunJob) throw new Error('Missing rerun publish job');
+      const producer = await nextStepForJob(rerunJob.id);
+      if (producer.kind !== 'step') throw new Error('Expected producer step');
+      await recordStepResult({
+        jobExecutionId: producer.step.jobExecutionId,
+        stepId: producer.step.id,
+        status: 'succeeded',
+        exitCode: 0,
+      });
+      const review = await nextStepForJob(rerunJob.id);
+      if (review.kind !== 'step') throw new Error('Expected review step');
+      const restart = await recordStepResult({
+        jobExecutionId: review.step.jobExecutionId,
+        stepId: review.step.id,
+        status: 'failed',
+        error: {message: 'review failed'},
+        exitCode: 1,
+      });
+
+      const retriedProducer = await nextStepForJob(rerunJob.id);
+      expect(rerun.currentAttempt).toBe(2);
+      expect(restart).toEqual({jobFinished: false});
+      expect(retriedProducer).toEqual({
+        kind: 'step',
+        step: expect.objectContaining({
+          id: producer.step.id,
+          currentAttempt: 2,
+          config: {run: 'echo publish', env: {ATTEMPT: '2'}},
+        }),
+        dispatched: true,
+      });
+      const attempts = await getStepAttempts(rerunJob.id);
+      expect(
+        attempts.find((attempt) => attempt.stepId === producer.step.id && attempt.attempt === 2),
+      ).toMatchObject({
+        config: {run: 'echo publish', env: {ATTEMPT: '2'}},
+        evaluationTrace: expect.arrayContaining([
+          expect.objectContaining({
+            expression: 'run.attempt',
+            evaluatedAt: 'run-creation',
+            value: '2',
+          }),
+        ]),
+      });
+    });
+
+    test('failed mode leaves carried step config on its source attempt', async () => {
+      const source = await createWorkflowRun({
+        workspaceId,
+        projectId,
+        definitionId,
+        model: buildModel({
+          jobs: {
+            build: {
+              steps: [{key: 'build', run: 'echo build', env: {ATTEMPT: template('run.attempt')}}],
+            },
+            publish: {
+              steps: [
+                {key: 'publish', run: 'echo publish', env: {ATTEMPT: template('run.attempt')}},
+              ],
+            },
+          },
+        }),
+        triggerPayload: {
+          source: 'manual',
+          event: 'fire',
+          subscriptionId: crypto.randomUUID(),
+          userId: crypto.randomUUID(),
+        },
+      });
+      const sourceJobs = await getJobsByWorkflowRunId(source.id);
+      await markJob(sourceJobs, 'build', 'succeeded');
+      await markJob(sourceJobs, 'publish', 'failed');
+      await updateWorkflowRunStatus({
+        workflowRunId: source.id,
+        status: 'failed',
+        expectedVersion: 1,
+      });
+
+      const rerun = await createRerunWorkflowRun({
+        workflowRunId: source.id,
+        mode: 'failed',
+        actorUserId: crypto.randomUUID(),
+      });
+
+      const rerunJobs = await getJobsByWorkflowRunId(rerun.id);
+      const build = rerunJobs.find((job) => job.key === 'build');
+      const publish = rerunJobs.find((job) => job.key === 'publish');
+      const buildStep = (await getStepsByJobId(build?.id as string)).find(
+        (step) => step.key === 'build',
+      );
+      const publishStep = (await getStepsByJobId(publish?.id as string)).find(
+        (step) => step.key === 'publish',
+      );
+      expect(build).toMatchObject({status: 'succeeded', carriedOver: true});
+      expect(buildStep?.config).toMatchObject({env: {ATTEMPT: '1'}});
+      expect(publish).toMatchObject({status: 'pending', carriedOver: false});
+      expect(publishStep?.config).toMatchObject({env: {ATTEMPT: '2'}});
+    });
+
     test('reruns clone the parsed model onto the new attempt', async () => {
       const source = await createTerminalSourceRun();
 
@@ -213,47 +554,108 @@ describe('workflow run queries', () => {
       }
     });
 
-    test('reruns clone the frozen agent tool materialization snapshot', async () => {
-      const source = await createTerminalSourceRun();
-      const [sourceAttempt] = await listTestRunAttempts({workflowRunId: source.id, projectId});
-      const snapshot: AgentToolMaterializationSnapshot = {
-        steps: [
+    test('reruns consume the frozen agent tool materialization snapshot', async () => {
+      const resolveAgentDefaults = vi.fn<AgentDefaultsResolver>().mockReturnValue({
+        harness: 'pi',
+        provider: 'openai',
+        model: 'gpt-5.5-pro',
+        thinking: 'medium',
+      });
+      const getAgentToolsContext = vi.fn().mockResolvedValue({
+        catalogs: [
           {
-            jobKey: 'test',
-            stepId: 'test-step-1',
-            integrations: [
+            provider: 'github',
+            tools: [
               {
-                connectionId: crypto.randomUUID(),
-                connectionSlug: 'github',
-                provider: 'github',
+                id: 'issue_read',
+                description: 'Read issues.',
+                sensitivity: 'read',
+                sensitive: false,
                 requiredScope: [{permission: 'issues', access: 'read'}],
-                tools: [
+                inputSchema: {type: 'object'},
+                methods: [
                   {
-                    id: 'issue_read',
+                    id: 'get',
+                    description: 'Get an issue.',
                     sensitivity: 'read',
                     sensitive: false,
                     requiredScope: [{permission: 'issues', access: 'read'}],
-                    inputSchema: {type: 'object'},
-                    methods: [
-                      {
-                        id: 'get',
-                        token: 'issue_read.get',
-                        sensitivity: 'read',
-                        sensitive: false,
-                        requiredScope: [{permission: 'issues', access: 'read'}],
-                      },
-                    ],
                   },
                 ],
               },
             ],
           },
         ],
-      };
-      await db()
-        .update(workflowRunAttempts)
-        .set({agentToolMaterialization: snapshot})
-        .where(eq(workflowRunAttempts.id, sourceAttempt?.id as string));
+        workspaceConnections: [
+          {
+            id: 'connection-1',
+            slug: 'github-main',
+            provider: 'github',
+            capabilities: ['agent_tools'],
+          },
+        ],
+        defaultConnection: {
+          id: 'connection-1',
+          slug: 'github-main',
+          provider: 'github',
+        },
+      });
+      const integrations = {getAgentToolsContext} as unknown as IntegrationsModuleClient;
+      const projects = {
+        getProjectById: vi.fn().mockResolvedValue({
+          project: {sourceConnectionId: 'connection-1'},
+        }),
+      } as unknown as ProjectsModuleClient;
+      const source = await createWorkflowRun({
+        workspaceId,
+        projectId,
+        definitionId,
+        model: buildModel({
+          jobs: {
+            fix: {
+              steps: [
+                {
+                  key: 'fix',
+                  harness: 'pi',
+                  provider: 'openai',
+                  model: 'gpt-5.5-pro',
+                  thinking: 'medium',
+                  prompt: `Fix attempt ${template('run.attempt')}.`,
+                  integrations: [
+                    {
+                      connection: 'github-main',
+                      include: ['issue_read.get'],
+                      allowWrite: false,
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+        }),
+        triggerPayload: {
+          source: 'manual',
+          event: 'fire',
+          subscriptionId: crypto.randomUUID(),
+          userId: crypto.randomUUID(),
+        },
+        integrations,
+        projects,
+        resolveAgentDefaults,
+      });
+      const [sourceJob] = await getJobsByWorkflowRunId(source.id);
+      if (!sourceJob) throw new Error('Missing source fix job');
+      await markJob([sourceJob], 'fix', 'failed');
+      await updateWorkflowRunStatus({
+        workflowRunId: source.id,
+        status: 'failed',
+        expectedVersion: 1,
+      });
+      const [sourceAttempt] = await listTestRunAttempts({workflowRunId: source.id, projectId});
+      const snapshot = sourceAttempt?.agentToolMaterialization;
+      const snapshotIntegrations = snapshot?.steps[0]?.integrations;
+      if (snapshotIntegrations === undefined)
+        throw new Error('Missing source integration snapshot');
 
       await createRerunWorkflowRun({
         workflowRunId: source.id,
@@ -264,6 +666,17 @@ describe('workflow run queries', () => {
       const attempts = await listTestRunAttempts({workflowRunId: source.id, projectId});
       const rerunAttempt = attempts.find((attempt) => attempt.attempt === 2);
       expect(rerunAttempt?.agentToolMaterialization).toEqual(snapshot);
+      expect(getAgentToolsContext).toHaveBeenCalledTimes(1);
+      expect(resolveAgentDefaults).toHaveBeenCalledTimes(1);
+      const [rerunJob] = await getJobsByWorkflowRunId(source.id);
+      if (!rerunJob) throw new Error('Missing rerun fix job');
+      const rerunAgentStep = (await getStepsByJobId(rerunJob.id)).find(
+        (step) => step.type === 'agent',
+      );
+      expect(rerunAgentStep?.config).toMatchObject({
+        prompt: 'Fix attempt 2.',
+        integrations: snapshotIntegrations,
+      });
     });
 
     test('reruns re-materialize each job checkout policy from the model', async () => {
@@ -411,7 +824,23 @@ describe('workflow run queries', () => {
         workspaceId,
         projectId,
         definitionId,
-        model: buildModel({jobs: {build: {steps: [{run: 'build'}, {run: 'deploy'}]}}}),
+        model: buildModel({
+          jobs: {
+            build: {
+              steps: [
+                {key: 'build', run: 'build'},
+                {
+                  key: 'deploy',
+                  run: 'deploy',
+                  env: {
+                    ATTEMPT: template('run.attempt'),
+                    SHA: template('steps.build.outputs.sha'),
+                  },
+                },
+              ],
+            },
+          },
+        }),
         triggerPayload: {
           source: 'manual',
           event: 'fire',
@@ -428,15 +857,6 @@ describe('workflow run queries', () => {
       const sourceConsumer = sourceSteps[1];
       if (!sourceProducer || !sourceConsumer) throw new Error('Expected source steps');
       const shaPlan = stepOutputField('build', 'sha');
-      await db().update(stepsTable).set({key: 'build'}).where(eq(stepsTable.id, sourceProducer.id));
-      await db()
-        .update(stepsTable)
-        .set({
-          key: 'deploy',
-          config: {run: 'deploy', env: {SHA: 'old-snapshot'}},
-          configPlan: {env: {SHA: shaPlan}},
-        })
-        .where(eq(stepsTable.id, sourceConsumer.id));
       await updateWorkflowRunStatus({
         workflowRunId: source.id,
         status: 'failed',
@@ -465,16 +885,31 @@ describe('workflow run queries', () => {
         kind: 'step',
         step: expect.objectContaining({
           key: 'deploy',
-          config: {run: 'deploy', env: {SHA: 'new-snapshot'}},
-          configPlan: {env: {SHA: shaPlan}},
+          config: {run: 'deploy', env: {ATTEMPT: '2', SHA: 'new-snapshot'}},
+          configPlan: expect.objectContaining({env: {SHA: shaPlan}}),
         }),
         dispatched: true,
       });
       const attempts = await getStepAttempts(rerunJob.id);
       expect(attempts.find((attempt) => attempt.stepId === sourceConsumer.id)).toBeUndefined();
-      expect(attempts.find((attempt) => attempt.stepId !== producer.step.id)).toMatchObject({
-        config: {run: 'deploy', env: {SHA: 'new-snapshot'}},
+      const consumerAttempt = attempts.find((attempt) => attempt.stepId !== producer.step.id);
+      expect(consumerAttempt).toMatchObject({
+        config: {run: 'deploy', env: {ATTEMPT: '2', SHA: 'new-snapshot'}},
       });
+      expect(consumerAttempt?.evaluationTrace).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            expression: 'run.attempt',
+            evaluatedAt: 'run-creation',
+            value: '2',
+          }),
+          expect.objectContaining({
+            expression: 'steps.build.outputs.sha',
+            evaluatedAt: 'step-dispatch',
+            value: 'new-snapshot',
+          }),
+        ]),
+      );
     });
 
     test('reruns copy the source job execution name', async () => {

--- a/libs/api/workflows/src/db/workflow-runs/run-rerun.test.ts
+++ b/libs/api/workflows/src/db/workflow-runs/run-rerun.test.ts
@@ -1,3 +1,4 @@
+import type {AgentInterModuleClient} from '@shipfox/api-agent-dto/inter-module';
 import type {IntegrationsModuleClient} from '@shipfox/api-integration-core-dto/inter-module';
 import type {ProjectsModuleClient} from '@shipfox/api-projects-dto/inter-module';
 import {eq, inArray} from 'drizzle-orm';
@@ -140,6 +141,48 @@ describe('workflow run queries', () => {
       }
     });
 
+    test('reruns listening agent jobs without materializing execution steps', async () => {
+      const source = await createWorkflowRun({
+        workspaceId,
+        projectId,
+        definitionId,
+        model: buildModel({
+          jobs: {
+            review: {
+              listening: {
+                on: [{source: 'github', event: 'pull_request_review'}],
+                onResolve: 'cancel',
+              },
+              steps: [{prompt: 'Review the pull request.'}],
+            },
+          },
+        }),
+        triggerPayload: {
+          source: 'manual',
+          event: 'fire',
+          subscriptionId: crypto.randomUUID(),
+          userId: crypto.randomUUID(),
+        },
+      });
+      await updateWorkflowRunStatus({
+        workflowRunId: source.id,
+        status: 'failed',
+        expectedVersion: 1,
+      });
+
+      const rerun = await createRerunWorkflowRun({
+        workflowRunId: source.id,
+        mode: 'all',
+        actorUserId: crypto.randomUUID(),
+      });
+
+      const [rerunJob] = await getJobsByWorkflowRunId(rerun.id);
+      if (!rerunJob) throw new Error('Missing rerun listener job');
+      expect(rerunJob).toMatchObject({key: 'review', mode: 'listening', status: 'pending'});
+      await expect(getJobExecutionsByJobId(rerunJob.id)).resolves.toEqual([]);
+      await expect(getStepsByJobId(rerunJob.id)).resolves.toEqual([]);
+    });
+
     test('re-materializes run-creation step config for the new attempt', async () => {
       const source = await createWorkflowRun({
         workspaceId,
@@ -205,6 +248,54 @@ describe('workflow run queries', () => {
       ).toEqual(sourceStep);
     });
 
+    test('reuses persisted variables when re-materializing rerun steps', async () => {
+      const getVariablesByNamespace = vi.fn().mockResolvedValue({values: {BRANCH: 'stable'}});
+      const source = await createWorkflowRun({
+        workspaceId,
+        projectId,
+        definitionId,
+        model: buildModel({
+          jobs: {
+            publish: {
+              steps: [
+                {
+                  key: 'publish',
+                  run: 'echo publish',
+                  env: {BRANCH: template('vars.BRANCH')},
+                },
+              ],
+            },
+          },
+        }),
+        triggerPayload: {
+          source: 'manual',
+          event: 'fire',
+          subscriptionId: crypto.randomUUID(),
+          userId: crypto.randomUUID(),
+        },
+        secrets: {getVariablesByNamespace},
+      });
+      const [sourceJob] = await getJobsByWorkflowRunId(source.id);
+      if (!sourceJob) throw new Error('Missing source publish job');
+      await markJob([sourceJob], 'publish', 'failed');
+      await updateWorkflowRunStatus({
+        workflowRunId: source.id,
+        status: 'failed',
+        expectedVersion: 1,
+      });
+
+      const rerun = await createRerunWorkflowRun({
+        workflowRunId: source.id,
+        mode: 'failed',
+        actorUserId: crypto.randomUUID(),
+      });
+
+      const [rerunJob] = await getJobsByWorkflowRunId(rerun.id);
+      if (!rerunJob) throw new Error('Missing rerun publish job');
+      const rerunStep = (await getStepsByJobId(rerunJob.id)).find((step) => step.key === 'publish');
+      expect(rerunStep?.config).toMatchObject({env: {BRANCH: 'stable'}});
+    });
+
     test('re-materializes agent prompts while preserving resolved defaults and session intent', async () => {
       const resolveAgentDefaults = vi.fn<AgentDefaultsResolver>().mockReturnValue({
         harness: 'pi',
@@ -262,6 +353,117 @@ describe('workflow run queries', () => {
         thinking: 'medium',
         prompt: 'Fix workflow attempt 2.',
         session: {key: 'implementation', mode: 'resume'},
+      });
+    });
+
+    test('preserves resolved agent defaults when a rerun field remains deferred', async () => {
+      const sourceResolveAgentConfig = vi.fn().mockResolvedValue({
+        harness: 'pi',
+        provider: 'openai',
+        model: 'source-model',
+        thinking: 'medium',
+      });
+      const sourceAgent = {
+        resolveAgentConfig: sourceResolveAgentConfig,
+      } as unknown as AgentInterModuleClient;
+      const source = await createWorkflowRun({
+        workspaceId,
+        projectId,
+        definitionId,
+        model: buildModel({
+          jobs: {
+            fix: {
+              steps: [
+                {key: 'select_model', run: 'echo model'},
+                {
+                  key: 'fix',
+                  model: template('steps.select_model.outputs.model'),
+                  prompt: 'Fix the workflow.',
+                },
+              ],
+            },
+          },
+        }),
+        triggerPayload: {
+          source: 'manual',
+          event: 'fire',
+          subscriptionId: crypto.randomUUID(),
+          userId: crypto.randomUUID(),
+        },
+      });
+      const [sourceJob] = await getJobsByWorkflowRunId(source.id);
+      if (!sourceJob) throw new Error('Missing source fix job');
+      await stripSetupStep(sourceJob.id);
+      const sourceProducer = await nextStepForJob(sourceJob.id);
+      if (sourceProducer.kind !== 'step') throw new Error('Missing source producer step');
+      await recordStepResult({
+        jobExecutionId: sourceProducer.step.jobExecutionId,
+        stepId: sourceProducer.step.id,
+        status: 'succeeded',
+        output: {model: 'source-model'},
+      });
+      const sourceAgentStep = await nextStepForJob(sourceJob.id, sourceAgent);
+      if (sourceAgentStep.kind !== 'step') throw new Error('Missing source agent step');
+      expect(sourceResolveAgentConfig).toHaveBeenCalledWith({
+        workspaceId: null,
+        config: {model: 'source-model'},
+      });
+      await markJob([sourceJob], 'fix', 'failed');
+      await updateWorkflowRunStatus({
+        workflowRunId: source.id,
+        status: 'failed',
+        expectedVersion: 1,
+      });
+
+      const rerun = await createRerunWorkflowRun({
+        workflowRunId: source.id,
+        mode: 'failed',
+        actorUserId: crypto.randomUUID(),
+      });
+      const [rerunJob] = await getJobsByWorkflowRunId(rerun.id);
+      if (!rerunJob) throw new Error('Missing rerun fix job');
+      await stripSetupStep(rerunJob.id);
+      const rerunProducer = await nextStepForJob(rerunJob.id);
+      if (rerunProducer.kind !== 'step') throw new Error('Missing rerun producer step');
+      await recordStepResult({
+        jobExecutionId: rerunProducer.step.jobExecutionId,
+        stepId: rerunProducer.step.id,
+        status: 'succeeded',
+        output: {model: 'rerun-model'},
+      });
+      const currentResolveAgentConfig = vi.fn().mockResolvedValue({
+        harness: 'pi',
+        provider: 'openai',
+        model: 'rerun-model',
+        thinking: 'medium',
+      });
+      const currentAgent = {
+        resolveAgentConfig: currentResolveAgentConfig,
+      } as unknown as AgentInterModuleClient;
+
+      const rerunAgentStep = await nextStepForJob(rerunJob.id, currentAgent);
+
+      expect(currentResolveAgentConfig).toHaveBeenCalledWith({
+        workspaceId: null,
+        config: {
+          harness: 'pi',
+          provider: 'openai',
+          model: 'rerun-model',
+          thinking: 'medium',
+        },
+      });
+      expect(rerunAgentStep).toEqual({
+        kind: 'step',
+        step: expect.objectContaining({
+          key: 'fix',
+          config: expect.objectContaining({
+            harness: 'pi',
+            provider: 'openai',
+            model: 'rerun-model',
+            thinking: 'medium',
+          }),
+        }),
+        dispatched: true,
       });
     });
 

--- a/libs/api/workflows/src/db/workflow-runs/run-rerun.ts
+++ b/libs/api/workflows/src/db/workflow-runs/run-rerun.ts
@@ -1,5 +1,7 @@
-import {readPersistedWorkflowModel} from '@shipfox/api-definitions-dto';
+import {materializedAgentStepConfigSchema} from '@shipfox/api-agent-dto';
+import {readPersistedWorkflowModel, type WorkflowModel} from '@shipfox/api-definitions-dto';
 import {and, asc, eq, inArray, sql} from 'drizzle-orm';
+import type {AgentDefaultsResolver} from '#core/agent-defaults.js';
 import {isWorkflowRunTerminal, type WorkflowRun} from '#core/entities/workflow-run.js';
 import {
   NoFailedJobsError,
@@ -8,6 +10,11 @@ import {
   WorkflowRunAttemptMismatchError,
 } from '#core/errors.js';
 import {restoreAgentSessionIntentForRedispatch} from '#core/step-config/agent.js';
+import {assembleCreationContext} from '#core/step-config/assemble-run-context.js';
+import {
+  type MaterializedWorkflowStep,
+  materializeJobExecutionSteps,
+} from '#core/step-config/materialize-job-execution-steps.js';
 import {deriveJobExecutionRunner} from '#core/workflow-run-creation.js';
 import {recordWorkflowRunCreated} from '#metrics/instance.js';
 import {db, type Tx} from '../db.js';
@@ -110,7 +117,7 @@ export async function createRerunWorkflowRun(
     const sourceGraph = await loadRerunSourceGraph(tx, sourceJobs);
 
     const runForAttempt = {...toWorkflowRun(sourceRow), currentAttempt: attempt};
-    const graphJobs = materializeRerunGraphJobs({
+    const graphJobs = await materializeRerunGraphJobs({
       mode: params.mode,
       sourceRun: runForAttempt,
       sourceAttempt: sourceAttemptRow,
@@ -213,7 +220,7 @@ interface MaterializeRerunGraphParams {
 
 function materializeRerunGraphJobs(
   params: MaterializeRerunGraphParams,
-): readonly MaterializedRunGraphJob[] {
+): Promise<readonly MaterializedRunGraphJob[]> {
   const sourceModel =
     params.sourceAttempt.model === null
       ? null
@@ -228,25 +235,44 @@ function materializeRerunGraphJobs(
     sourceStepsByJobId.set(sourceJob.id, sourceJobSteps);
   }
 
-  return params.sourceJobs.map((sourceJob) =>
-    materializeRerunGraphJob(
-      params,
-      sourceJob,
-      sourceModelJobByKey.get(sourceJob.key),
-      sourceStepsByJobId.get(sourceJob.id) ?? [],
+  return Promise.all(
+    params.sourceJobs.map((sourceJob) =>
+      materializeRerunGraphJob(
+        params,
+        sourceModel,
+        sourceJob,
+        sourceModelJobByKey.get(sourceJob.key),
+        sourceStepsByJobId.get(sourceJob.id) ?? [],
+      ),
     ),
   );
 }
 
-function materializeRerunGraphJob(
+async function materializeRerunGraphJob(
   params: MaterializeRerunGraphParams,
+  sourceModel: WorkflowModel | null,
   sourceJob: JobDb,
   modelJob: ReturnType<typeof readPersistedWorkflowModel>['jobs'][number] | undefined,
   sourceJobSteps: readonly StepDb[],
-): MaterializedRunGraphJob {
+): Promise<MaterializedRunGraphJob> {
   const carriedOver = params.mode === 'failed' && sourceJob.status === 'succeeded';
   const modelCheckout = modelJob?.checkout;
   const resolvedModelCheckout = modelCheckout === false ? undefined : modelCheckout;
+  const rematerializedSteps = await rematerializeRerunSteps({
+    params,
+    sourceModel,
+    modelJob,
+    sourceJobSteps,
+    carriedOver,
+  });
+  const sourceIncludesSetupStep = sourceJobSteps.some((step) => step.type === 'setup');
+  const rematerializedStepByPosition = new Map(
+    rematerializedSteps.flatMap((step) => {
+      if (step.type === 'setup' && !sourceIncludesSetupStep) return [];
+      const sourcePosition = sourceIncludesSetupStep ? step.position : step.position - 1;
+      return [[sourcePosition, step] as const];
+    }),
+  );
 
   return {
     job: {
@@ -280,21 +306,93 @@ function materializeRerunGraphJob(
     createExecution: (job) =>
       createRerunJobExecution({params, sourceJob, modelJob, carriedOver, job}),
     createSteps: () =>
-      sourceJobSteps.map((step) => ({
-        key: step.key,
-        name: step.name,
-        sourceLocation: step.sourceLocation,
-        status: carriedOver ? step.status : 'pending',
-        statusReason: carriedOver ? step.statusReason : null,
-        type: step.type,
-        config: carriedOver ? {...step.config} : rerunStepConfig(step),
-        condition: step.condition ?? null,
-        configPlan: step.configPlan,
-        authoredConfig: step.authoredConfig,
-        error: null,
-        position: step.position,
-        currentAttempt: 1,
-      })),
+      sourceJobSteps.map((step) =>
+        materializedRerunStep({
+          step,
+          carriedOver,
+          rematerialized: rematerializedStepByPosition.get(step.position),
+        }),
+      ),
+  };
+}
+
+function materializedRerunStep(params: {
+  readonly step: StepDb;
+  readonly carriedOver: boolean;
+  readonly rematerialized: MaterializedWorkflowStep | undefined;
+}) {
+  let config = rerunStepConfig(params.step);
+  if (params.carriedOver) config = {...params.step.config};
+  else if (params.rematerialized !== undefined) config = {...params.rematerialized.config};
+
+  return {
+    key: params.step.key,
+    name: params.step.name,
+    sourceLocation: params.step.sourceLocation,
+    status: params.carriedOver ? params.step.status : ('pending' as const),
+    statusReason: params.carriedOver ? params.step.statusReason : null,
+    type: params.step.type,
+    config,
+    condition: params.step.condition ?? null,
+    configPlan:
+      params.rematerialized === undefined
+        ? params.step.configPlan
+        : (params.rematerialized.configPlan ?? null),
+    authoredConfig: params.step.authoredConfig,
+    error: null,
+    position: params.step.position,
+    currentAttempt: 1,
+  };
+}
+
+async function rematerializeRerunSteps(params: {
+  readonly params: MaterializeRerunGraphParams;
+  readonly sourceModel: WorkflowModel | null;
+  readonly modelJob: WorkflowModel['jobs'][number] | undefined;
+  readonly sourceJobSteps: readonly StepDb[];
+  readonly carriedOver: boolean;
+}): Promise<readonly MaterializedWorkflowStep[]> {
+  if (params.carriedOver || params.sourceModel === null || params.modelJob === undefined) return [];
+
+  const sourceIncludesSetupStep = params.sourceJobSteps.some((step) => step.type === 'setup');
+  const sourceStepByPosition = new Map(params.sourceJobSteps.map((step) => [step.position, step]));
+  return await materializeJobExecutionSteps({
+    model: params.sourceModel,
+    job: params.modelJob,
+    context: assembleCreationContext({
+      run: params.params.sourceRun,
+      triggerPayload: params.params.sourceRun.triggerPayload,
+      inputs: params.params.sourceRun.inputs,
+      vars: params.params.sourceAttempt.vars ?? undefined,
+    }),
+    definitionId: params.params.sourceRun.definitionId,
+    agentToolSnapshot: params.params.sourceAttempt.agentToolMaterialization,
+    resolveAgentDefaultsForStep: (stepPosition) =>
+      resolvedAgentDefaultsFromSource(
+        sourceStepByPosition.get(sourceIncludesSetupStep ? stepPosition + 1 : stepPosition),
+      ),
+  });
+}
+
+function resolvedAgentDefaultsFromSource(
+  step: StepDb | undefined,
+): AgentDefaultsResolver | undefined {
+  if (step?.type !== 'agent') return undefined;
+
+  return (input) => {
+    const resolved = materializedAgentStepConfigSchema.parse({
+      harness: input.harness ?? step.config.harness,
+      provider: input.provider ?? step.config.provider,
+      model: input.model ?? step.config.model,
+      thinking: input.thinking ?? step.config.thinking,
+      prompt: '',
+    });
+    return {
+      harness: resolved.harness,
+      provider: resolved.provider,
+      model: resolved.model,
+      thinking: resolved.thinking,
+    };
   };
 }
 

--- a/libs/api/workflows/src/db/workflow-runs/run-rerun.ts
+++ b/libs/api/workflows/src/db/workflow-runs/run-rerun.ts
@@ -323,7 +323,12 @@ function materializedRerunStep(params: {
 }) {
   let config = rerunStepConfig(params.step);
   if (params.carriedOver) config = {...params.step.config};
-  else if (params.rematerialized !== undefined) config = {...params.rematerialized.config};
+  else if (params.rematerialized !== undefined) {
+    config = {
+      ...(resolvedAgentDefaultsFromSourceStep(params.step) ?? {}),
+      ...params.rematerialized.config,
+    };
+  }
 
   return {
     key: params.step.key,
@@ -352,7 +357,14 @@ async function rematerializeRerunSteps(params: {
   readonly sourceJobSteps: readonly StepDb[];
   readonly carriedOver: boolean;
 }): Promise<readonly MaterializedWorkflowStep[]> {
-  if (params.carriedOver || params.sourceModel === null || params.modelJob === undefined) return [];
+  if (
+    params.carriedOver ||
+    params.sourceModel === null ||
+    params.modelJob === undefined ||
+    params.modelJob.mode === 'listening'
+  ) {
+    return [];
+  }
 
   const sourceIncludesSetupStep = params.sourceJobSteps.some((step) => step.type === 'setup');
   const sourceStepByPosition = new Map(params.sourceJobSteps.map((step) => [step.position, step]));
@@ -377,14 +389,15 @@ async function rematerializeRerunSteps(params: {
 function resolvedAgentDefaultsFromSource(
   step: StepDb | undefined,
 ): AgentDefaultsResolver | undefined {
-  if (step?.type !== 'agent') return undefined;
+  const sourceDefaults = resolvedAgentDefaultsFromSourceStep(step);
+  if (sourceDefaults === undefined) return undefined;
 
   return (input) => {
     const resolved = materializedAgentStepConfigSchema.parse({
-      harness: input.harness ?? step.config.harness,
-      provider: input.provider ?? step.config.provider,
-      model: input.model ?? step.config.model,
-      thinking: input.thinking ?? step.config.thinking,
+      harness: input.harness ?? sourceDefaults.harness,
+      provider: input.provider ?? sourceDefaults.provider,
+      model: input.model ?? sourceDefaults.model,
+      thinking: input.thinking ?? sourceDefaults.thinking,
       prompt: '',
     });
     return {
@@ -393,6 +406,26 @@ function resolvedAgentDefaultsFromSource(
       model: resolved.model,
       thinking: resolved.thinking,
     };
+  };
+}
+
+function resolvedAgentDefaultsFromSourceStep(step: StepDb | undefined) {
+  if (step?.type !== 'agent') return undefined;
+
+  const parsed = materializedAgentStepConfigSchema.safeParse({
+    harness: step.config.harness,
+    provider: step.config.provider,
+    model: step.config.model,
+    thinking: step.config.thinking,
+    prompt: '',
+  });
+  if (!parsed.success) return undefined;
+
+  return {
+    harness: parsed.data.harness,
+    provider: parsed.data.provider,
+    model: parsed.data.model,
+    thinking: parsed.data.thinking,
   };
 }
 

--- a/libs/api/workflows/src/db/workflow-runs/run-rerun.ts
+++ b/libs/api/workflows/src/db/workflow-runs/run-rerun.ts
@@ -332,7 +332,7 @@ function materializedRerunStep(params: {
 
   return {
     key: params.step.key,
-    name: params.step.name,
+    name: params.rematerialized?.name ?? params.step.name,
     sourceLocation: params.step.sourceLocation,
     status: params.carriedOver ? params.step.status : ('pending' as const),
     statusReason: params.carriedOver ? params.step.statusReason : null,


### PR DESCRIPTION
## Summary

Workflow reruns copied step configuration that had already resolved run-creation expressions against attempt 1. That left values such as `${{ run.attempt }}` stale in later attempts and could reuse attempt-qualified external identifiers.

Re-materialize non-carried step configuration from the pinned workflow model with the new run attempt while preserving trigger inputs, variables, late dispatch plans, agent session intent and defaults, and frozen integration and tool selections. Succeeded jobs carried by failed-only reruns remain unchanged.

Regression coverage exercises run and agent fields, consecutive attempts, mixed early and late expressions, failed-job carry-over, frozen integrations, source-attempt immutability, and step-restart isolation.

## Validation

- `mise exec -- pnpm --filter=@shipfox/api-workflows test run-rerun.test.ts`
- `mise exec -- turbo test --filter=@shipfox/api-workflows`
- `mise exec -- turbo check type build depcruise --filter=@shipfox/api-workflows...`
- `mise exec -- pnpm exec changeset status --output=.context/changeset-status.json`
- `mise exec -- git diff --check origin/main...HEAD`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes workflow reruns copying step configuration that had already resolved run-creation expressions against attempt 1, leaving stale values like `${{run.attempt}}` in later attempts. Reruns now re-materialize non-carried step config from the pinned workflow model with the new attempt context, while listening jobs skip re-materialization and deferred agent fields keep source-resolved defaults.

**Bug Fixes**
- Preserves trigger inputs, variables, late dispatch plans, agent session intent and defaults, and frozen agent tool selections.
- Skips step config re-materialization for listening jobs and keeps source-resolved agent defaults when a rerun step defers a field like `model`.
- Carried-over succeeded jobs in failed-only reruns keep their original step config.
- Refreshes step display names from the model on reruns.
- Adds regression coverage for consecutive attempts, mixed early/late expressions, failed-job carry-over, frozen integrations, listening jobs, deferred agent defaults, and step-restart isolation.
- Adds a patch changeset for `@shipfox/api-workflows`.

<sup>Written for commit ce8f591cdde4cd48901b873d384f1750f82512db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1787?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

